### PR TITLE
Add ads.txt for AdSense authorization

### DIFF
--- a/apps/client-fnp/public/ads.txt
+++ b/apps/client-fnp/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-9685248262342396, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## Summary
- Add ads.txt file to client-fnp public directory for Google AdSense domain authorization
- Contains Google publisher ID (pub-9685248262342396) with DIRECT relationship

## Test Plan
- [ ] Verify ads.txt is accessible at farmnport.com/ads.txt after deployment
- [ ] Confirm AdSense status changes from "Not found" to "Authorised"