### PR TITLE
Add AdSense in-feed ads with admin management groundwork

### DIFF
--- a/apps/client-fnp/.dockerignore
+++ b/apps/client-fnp/.dockerignore
@@ -1,0 +1,3 @@
+.env.local
+node_modules
+.next

--- a/apps/client-fnp/Dockerfile
+++ b/apps/client-fnp/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_PUBLIC_APP_URL=https://farmnport.com
 ENV NEXT_PUBLIC_BASE_URL=https://farmnport.com
+ENV NEXT_PUBLIC_GTM_ID=GTM-TS7XJ4J
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN bun run build

--- a/apps/client-fnp/app/(auth)/login/page.tsx
+++ b/apps/client-fnp/app/(auth)/login/page.tsx
@@ -2,8 +2,17 @@ import { AuthForm } from "@/components/forms/login"
 
 
 export const metadata = {
-    title: 'Sign into Farmnport',
-    description: 'Agricultural produce, fresh produce, buyers buying directly from farmers in Zimbabwe'
+    title: 'Sign In | Farmnport — Access Your Farm & Market Dashboard',
+    description: 'Sign in to Farmnport to connect with buyers, track produce prices, and manage your agricultural business. Access agrochemical guides, market listings, and more.',
+    alternates: {
+        canonical: '/login',
+    },
+    openGraph: {
+        title: 'Sign In | Farmnport',
+        description: 'Sign in to Farmnport to connect with buyers, track produce prices, and manage your agricultural business.',
+        siteName: 'farmnport',
+        type: 'website',
+    },
 }
 
 export default function LoginPage() {
@@ -12,7 +21,7 @@ export default function LoginPage() {
         <>
             <div className="flex min-h-full flex-1 flex-col justify-center py-16 px-3 sm:px-6 lg:px-8">
                 <div className="mx-auto sm:w-full sm:max-w-md h-10 text-center">
-                    <h3 className="text-lg">Sign into Farmnport</h3>
+                    <h1 className="text-lg">Sign into Farmnport</h1>
                     <p className="text-muted-foreground text-sm">We pleased to have you back.</p>
                 </div>
 

--- a/apps/client-fnp/app/(auth)/reset/page.tsx
+++ b/apps/client-fnp/app/(auth)/reset/page.tsx
@@ -2,8 +2,17 @@ import { ResetAuthForm } from "@/components/forms/reset"
 
 
 export const metadata = {
-    title: 'Reset Password Farmnport',
-    description: 'Agri produce, fresh produce, buyers buying directly from farmers in Zimbabwe'
+    title: 'Reset Password | Farmnport',
+    description: 'Reset your Farmnport account password. Enter your email to receive a password reset link and regain access to your farming marketplace account.',
+    alternates: {
+        canonical: '/reset',
+    },
+    openGraph: {
+        title: 'Reset Password | Farmnport',
+        description: 'Reset your Farmnport account password and regain access to your farming marketplace account.',
+        siteName: 'farmnport',
+        type: 'website',
+    },
 }
 
 export default function ResetPage() {
@@ -12,7 +21,7 @@ export default function ResetPage() {
         <>
             <div className="flex min-h-full flex-1 flex-col justify-center py-16 sm:px-6 lg:px-8">
                 <div className="mx-auto sm:w-full sm:max-w-md h-10 text-center">
-                    <h3 className="text-lg">Reset your Farmnport password</h3>
+                    <h1 className="text-lg">Reset your Farmnport password</h1>
                     <p className="text-muted-foreground text-sm">Sorry you have forgotten your password, but it is quick and easy to reset here using your email.</p>
                 </div>
 

--- a/apps/client-fnp/app/(auth)/signup/page.tsx
+++ b/apps/client-fnp/app/(auth)/signup/page.tsx
@@ -2,8 +2,17 @@ import { SignUpAuthForm } from "@/components/forms/signup"
 
 
 export const metadata = {
-    title: 'Sign Up to Farmnport',
-    description: 'Agricultural produce, fresh produce, buyers buying directly from farmers in Zimbabwe'
+    title: 'Sign Up | Farmnport — Join Zimbabwe\'s Largest Farming Marketplace',
+    description: 'Create a free Farmnport account to buy and sell agricultural produce, access agrochemical guides, and connect directly with farmers and buyers across Zimbabwe.',
+    alternates: {
+        canonical: '/signup',
+    },
+    openGraph: {
+        title: 'Sign Up | Farmnport — Join Zimbabwe\'s Largest Farming Marketplace',
+        description: 'Create a free Farmnport account to buy and sell agricultural produce and connect with farmers and buyers across Zimbabwe.',
+        siteName: 'farmnport',
+        type: 'website',
+    },
 }
 
 export default function SignUpPage() {
@@ -12,7 +21,7 @@ export default function SignUpPage() {
         <>
             <div className="flex min-h-full flex-1 flex-col justify-center py-10 px-3 sm:px-6 lg:px-8">
                 <div className="mx-auto sm:w-full sm:max-w-2xl text-center mb-8">
-                    <h2 className="text-2xl/9 font-bold tracking-tight">Join Farmnport</h2>
+                    <h1 className="text-2xl/9 font-bold tracking-tight">Join Farmnport</h1>
                     <p className="mt-2 text-sm/6 text-muted-foreground">
                         Enter your information below and join the largest farming ecosystem in Zimbabwe
                     </p>

--- a/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/[slug]/page.tsx
@@ -152,6 +152,7 @@ export default function AgroChemicalGuidePage({ params }: GuidePageProps) {
                                     src={chemical.images[0].img.src}
                                     alt={chemical.name}
                                     fill
+                                    sizes="(max-width: 1024px) 100vw, 450px"
                                     className="object-contain p-8"
                                     priority
                                 />
@@ -175,6 +176,7 @@ export default function AgroChemicalGuidePage({ params }: GuidePageProps) {
                                                 src={img.img.src}
                                                 alt={`${chemical.name} ${idx + 1}`}
                                                 fill
+                                                sizes="(max-width: 1024px) 25vw, 100px"
                                                 className="object-contain p-2"
                                             />
                                         )}
@@ -372,6 +374,7 @@ export default function AgroChemicalGuidePage({ params }: GuidePageProps) {
                                             src={chemical.front_label.img.src}
                                             alt={`${chemical.name} - Front Label`}
                                             fill
+                                            sizes="(max-width: 768px) 100vw, 50vw"
                                             className="object-contain p-4"
                                         />
                                     </div>
@@ -387,6 +390,7 @@ export default function AgroChemicalGuidePage({ params }: GuidePageProps) {
                                             src={chemical.back_label.img.src}
                                             alt={`${chemical.name} - Back Label`}
                                             fill
+                                            sizes="(max-width: 768px) 100vw, 50vw"
                                             className="object-contain p-4"
                                         />
                                     </div>

--- a/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { queryAgroChemical } from "@/lib/query"
 import Image from "next/image"
 import { Beaker, AlertTriangle } from "lucide-react"
 import Link from "next/link"
+import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
 
 interface GuidePageProps {
     params: Promise<{
@@ -240,6 +241,9 @@ export default function AgroChemicalGuidePage({ params }: GuidePageProps) {
                                 <p className="text-sm text-muted-foreground p-4 bg-muted/30 rounded-lg border">No active ingredient information available.</p>
                             )}
                         </div>
+
+                        {/* AdSense Ad */}
+                        <AdSenseInFeed />
 
                         {/* Used On Section */}
                         {chemical.dosage_rates && chemical.dosage_rates.length > 0 && (

--- a/apps/client-fnp/app/(landing)/buy-agrochemicals/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/buy-agrochemicals/[slug]/page.tsx
@@ -136,6 +136,7 @@ export default function BuyAgroChemicalPage({ params }: BuyAgroChemicalPageProps
                                     src={chemical.images[0].img.src}
                                     alt={chemical.name}
                                     fill
+                                    sizes="(max-width: 1024px) 100vw, 450px"
                                     className="object-contain p-4"
                                     priority
                                 />
@@ -159,6 +160,7 @@ export default function BuyAgroChemicalPage({ params }: BuyAgroChemicalPageProps
                                                 src={img.img.src}
                                                 alt={`${chemical.name} ${idx + 1}`}
                                                 fill
+                                                sizes="(max-width: 1024px) 25vw, 100px"
                                                 className="object-contain p-2"
                                             />
                                         )}

--- a/apps/client-fnp/app/(landing)/buyers/[product]/page.tsx
+++ b/apps/client-fnp/app/(landing)/buyers/[product]/page.tsx
@@ -2,7 +2,7 @@ import {capitalizeFirstLetter, plural} from "@/lib/utilities"
 import { Buyers } from "@/components/layouts/buyers"
 import { retrieveUser } from "@/lib/actions"
 import type { Metadata, ResolvingMetadata } from "next";
-import { AppURL, BuyerSeo } from "@/lib/schemas";
+import { AppURL, getBuyerSeo } from "@/lib/schemas";
 import { FilterSidebar } from "@/components/generic/filterSidebar"
 
 
@@ -14,7 +14,7 @@ type Props = {
 export async function generateMetadata({ params }: Props,  parent: ResolvingMetadata): Promise<Metadata> {
   const { product } = await params
   const name = capitalizeFirstLetter(plural(product))
-  const description = BuyerSeo[product]
+  const description = getBuyerSeo(product)
 
   return {
     alternates: {
@@ -59,10 +59,17 @@ export default async function BuyersProductPage({ params }: BuyerProductPageProp
 
   const user = await retrieveUser()
   const { product } = await params
+  const name = capitalizeFirstLetter(plural(product))
 
   return (
     <main>
       <div className="mx-auto max-w-7xl px-6 lg:px-8 min-h-[70lvh]">
+        <h1 className="text-3xl font-bold font-heading pt-8 pb-4">
+          {name} Buyers in Zimbabwe
+        </h1>
+        <p className="text-muted-foreground mb-6">
+          Find verified {product} buyers across Zimbabwe. Sell your {product} directly at competitive market prices.
+        </p>
         <div className="lg:flex lg:space-x-10">
 
           <div className="hidden lg:block lg:w-44 relative">

--- a/apps/client-fnp/app/(landing)/buyers/page.tsx
+++ b/apps/client-fnp/app/(landing)/buyers/page.tsx
@@ -5,12 +5,17 @@ import { ActionsSidebar } from "@/components/generic/actions-sidebar"
 
 
 export const metadata = {
-    title: 'Sell Your Farm Produce Directly – Reach Buyers Faster. | farmnport.com',
-    description: `Farmers, sell your fresh produce directly to buyers! Access fairer markets,
-      build customer relationships, and reduce dependency on traditional channels.`,
+    title: 'Sell Your Farm Produce Directly – Reach Buyers Faster | farmnport.com',
+    description: 'Farmers, sell your fresh produce directly to buyers. Access fairer markets, build customer relationships, and reduce dependency on traditional channels.',
     alternates: {
-        canonical: `/buyers`,
-    }
+        canonical: '/buyers',
+    },
+    openGraph: {
+        title: 'Sell Your Farm Produce Directly – Reach Buyers Faster',
+        description: 'Farmers, sell your fresh produce directly to buyers across Zimbabwe. Access fairer markets and build customer relationships.',
+        siteName: 'farmnport',
+        type: 'website',
+    },
 }
 
 export default async function BuyersPage() {
@@ -20,6 +25,12 @@ export default async function BuyersPage() {
     return (
         <main>
             <div className="mx-auto max-w-7xl px-6 lg:px-8 min-h-[70lvh]">
+                <h1 className="text-3xl font-bold font-heading pt-8 pb-4">
+                    Agricultural Produce Buyers in Zimbabwe
+                </h1>
+                <p className="text-muted-foreground mb-6">
+                    Sell your farm produce directly to verified buyers across Zimbabwe. Browse buyers by category and connect today.
+                </p>
                 <div className="lg:flex lg:space-x-10">
 
                     <div className="hidden lg:block lg:w-64 relative">

--- a/apps/client-fnp/app/(landing)/farmers/[product]/page.tsx
+++ b/apps/client-fnp/app/(landing)/farmers/[product]/page.tsx
@@ -2,7 +2,7 @@ import { capitalizeFirstLetter, plural } from "@/lib/utilities"
 import { Farmers } from "@/components/layouts/farmers"
 import { retrieveUser } from "@/lib/actions"
 import type { Metadata, ResolvingMetadata } from "next";
-import {AppURL, FarmerSeo} from "@/lib/schemas";
+import {AppURL, getFarmerSeo} from "@/lib/schemas";
 import { FilterSidebar } from "@/components/generic/filterSidebar"
 
 
@@ -14,7 +14,7 @@ type Props = {
 export async function generateMetadata({ params }: Props,  parent: ResolvingMetadata): Promise<Metadata> {
   const { product } = await params
   const name = capitalizeFirstLetter(plural(product))
-  const description = FarmerSeo[product]
+  const description = getFarmerSeo(product)
 
   return {
     alternates: {
@@ -59,10 +59,17 @@ export default async function FarmersProductPage({ params }: FarmerProductPagePr
 
   const user = await retrieveUser()
   const { product } = await params
+  const name = capitalizeFirstLetter(plural(product))
 
   return (
     <main>
       <div className="mx-auto max-w-7xl px-6 lg:px-8 min-h-[70lvh]">
+        <h1 className="text-3xl font-bold font-heading pt-8 pb-4">
+          {name} Farmers in Zimbabwe
+        </h1>
+        <p className="text-muted-foreground mb-6">
+          Buy quality {product} directly from trusted farmers across Zimbabwe at fair farm-gate prices.
+        </p>
         <div className="lg:flex lg:space-x-10">
 
           <div className="hidden lg:block lg:w-44 relative">

--- a/apps/client-fnp/app/(landing)/farmers/page.tsx
+++ b/apps/client-fnp/app/(landing)/farmers/page.tsx
@@ -6,11 +6,16 @@ import { ActionsSidebar } from "@/components/generic/actions-sidebar"
 
 export const metadata = {
   title: 'Buy Fresh Agricultural Produce Directly from Farmers | farmnport.com',
-  description: `Looking for fresh, high-quality agricultural produce in Zimbabwe? Buy directly from local farmers for the best prices,
-      farm-to-table freshness, and support for Zimbabwean agriculture. Connect with trusted suppliers today!,`,
+  description: 'Looking for fresh, high-quality agricultural produce in Zimbabwe? Buy directly from local farmers for the best prices, farm-to-table freshness, and support for Zimbabwean agriculture.',
   alternates: {
-    canonical: `/farmers`,
-  }
+    canonical: '/farmers',
+  },
+  openGraph: {
+    title: 'Buy Fresh Agricultural Produce Directly from Farmers',
+    description: 'Buy fresh, high-quality agricultural produce directly from local farmers across Zimbabwe at the best prices.',
+    siteName: 'farmnport',
+    type: 'website',
+  },
 }
 
 export default async function FarmersPage() {
@@ -20,6 +25,12 @@ export default async function FarmersPage() {
   return (
     <main>
       <div className="mx-auto max-w-7xl px-6 lg:px-8 min-h-[70lvh]">
+        <h1 className="text-3xl font-bold font-heading pt-8 pb-4">
+          Farmers Selling Fresh Produce in Zimbabwe
+        </h1>
+        <p className="text-muted-foreground mb-6">
+          Buy fresh, high-quality agricultural produce directly from local farmers across Zimbabwe at the best prices.
+        </p>
         <div className="lg:flex lg:space-x-10">
 
           <div className="hidden lg:block lg:w-64 relative">

--- a/apps/client-fnp/app/(landing)/page.tsx
+++ b/apps/client-fnp/app/(landing)/page.tsx
@@ -2,6 +2,20 @@ import { auth } from "@/auth"
 import { LoggedOutLanding } from "@/components/layouts/logged-out-landing"
 import { LoggedInDashboard } from "@/components/layouts/logged-in-dashboard"
 
+export const metadata = {
+  title: 'Farmnport — Buy & Sell Farm Produce Directly in Zimbabwe',
+  description: 'Connect farmers and buyers across Zimbabwe. Browse agricultural produce prices, find buyers and sellers, and access agrochemical guides. Join the largest farming marketplace.',
+  alternates: {
+    canonical: '/',
+  },
+  openGraph: {
+    title: 'Farmnport — Buy & Sell Farm Produce Directly in Zimbabwe',
+    description: 'Connect farmers and buyers across Zimbabwe. Browse produce prices, find buyers and sellers, and access agrochemical guides.',
+    siteName: 'farmnport',
+    type: 'website',
+  },
+}
+
 export default async function LandingPage() {
   const session = await auth()
   const user = session?.user

--- a/apps/client-fnp/app/(landing)/prices/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/prices/[slug]/page.tsx
@@ -3,15 +3,45 @@ import { RelatedPricesSidebar } from "@/components/structures/related-prices-sid
 import { ContactBuyerButton } from "@/components/structures/contact-buyer-button"
 import { Badge } from "@/components/ui/badge"
 import { formatDate, capitalizeFirstLetter } from "@/lib/utilities"
+import { AppURL } from "@/lib/schemas"
 import axios from "axios"
 import { notFound } from "next/navigation"
 import { Calendar, Building2, CheckCircle2 } from "lucide-react"
 import { auth } from "@/auth"
+import type { Metadata } from "next"
 
 interface PriceDetailsPageProps {
   params: Promise<{
     slug: string
   }>
+}
+
+export async function generateMetadata({ params }: PriceDetailsPageProps): Promise<Metadata> {
+  const { slug } = await params
+  const { priceList } = await getPriceListBySlug(slug)
+
+  if (!priceList) {
+    return { title: 'Price List Not Found | farmnport.com' }
+  }
+
+  const name = capitalizeFirstLetter(priceList.client_name)
+  const date = formatDate(priceList.effectiveDate.toString())
+  const specialization = priceList.client_specialization ? capitalizeFirstLetter(priceList.client_specialization) : 'Farm Produce'
+
+  return {
+    alternates: {
+      canonical: `${AppURL}/prices/${slug}`,
+    },
+    title: `${name} Price List — ${specialization} Prices | farmnport.com`,
+    description: `${name} ${specialization.toLowerCase()} price list effective ${date}. View current market rates and connect with this buyer on Farmnport.`,
+    openGraph: {
+      title: `${name} — ${specialization} Price List`,
+      description: `${name} ${specialization.toLowerCase()} price list effective ${date}. View current market rates on Farmnport.`,
+      url: `${AppURL}/prices/${slug}`,
+      siteName: 'farmnport',
+      type: 'website',
+    },
+  }
 }
 
 async function getPriceListBySlug(slug: string) {

--- a/apps/client-fnp/app/(landing)/prices/page.tsx
+++ b/apps/client-fnp/app/(landing)/prices/page.tsx
@@ -3,10 +3,16 @@ import { PriceCardsView } from "@/components/structures/price-cards-view"
 
 export const metadata = {
   title: 'Agricultural Produce Prices – Market Rates | farmnport.com',
-  description: `Stay updated with current market prices for agricultural produce. Trusted by farmers and bulk buyers for pricing on crops, poultry, and livestock across Zimbabwe.`,
+  description: 'Stay updated with current market prices for agricultural produce. Trusted by farmers and bulk buyers for pricing on crops, poultry, and livestock across Zimbabwe.',
   alternates: {
-    canonical: `/prices`,
-  }
+    canonical: '/prices',
+  },
+  openGraph: {
+    title: 'Agricultural Produce Prices – Market Rates',
+    description: 'Stay updated with current market prices for agricultural produce across Zimbabwe.',
+    siteName: 'farmnport',
+    type: 'website',
+  },
 }
 
 export default async function PricesPage() {

--- a/apps/client-fnp/app/(resources)/buyer/[slug]/page.tsx
+++ b/apps/client-fnp/app/(resources)/buyer/[slug]/page.tsx
@@ -21,6 +21,14 @@ export async function generateMetadata({ params }: Props,  parent: ResolvingMeta
       canonical: `${AppURL}/buyer/${slug.toLowerCase()}`,
     },
     title: `${name} - Buyer in Zimbabwe | farmnport.com`,
+    description: `View ${name}'s buyer profile on Farmnport. See what produce they're looking for and connect directly.`,
+    openGraph: {
+      title: `${name} - Buyer in Zimbabwe`,
+      description: `View ${name}'s buyer profile on Farmnport. See what produce they're looking for and connect directly.`,
+      url: `${AppURL}/buyer/${slug.toLowerCase()}`,
+      siteName: 'farmnport',
+      type: 'profile',
+    },
   }
 }
 

--- a/apps/client-fnp/app/(resources)/farmer/[slug]/page.tsx
+++ b/apps/client-fnp/app/(resources)/farmer/[slug]/page.tsx
@@ -21,6 +21,14 @@ export async function generateMetadata({ params }: Props,  parent: ResolvingMeta
       canonical: `${AppURL}/farmer/${slug.toLowerCase()}`,
     },
     title: `${name} - Farmer in Zimbabwe | farmnport.com`,
+    description: `View ${name}'s farmer profile on Farmnport. Browse their available farm produce and connect directly.`,
+    openGraph: {
+      title: `${name} - Farmer in Zimbabwe`,
+      description: `View ${name}'s farmer profile on Farmnport. Browse their available farm produce and connect directly.`,
+      url: `${AppURL}/farmer/${slug.toLowerCase()}`,
+      siteName: 'farmnport',
+      type: 'profile',
+    },
   }
 }
 

--- a/apps/client-fnp/app/sitemap.ts
+++ b/apps/client-fnp/app/sitemap.ts
@@ -3,7 +3,7 @@ import { MetadataRoute } from 'next'
 export const dynamic = 'force-dynamic'
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const BASE_URL = process.env.APP_URL || 'http://localhost:3000'
+  const BASE_URL = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
   // Static routes
   const staticRoutes: MetadataRoute.Sitemap = [
     {

--- a/apps/client-fnp/components/ads/AdSenseInFeed.tsx
+++ b/apps/client-fnp/components/ads/AdSenseInFeed.tsx
@@ -11,9 +11,13 @@ declare global {
 
 export function AdSenseInFeed() {
     const adRef = useRef<HTMLModElement>(null)
+    const hasPushed = useRef(false)
     const [adFilled, setAdFilled] = useState(false)
 
     useEffect(() => {
+        if (hasPushed.current) return
+        hasPushed.current = true
+
         try {
             (window.adsbygoogle = window.adsbygoogle || []).push({})
         } catch (e) {
@@ -49,7 +53,7 @@ export function AdSenseInFeed() {
                 data-ad-client="ca-pub-9685248262342396"
                 data-ad-slot="1965423288"
             />
-            {!adFilled && (
+            {!adFilled && process.env.NODE_ENV === "development" && (
                 <div className="p-4 rounded-lg border border-gray-200 dark:border-zinc-700">
                     <p className="text-[10px] font-medium text-gray-400 dark:text-zinc-500 uppercase tracking-wider mb-2">Sponsored</p>
                     <a href="#" onClick={(e) => e.preventDefault()} className="group block">

--- a/apps/client-fnp/components/ads/AdSenseInFeed.tsx
+++ b/apps/client-fnp/components/ads/AdSenseInFeed.tsx
@@ -1,0 +1,68 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import Script from "next/script"
+
+declare global {
+    interface Window {
+        adsbygoogle: any[]
+    }
+}
+
+export function AdSenseInFeed() {
+    const adRef = useRef<HTMLModElement>(null)
+    const [adFilled, setAdFilled] = useState(false)
+
+    useEffect(() => {
+        try {
+            (window.adsbygoogle = window.adsbygoogle || []).push({})
+        } catch (e) {
+            console.error("AdSense error:", e)
+        }
+
+        const observer = new MutationObserver(() => {
+            if (adRef.current && adRef.current.getAttribute("data-ad-status") === "filled") {
+                setAdFilled(true)
+            }
+        })
+
+        if (adRef.current) {
+            observer.observe(adRef.current, { attributes: true })
+        }
+
+        return () => observer.disconnect()
+    }, [])
+
+    return (
+        <div className="my-4">
+            <Script
+                async
+                src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9685248262342396"
+                crossOrigin="anonymous"
+                strategy="afterInteractive"
+            />
+            <ins className="adsbygoogle"
+                ref={adRef}
+                style={{ display: adFilled ? "block" : "none" }}
+                data-ad-format="fluid"
+                data-ad-layout-key="-gw-3+1f-3d+2z"
+                data-ad-client="ca-pub-9685248262342396"
+                data-ad-slot="1965423288"
+            />
+            {!adFilled && (
+                <div className="p-4 rounded-lg border border-gray-200 dark:border-zinc-700">
+                    <p className="text-[10px] font-medium text-gray-400 dark:text-zinc-500 uppercase tracking-wider mb-2">Sponsored</p>
+                    <a href="#" onClick={(e) => e.preventDefault()} className="group block">
+                        <h4 className="text-base font-medium text-blue-700 dark:text-blue-400 group-hover:underline leading-snug">
+                            Premium Crop Protection Solutions — Shop Now
+                        </h4>
+                        <p className="text-xs text-green-700 dark:text-green-500 mt-1">www.example-agristore.com/crop-protection</p>
+                        <p className="text-sm text-gray-600 dark:text-zinc-400 mt-1 leading-relaxed">
+                            Trusted fungicides, insecticides &amp; herbicides for every season. Free delivery on orders over KSh 5,000. PCPB-registered products only.
+                        </p>
+                    </a>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/apps/client-fnp/components/agrochemical/AgroChemicalCard.tsx
+++ b/apps/client-fnp/components/agrochemical/AgroChemicalCard.tsx
@@ -27,6 +27,7 @@ export function AgroChemicalCard({ chemical, mode }: AgroChemicalCardProps) {
               src={chemical.images[0].img.src}
               alt={chemical.name}
               fill
+              sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
               className="object-contain transition-transform duration-200 group-hover:scale-105"
             />
           ) : (

--- a/apps/client-fnp/lib/schemas.ts
+++ b/apps/client-fnp/lib/schemas.ts
@@ -369,11 +369,207 @@ export const FeatureFlags = process.env.NEXT_PUBLIC_FEATURE_FLAGS
 export type BuyerSeoCategoryKeys = | "beef" | "lamb" | "mutton" | "goat" | "chicken" | "pork"
 
 export const BuyerSeo: Record<string, string>  = {
-  chicken: "Looking for trusted chicken buyers and  where to sell chickens in Zimbabwe? Connect with reliable poultry buyers across the country, in major towns who purchase broiler, free-range, and live chickens in bulk or retail."
+  // Livestock
+  cattle: "Find cattle buyers in Zimbabwe. Sell beef cattle, dairy cows, and livestock directly to verified buyers offering competitive prices across all provinces.",
+  pigs: "Connect with pig buyers in Zimbabwe. Sell pigs to abattoirs, pork processors, and traders at fair market prices.",
+  sheep: "Find sheep buyers in Zimbabwe. Sell sheep and wool directly to abattoirs, butcheries, and livestock traders nationwide.",
+  goats: "Connect with goat buyers in Zimbabwe. Sell goats to butcheries, traders, and communities at competitive prices.",
+  chicken: "Looking for trusted chicken buyers and where to sell chickens in Zimbabwe? Connect with reliable poultry buyers who purchase broiler, free-range, and live chickens in bulk or retail.",
+  ducks: "Find duck buyers in Zimbabwe. Sell ducks and duck eggs to restaurants, retailers, and traders across the country.",
+  turkeys: "Connect with turkey buyers in Zimbabwe. Sell turkeys to hotels, restaurants, and retailers especially during festive seasons.",
+  rabbits: "Find rabbit buyers in Zimbabwe. Sell rabbits to restaurants, butcheries, and health-conscious consumers.",
+  ostriches: "Connect with ostrich buyers in Zimbabwe. Sell ostrich meat, leather, and feathers to processors and exporters.",
+  // Meat & Poultry
+  beef: "Find beef buyers in Zimbabwe. Sell quality beef to butcheries, supermarkets, and restaurants at competitive wholesale and retail prices.",
+  pork: "Connect with pork buyers in Zimbabwe. Sell fresh pork to butcheries, processors, and retailers nationwide.",
+  lamb: "Find lamb buyers in Zimbabwe. Sell premium lamb to butcheries, restaurants, and supermarkets at fair market prices.",
+  mutton: "Connect with mutton buyers in Zimbabwe. Sell mutton to butcheries, wholesalers, and retail outlets across all provinces.",
+  "goat-meat": "Find goat meat buyers in Zimbabwe. Sell chevon to butcheries, restaurants, and traders at competitive prices.",
+  "chicken-meat": "Connect with chicken meat buyers in Zimbabwe. Sell dressed chicken to supermarkets, fast-food chains, and retailers.",
+  // Dairy & Eggs
+  "milk-raw": "Find raw milk buyers in Zimbabwe. Sell fresh milk to dairy processors, cheese makers, and direct consumers.",
+  cheese: "Connect with cheese buyers in Zimbabwe. Sell artisanal and farm-produced cheese to retailers and restaurants.",
+  yogurt: "Find yogurt buyers in Zimbabwe. Sell farm-fresh yogurt to supermarkets, health shops, and wholesale distributors.",
+  butter: "Connect with butter buyers in Zimbabwe. Sell farm-produced butter to retailers, bakeries, and food processors.",
+  "chicken-eggs": "Find egg buyers in Zimbabwe. Sell fresh chicken eggs to retailers, bakeries, and wholesalers at competitive prices.",
+  "duck-eggs": "Connect with duck egg buyers in Zimbabwe. Sell duck eggs to speciality food shops and restaurants.",
+  eggs: "Find egg buyers in Zimbabwe. Sell fresh eggs to supermarkets, bakeries, restaurants, and wholesale distributors at competitive prices.",
+  // Grains & Cereals
+  maize: "Connect with maize buyers in Zimbabwe. Sell your maize harvest directly to millers, traders, and bulk buyers at fair market prices.",
+  wheat: "Find wheat buyers in Zimbabwe. Sell wheat directly to millers and grain traders at competitive market rates.",
+  sorghum: "Connect with sorghum buyers in Zimbabwe. Sell sorghum to breweries, millers, and animal feed producers.",
+  barley: "Find barley buyers in Zimbabwe. Sell malting and feed barley to breweries and livestock feed manufacturers.",
+  oats: "Connect with oat buyers in Zimbabwe. Sell oats to food processors, millers, and animal feed producers.",
+  rice: "Find rice buyers in Zimbabwe. Sell locally grown rice to retailers, wholesalers, and food service companies.",
+  millet: "Connect with millet buyers in Zimbabwe. Sell millet to millers, breweries, and health food producers.",
+  // Oilseeds & Legumes
+  soybeans: "Find soybean buyers in Zimbabwe. Sell soya beans to oil expressers, feed manufacturers, and export traders.",
+  soya: "Find soya bean buyers in Zimbabwe. Sell soya beans to oil expressers, feed manufacturers, and bulk traders at competitive prices.",
+  sunflower: "Connect with sunflower buyers in Zimbabwe. Sell sunflower seed to oil processors and export traders.",
+  groundnuts: "Find groundnut buyers in Zimbabwe. Sell peanuts to butter manufacturers, confectioneries, and export traders.",
+  "dry-beans": "Connect with dry bean buyers in Zimbabwe. Sell beans to wholesalers, retailers, and food processors.",
+  lentils: "Find lentil buyers in Zimbabwe. Sell lentils to food importers, retailers, and health food companies.",
+  chickpeas: "Connect with chickpea buyers in Zimbabwe. Sell chickpeas to food processors and export traders.",
+  // Vegetables
+  potatoes: "Find potato buyers in Zimbabwe. Sell potatoes to retailers, chip manufacturers, and wholesale markets.",
+  "sweet-potatoes": "Connect with sweet potato buyers in Zimbabwe. Sell sweet potatoes to retailers and food processors.",
+  tomatoes: "Find tomato buyers in Zimbabwe. Sell fresh tomatoes to retailers, wholesalers, and processing companies.",
+  onions: "Connect with onion buyers in Zimbabwe. Sell onions to retailers, wholesalers, and food service companies.",
+  cabbage: "Find cabbage buyers in Zimbabwe. Sell cabbage to supermarkets, restaurants, and wholesale markets.",
+  carrots: "Connect with carrot buyers in Zimbabwe. Sell fresh carrots to retailers, juice makers, and wholesalers.",
+  butternut: "Find butternut buyers in Zimbabwe. Sell butternut to supermarkets, restaurants, and food processors.",
+  pumpkins: "Connect with pumpkin buyers in Zimbabwe. Sell pumpkins to retailers, markets, and food processors.",
+  peppers: "Find pepper buyers in Zimbabwe. Sell green, red, and chilli peppers to retailers and food processors.",
+  lettuce: "Connect with lettuce buyers in Zimbabwe. Sell fresh lettuce to supermarkets, restaurants, and fast-food chains.",
+  spinach: "Find spinach buyers in Zimbabwe. Sell fresh spinach to retailers, restaurants, and wholesale markets.",
+  beetroot: "Connect with beetroot buyers in Zimbabwe. Sell beetroot to retailers, juice bars, and food processors.",
+  cauliflower: "Find cauliflower buyers in Zimbabwe. Sell cauliflower to supermarkets, restaurants, and wholesalers.",
+  broccoli: "Connect with broccoli buyers in Zimbabwe. Sell fresh broccoli to supermarkets and health-food retailers.",
+  cucumbers: "Find cucumber buyers in Zimbabwe. Sell cucumbers to retailers, restaurants, and wholesale markets.",
+  "green-beans": "Connect with green bean buyers in Zimbabwe. Sell fresh green beans to retailers, exporters, and food processors.",
+  chilli: "Find chilli buyers in Zimbabwe. Sell fresh and dried chillies to food processors, restaurants, and spice traders.",
+  // Fruits
+  oranges: "Find orange buyers in Zimbabwe. Sell oranges to juice processors, retailers, and wholesale fruit markets.",
+  apples: "Connect with apple buyers in Zimbabwe. Sell apples to supermarkets, juice makers, and wholesale markets.",
+  bananas: "Find banana buyers in Zimbabwe. Sell bananas to retailers, wholesalers, and food processors.",
+  avocados: "Connect with avocado buyers in Zimbabwe. Sell avocados to supermarkets, restaurants, and export traders.",
+  mangoes: "Find mango buyers in Zimbabwe. Sell fresh mangoes to juice processors, retailers, and export companies.",
+  grapes: "Connect with grape buyers in Zimbabwe. Sell grapes to wine producers, retailers, and wholesale markets.",
+  strawberries: "Find strawberry buyers in Zimbabwe. Sell strawberries to supermarkets, restaurants, and jam manufacturers.",
+  peaches: "Connect with peach buyers in Zimbabwe. Sell peaches to canners, retailers, and wholesale fruit markets.",
+  plums: "Find plum buyers in Zimbabwe. Sell plums to retailers, jam producers, and wholesale markets.",
+  lemons: "Connect with lemon buyers in Zimbabwe. Sell lemons to juice processors, retailers, and restaurants.",
+  pears: "Find pear buyers in Zimbabwe. Sell pears to retailers, canners, and wholesale fruit markets.",
+  watermelons: "Find watermelon buyers in Zimbabwe. Sell watermelons to retailers, juice bars, and wholesale markets.",
+  watermelon: "Find watermelon buyers in Zimbabwe. Sell watermelons to retailers, juice bars, and wholesale markets.",
+  litchis: "Connect with litchi buyers in Zimbabwe. Sell litchis to retailers, exporters, and juice processors.",
+  papayas: "Find papaya buyers in Zimbabwe. Sell papayas to retailers, juice processors, and health-food shops.",
+  // Herbs & Spices
+  garlic: "Find garlic buyers in Zimbabwe. Sell garlic to retailers, food processors, and restaurants.",
+  ginger: "Connect with ginger buyers in Zimbabwe. Sell fresh ginger to food processors, retailers, and health-food companies.",
+  // Industrial Crops
+  sugarcane: "Find sugarcane buyers in Zimbabwe. Sell sugarcane to millers and ethanol producers.",
+  cotton: "Connect with cotton buyers in Zimbabwe. Sell lint and seed cotton to ginners, textile manufacturers, and export traders.",
+  tobacco: "Find tobacco buyers in Zimbabwe. Sell flue-cured, burley, and oriental tobacco to verified buyers and auction floors.",
+  coffee: "Connect with coffee buyers in Zimbabwe. Sell Arabica and Robusta coffee beans to roasters, exporters, and traders.",
+  tea: "Find tea buyers in Zimbabwe. Sell black and green tea to processors, exporters, and blenders.",
+  // Animal Feed
+  lucerne: "Connect with lucerne buyers in Zimbabwe. Sell lucerne bales to dairy farmers, horse owners, and livestock feedlots.",
+  hay: "Find hay buyers in Zimbabwe. Sell hay bales to livestock farmers, horse stables, and feedlots.",
+  // Aquaculture
+  tilapia: "Connect with tilapia buyers in Zimbabwe. Sell fresh tilapia to restaurants, retailers, and fish markets.",
+  trout: "Find trout buyers in Zimbabwe. Sell fresh trout to restaurants, supermarkets, and fish mongers.",
+  catfish: "Connect with catfish buyers in Zimbabwe. Sell catfish to restaurants, retailers, and fish markets.",
+  // Other
+  honey: "Find honey buyers in Zimbabwe. Sell raw and processed honey to retailers, health shops, and food companies.",
+  flowers: "Connect with flower buyers in Zimbabwe. Sell cut flowers to florists, event companies, and export markets.",
+  mushrooms: "Find mushroom buyers in Zimbabwe. Sell fresh and dried mushrooms to restaurants, retailers, and health-food shops.",
 }
 
 export const FarmerSeo: Record<string, string>  = {
-  chicken: "Looking for trusted chicken farmers and  where to buy chickens in Zimbabwe? Connect with reliable poultry farmers across the country, in major towns who purchase broiler, free-range, and live chickens in bulk or retail."
+  // Livestock
+  cattle: "Find cattle farmers in Zimbabwe. Buy beef cattle, dairy cows, and livestock directly from trusted farmers at fair prices across all provinces.",
+  pigs: "Connect with pig farmers in Zimbabwe. Buy quality pigs directly from breeders and growers for your abattoir or farm.",
+  sheep: "Find sheep farmers in Zimbabwe. Buy sheep for meat, wool, and breeding directly from trusted livestock producers.",
+  goats: "Connect with goat farmers in Zimbabwe. Buy quality goats directly from breeders and smallholder farmers.",
+  chicken: "Looking for trusted chicken farmers and where to buy chickens in Zimbabwe? Connect with reliable poultry farmers who sell broiler, free-range, and live chickens in bulk or retail.",
+  ducks: "Find duck farmers in Zimbabwe. Buy ducks and duck eggs directly from trusted poultry farmers.",
+  turkeys: "Connect with turkey farmers in Zimbabwe. Buy turkeys directly from breeders especially for festive seasons.",
+  rabbits: "Find rabbit farmers in Zimbabwe. Buy rabbits directly from breeders for meat, fur, and breeding.",
+  ostriches: "Connect with ostrich farmers in Zimbabwe. Buy ostriches for meat, leather, and feather production.",
+  // Meat & Poultry
+  beef: "Find beef farmers and suppliers in Zimbabwe. Buy quality beef directly from farmers and feedlot operators at wholesale prices.",
+  pork: "Connect with pork farmers in Zimbabwe. Buy fresh pork directly from pig producers and abattoirs.",
+  lamb: "Find lamb farmers in Zimbabwe. Buy premium lamb from trusted sheep producers and feedlots.",
+  mutton: "Connect with mutton suppliers in Zimbabwe. Buy quality mutton directly from sheep farmers across all provinces.",
+  "goat-meat": "Find goat meat farmers in Zimbabwe. Buy fresh chevon directly from goat producers at farm-gate prices.",
+  "chicken-meat": "Connect with chicken meat suppliers in Zimbabwe. Buy dressed chicken directly from poultry farmers and abattoirs.",
+  // Dairy & Eggs
+  "milk-raw": "Find dairy farmers in Zimbabwe. Buy fresh raw milk directly from trusted dairy producers.",
+  cheese: "Connect with cheese-producing farmers in Zimbabwe. Buy artisanal farm cheese directly from dairy producers.",
+  yogurt: "Find yogurt-producing farmers in Zimbabwe. Buy farm-fresh yogurt directly from dairy producers.",
+  butter: "Connect with butter-producing farmers in Zimbabwe. Buy farm-fresh butter directly from dairy producers.",
+  "chicken-eggs": "Find egg farmers in Zimbabwe. Buy fresh chicken eggs directly from poultry farmers at wholesale prices.",
+  "duck-eggs": "Connect with duck egg farmers in Zimbabwe. Buy fresh duck eggs directly from poultry producers.",
+  eggs: "Find egg farmers in Zimbabwe. Buy fresh eggs directly from poultry farmers at competitive wholesale and retail prices.",
+  // Grains & Cereals
+  maize: "Connect with maize farmers in Zimbabwe. Buy quality maize directly from growers for milling, animal feed, or resale.",
+  wheat: "Find wheat farmers in Zimbabwe. Buy quality wheat grain directly from growers for milling and food production.",
+  sorghum: "Connect with sorghum farmers in Zimbabwe. Buy quality sorghum directly from growers for brewing, milling, and feed.",
+  barley: "Find barley farmers in Zimbabwe. Buy malting and feed barley directly from growers.",
+  oats: "Connect with oat farmers in Zimbabwe. Buy quality oats directly from growers for food processing and animal feed.",
+  rice: "Find rice farmers in Zimbabwe. Buy locally grown rice directly from paddy farmers.",
+  millet: "Connect with millet farmers in Zimbabwe. Buy quality millet directly from growers for milling and brewing.",
+  // Oilseeds & Legumes
+  soybeans: "Find soybean farmers in Zimbabwe. Buy quality soya beans directly from growers for oil extraction, feed, or export.",
+  soya: "Find soya bean farmers in Zimbabwe. Buy quality soya beans directly from growers for oil extraction, animal feed, or export.",
+  sunflower: "Connect with sunflower farmers in Zimbabwe. Buy sunflower seed directly from growers for oil processing.",
+  groundnuts: "Find groundnut farmers in Zimbabwe. Buy quality peanuts directly from growers for processing, confectionery, or export.",
+  "dry-beans": "Connect with bean farmers in Zimbabwe. Buy dry beans directly from growers at farm-gate prices.",
+  lentils: "Find lentil farmers in Zimbabwe. Buy lentils directly from growers for retail and food processing.",
+  chickpeas: "Connect with chickpea farmers in Zimbabwe. Buy chickpeas directly from growers for food processing and export.",
+  // Vegetables
+  potatoes: "Find potato farmers in Zimbabwe. Buy fresh potatoes directly from growers for retail, wholesale, or chip manufacturing.",
+  "sweet-potatoes": "Connect with sweet potato farmers in Zimbabwe. Buy sweet potatoes directly from growers.",
+  tomatoes: "Find tomato farmers in Zimbabwe. Buy fresh tomatoes directly from growers for retail, wholesale, and processing.",
+  onions: "Connect with onion farmers in Zimbabwe. Buy fresh onions directly from growers at farm-gate prices.",
+  cabbage: "Find cabbage farmers in Zimbabwe. Buy fresh cabbage directly from growers for retail and wholesale.",
+  carrots: "Connect with carrot farmers in Zimbabwe. Buy fresh carrots directly from growers.",
+  butternut: "Find butternut farmers in Zimbabwe. Buy butternut directly from growers for retail and wholesale.",
+  pumpkins: "Connect with pumpkin farmers in Zimbabwe. Buy pumpkins directly from growers.",
+  peppers: "Find pepper farmers in Zimbabwe. Buy fresh peppers directly from growers for retail and processing.",
+  lettuce: "Connect with lettuce farmers in Zimbabwe. Buy fresh lettuce directly from growers for restaurants and retail.",
+  spinach: "Find spinach farmers in Zimbabwe. Buy fresh spinach directly from growers for retail and wholesale.",
+  beetroot: "Connect with beetroot farmers in Zimbabwe. Buy fresh beetroot directly from growers.",
+  cauliflower: "Find cauliflower farmers in Zimbabwe. Buy fresh cauliflower directly from growers.",
+  broccoli: "Connect with broccoli farmers in Zimbabwe. Buy fresh broccoli directly from growers.",
+  cucumbers: "Find cucumber farmers in Zimbabwe. Buy fresh cucumbers directly from growers for retail and wholesale.",
+  "green-beans": "Connect with green bean farmers in Zimbabwe. Buy fresh green beans directly from growers for retail and export.",
+  chilli: "Find chilli farmers in Zimbabwe. Buy fresh and dried chillies directly from growers for processing and retail.",
+  // Fruits
+  oranges: "Find orange farmers in Zimbabwe. Buy fresh oranges directly from citrus growers for retail and juice processing.",
+  apples: "Connect with apple farmers in Zimbabwe. Buy fresh apples directly from orchards for retail and processing.",
+  bananas: "Find banana farmers in Zimbabwe. Buy bananas directly from growers for retail and wholesale.",
+  avocados: "Connect with avocado farmers in Zimbabwe. Buy fresh avocados directly from growers for retail and export.",
+  mangoes: "Find mango farmers in Zimbabwe. Buy fresh mangoes directly from growers for retail, processing, and export.",
+  grapes: "Connect with grape farmers in Zimbabwe. Buy grapes directly from vineyards for wine production and retail.",
+  strawberries: "Find strawberry farmers in Zimbabwe. Buy fresh strawberries directly from growers.",
+  peaches: "Connect with peach farmers in Zimbabwe. Buy fresh peaches directly from orchards for retail and canning.",
+  plums: "Find plum farmers in Zimbabwe. Buy fresh plums directly from orchards for retail and processing.",
+  lemons: "Connect with lemon farmers in Zimbabwe. Buy fresh lemons directly from citrus growers.",
+  pears: "Find pear farmers in Zimbabwe. Buy fresh pears directly from orchards for retail and canning.",
+  watermelons: "Find watermelon farmers in Zimbabwe. Buy watermelons directly from growers for retail and wholesale.",
+  watermelon: "Find watermelon farmers in Zimbabwe. Buy watermelons directly from growers for retail and wholesale.",
+  litchis: "Connect with litchi farmers in Zimbabwe. Buy fresh litchis directly from growers for retail and export.",
+  papayas: "Find papaya farmers in Zimbabwe. Buy fresh papayas directly from growers for retail and processing.",
+  // Herbs & Spices
+  garlic: "Find garlic farmers in Zimbabwe. Buy fresh garlic directly from growers for retail and food processing.",
+  ginger: "Connect with ginger farmers in Zimbabwe. Buy fresh ginger directly from growers for retail and processing.",
+  // Industrial Crops
+  sugarcane: "Find sugarcane farmers in Zimbabwe. Buy sugarcane directly from growers for milling and ethanol production.",
+  cotton: "Connect with cotton farmers in Zimbabwe. Buy lint and seed cotton directly from growers across cotton-producing regions.",
+  tobacco: "Find tobacco farmers in Zimbabwe. Buy flue-cured, burley, and oriental tobacco directly from experienced growers.",
+  coffee: "Connect with coffee farmers in Zimbabwe. Buy Arabica and Robusta coffee beans directly from growers.",
+  tea: "Find tea farmers in Zimbabwe. Buy black and green tea directly from estate and smallholder growers.",
+  // Animal Feed
+  lucerne: "Connect with lucerne farmers in Zimbabwe. Buy lucerne bales directly from growers for dairy and livestock feeding.",
+  hay: "Find hay farmers in Zimbabwe. Buy hay bales directly from growers for livestock feeding.",
+  // Aquaculture
+  tilapia: "Find tilapia farmers in Zimbabwe. Buy fresh tilapia directly from fish farmers and aquaculture producers.",
+  trout: "Connect with trout farmers in Zimbabwe. Buy fresh trout directly from aquaculture producers.",
+  catfish: "Find catfish farmers in Zimbabwe. Buy fresh catfish directly from fish farmers.",
+  // Other
+  honey: "Connect with beekeepers in Zimbabwe. Buy raw and processed honey directly from apiarists.",
+  flowers: "Find flower farmers in Zimbabwe. Buy cut flowers directly from growers for floristry and events.",
+  mushrooms: "Find mushroom farmers in Zimbabwe. Buy fresh and dried mushrooms directly from growers.",
+}
+
+export function getBuyerSeo(product: string): string {
+  return BuyerSeo[product] || `Find ${product} buyers in Zimbabwe on Farmnport. Sell your ${product} directly to verified buyers at competitive market prices.`
+}
+
+export function getFarmerSeo(product: string): string {
+  return FarmerSeo[product] || `Find ${product} farmers in Zimbabwe on Farmnport. Buy quality ${product} directly from trusted local growers at fair prices.`
 }
 
 export type FarmProduceCategory = {

--- a/apps/client-fnp/public/robots.txt
+++ b/apps/client-fnp/public/robots.txt
@@ -2,8 +2,8 @@
 User-agent: *
 Allow: /
 
-# Disallow crawling of API routes
+# Disallow crawling of API routes and auth pages
 Disallow: /api/
 
-# Sitemap location (update with your actual domain)
-# Sitemap: https://yourdomain.com/sitemap.xml
+# Sitemap location
+Sitemap: https://farmnport.com/sitemap.xml


### PR DESCRIPTION
## Summary
- Add `AdSenseInFeed` component with Google AdSense integration for agrochemical guide pages
- Realistic text ad fallback (agricultural-themed) shown when AdSense doesn't fill the slot (e.g. on localhost)
- Hidden `<ins>` element when unfilled to prevent blank white box rendering
- Groundwork for an admin section to manage ad placements

## Test plan
- [ ] Verify fallback text ad renders correctly on localhost
- [ ] Confirm no white box appears when AdSense is unfilled
- [ ] Test on production domain to verify real AdSense ads load
- [ ] Check dark mode styling of fallback ad