### PR TITLE
Truncate long target descriptions in admin

### DIFF
--- a/apps/admin-fnp/components/structures/columns/agroChemicalTargets.tsx
+++ b/apps/admin-fnp/components/structures/columns/agroChemicalTargets.tsx
@@ -39,9 +39,9 @@ export const agroChemicalTargetColumns: ColumnDef<AgroChemicalTarget>[] = [
     accessorKey: "description",
     header: "Description",
     cell: ({ row }) => (
-      <span className="max-w-md truncate">
+      <div className="max-w-xs block truncate" title={row.original.description || ""}>
         {row.original.description || "-"}
-      </span>
+      </div>
     ),
   },
   {


### PR DESCRIPTION
## Summary
- Fix ellipsis truncation on agrochemical target descriptions in admin table
- Change from inline `span` to block `div` so `truncate` class works properly
- Add `title` attribute for full text on hover

## Test plan
- [ ] Check /dashboard/agrochemical-targets table for long descriptions