### PR TITLE
Add crop group feature and dosage rate grouping

### DIFF
--- a/apps/admin-fnp/app/(dashboard)/dashboard/crop-groups/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/(dashboard)/dashboard/crop-groups/[slug]/edit/page.tsx
@@ -1,0 +1,336 @@
+"use client"
+
+import { use, useState, useRef, useEffect } from "react"
+import Link from "next/link"
+import { useMutation, useQuery } from "@tanstack/react-query"
+import { useRouter } from "next/navigation"
+import { useDebounce } from "use-debounce"
+
+import { updateCropGroup, queryCropGroup, queryFarmProduce } from "@/lib/query"
+import { FarmProduce } from "@/lib/schemas"
+import { cn } from "@/lib/utilities"
+import { buttonVariants } from "@/components/ui/button"
+import { Button } from "@/components/ui/button"
+import { Icons } from "@/components/icons/lucide"
+import { toast } from "@/components/ui/use-toast"
+import { handleApiError, handleFetchError } from "@/lib/error-handler"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from "@/components/ui/popover"
+import {
+    Command,
+    CommandEmpty,
+    CommandInput,
+    CommandItem,
+    CommandList,
+} from "@/components/ui/command"
+
+export default function EditCropGroupPage({ params }: { params: Promise<{ slug: string }> }) {
+    const router = useRouter()
+    const { slug } = use(params)
+    const groupId = slug
+
+    const [name, setName] = useState("")
+    const [description, setDescription] = useState("")
+    const [selectedCrops, setSelectedCrops] = useState<Array<{ id: string; name: string }>>([])
+    const [searchCrop, setSearchCrop] = useState("")
+    const [openCrops, setOpenCrops] = useState(false)
+    const [initialized, setInitialized] = useState(false)
+
+    const [debouncedCropQuery] = useDebounce(searchCrop, 1000)
+
+    const hasShownError = useRef(false)
+
+    const { data: groupData, isLoading } = useQuery({
+        queryKey: ["crop-group", groupId],
+        queryFn: () => queryCropGroup(groupId),
+    })
+
+    const group = groupData?.data
+
+    // Initialize form with fetched data
+    useEffect(() => {
+        if (group && !initialized) {
+            setName(group.name || "")
+            setDescription(group.description || "")
+            if (group.farm_produce_items) {
+                setSelectedCrops(group.farm_produce_items.map((item: FarmProduce) => ({
+                    id: item.id,
+                    name: item.name,
+                })))
+            }
+            setInitialized(true)
+        }
+    }, [group, initialized])
+
+    const { data: cropData, isError: cropError, error: cropFetchError, refetch: cropRefetch } = useQuery({
+        queryKey: ["farm-produce-search", { search: debouncedCropQuery }],
+        queryFn: () => queryFarmProduce({ search: debouncedCropQuery }),
+        enabled: debouncedCropQuery.length >= 2,
+        refetchOnWindowFocus: false
+    })
+
+    useEffect(() => {
+        if (cropError && !hasShownError.current) {
+            hasShownError.current = true
+            handleFetchError(cropFetchError, {
+                onRetry: () => {
+                    hasShownError.current = false
+                    cropRefetch()
+                },
+                context: "farm produce"
+            })
+        }
+        if (!cropError) {
+            hasShownError.current = false
+        }
+    }, [cropError, cropFetchError, cropRefetch])
+
+    const farmProduceList = cropData?.data?.data as FarmProduce[]
+
+    const handleToggleCrop = (crop: FarmProduce) => {
+        const exists = selectedCrops.find(c => c.id === crop.id)
+        if (exists) {
+            setSelectedCrops(selectedCrops.filter(c => c.id !== crop.id))
+        } else {
+            setSelectedCrops([...selectedCrops, { id: crop.id, name: crop.name }])
+        }
+    }
+
+    const { mutate, isPending } = useMutation({
+        mutationFn: updateCropGroup,
+        onSuccess: () => {
+            toast({
+                description: "Crop group updated successfully",
+            })
+            router.push("/dashboard/crop-groups")
+        },
+        onError: (error) => {
+            handleApiError(error, {
+                context: "crop group update"
+            })
+        },
+    })
+
+    function onSubmit(e: React.FormEvent) {
+        e.preventDefault()
+
+        if (!name.trim()) {
+            toast({ description: "Name is required", variant: "destructive" })
+            return
+        }
+
+        if (selectedCrops.length === 0) {
+            toast({ description: "At least one crop is required", variant: "destructive" })
+            return
+        }
+
+        mutate({
+            id: groupId,
+            name: name.trim(),
+            description: description.trim(),
+            farm_produce_ids: selectedCrops.map(c => c.id),
+        })
+    }
+
+    if (isLoading) {
+        return (
+            <div className="flex justify-center py-12">
+                <Icons.spinner className="w-8 h-8 animate-spin text-gray-400" />
+            </div>
+        )
+    }
+
+    if (!group) {
+        return (
+            <div className="text-center py-12">
+                <p className="text-sm text-red-600 dark:text-red-400">
+                    Crop group not found.
+                </p>
+            </div>
+        )
+    }
+
+    return (
+        <div className="space-y-10">
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+                        Edit Crop Group
+                    </h1>
+                    <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                        Update the crop group information.
+                    </p>
+                </div>
+                <Link
+                    href="/dashboard/crop-groups"
+                    className={cn(buttonVariants({ variant: "ghost" }))}
+                >
+                    <Icons.close className="w-4 h-4 mr-2" />
+                    Close
+                </Link>
+            </div>
+
+            <form onSubmit={onSubmit}>
+                <div className="space-y-12">
+                    <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
+                        <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                            Group Information
+                        </h2>
+                        <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                            Crop groups let you apply the same dosage rate to multiple crops at once.
+                        </p>
+
+                        <div className="mt-10 space-y-8">
+                            <div className="px-1">
+                                <label
+                                    htmlFor="name"
+                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                >
+                                    Group Name
+                                </label>
+                                <div className="mt-2">
+                                    <Input
+                                        id="name"
+                                        placeholder="e.g., Cucurbits, Brassicas, Stone Fruits"
+                                        value={name}
+                                        onChange={(e) => setName(e.target.value)}
+                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                    />
+                                </div>
+                            </div>
+
+                            <div className="px-1">
+                                <label
+                                    htmlFor="description"
+                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                >
+                                    Description
+                                </label>
+                                <div className="mt-2">
+                                    <Textarea
+                                        id="description"
+                                        placeholder="Describe this crop group"
+                                        rows={3}
+                                        value={description}
+                                        onChange={(e) => setDescription(e.target.value)}
+                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                    />
+                                </div>
+                            </div>
+
+                            <div className="px-1">
+                                <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                                    Crops in this Group
+                                </label>
+
+                                {selectedCrops.length > 0 && (
+                                    <div className="flex flex-wrap gap-2 mt-2 mb-3">
+                                        {selectedCrops.map(crop => (
+                                            <span
+                                                key={crop.id}
+                                                className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-sm bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-300 cursor-pointer hover:bg-blue-100 dark:hover:bg-blue-900/40"
+                                                onClick={() => setSelectedCrops(selectedCrops.filter(c => c.id !== crop.id))}
+                                            >
+                                                {crop.name}
+                                                <Icons.close className="w-3 h-3" />
+                                            </span>
+                                        ))}
+                                    </div>
+                                )}
+
+                                <Popover open={openCrops} onOpenChange={setOpenCrops}>
+                                    <PopoverTrigger asChild>
+                                        <Button
+                                            type="button"
+                                            variant="outline"
+                                            role="combobox"
+                                            aria-expanded={openCrops}
+                                            className="w-full justify-start text-left font-normal"
+                                        >
+                                            <Icons.search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+                                            Search and add crops...
+                                        </Button>
+                                    </PopoverTrigger>
+                                    <PopoverContent className="w-full p-0" align="start">
+                                        <Command shouldFilter={false}>
+                                            <CommandInput
+                                                placeholder="Type crop name (min 2 chars)..."
+                                                value={searchCrop}
+                                                onValueChange={setSearchCrop}
+                                            />
+                                            <CommandList>
+                                                <CommandEmpty>
+                                                    {debouncedCropQuery.length < 2
+                                                        ? "Type at least 2 characters to search"
+                                                        : "No crops found"
+                                                    }
+                                                </CommandEmpty>
+                                                {farmProduceList?.map((crop) => {
+                                                    const isSelected = selectedCrops.some(c => c.id === crop.id)
+                                                    return (
+                                                        <CommandItem
+                                                            key={crop.id}
+                                                            value={crop.id}
+                                                            onSelect={() => handleToggleCrop(crop)}
+                                                        >
+                                                            <span className={cn(
+                                                                "mr-2 flex h-4 w-4 items-center justify-center rounded-sm border",
+                                                                isSelected
+                                                                    ? "bg-primary border-primary text-primary-foreground"
+                                                                    : "border-gray-300 dark:border-gray-600"
+                                                            )}>
+                                                                {isSelected && <Icons.check className="w-3 h-3" />}
+                                                            </span>
+                                                            {crop.name}
+                                                        </CommandItem>
+                                                    )
+                                                })}
+                                            </CommandList>
+                                        </Command>
+                                    </PopoverContent>
+                                </Popover>
+                                <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                    Select the crops that belong to this group.
+                                </p>
+                            </div>
+
+                            <div className="px-1">
+                                <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                                    Current Slug
+                                </label>
+                                <div className="mt-2">
+                                    <div className="block w-full rounded-md bg-gray-50 px-3 py-1.5 text-base text-gray-500 outline outline-1 outline-gray-300 sm:text-sm/6 dark:bg-gray-900 dark:text-gray-400 dark:outline-white/10">
+                                        {group.slug}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div className="mt-6 flex items-center justify-end gap-x-6">
+                    <button
+                        type="button"
+                        onClick={() => router.push("/dashboard/crop-groups")}
+                        className="text-sm/6 font-semibold text-gray-900 dark:text-white"
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        type="submit"
+                        disabled={isPending}
+                        className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
+                    >
+                        {isPending && <Icons.spinner className="w-4 h-4 mr-2 animate-spin" />}
+                        Save
+                    </button>
+                </div>
+            </form>
+        </div>
+    )
+}

--- a/apps/admin-fnp/app/(dashboard)/dashboard/crop-groups/new/page.tsx
+++ b/apps/admin-fnp/app/(dashboard)/dashboard/crop-groups/new/page.tsx
@@ -1,0 +1,287 @@
+"use client"
+
+import { useState, useRef, useEffect } from "react"
+import Link from "next/link"
+import { useMutation, useQuery } from "@tanstack/react-query"
+import { useRouter } from "next/navigation"
+import { useDebounce } from "use-debounce"
+
+import { addCropGroup, queryFarmProduce } from "@/lib/query"
+import { FarmProduce } from "@/lib/schemas"
+import { cn } from "@/lib/utilities"
+import { buttonVariants } from "@/components/ui/button"
+import { Button } from "@/components/ui/button"
+import { Icons } from "@/components/icons/lucide"
+import { toast } from "@/components/ui/use-toast"
+import { handleApiError, handleFetchError } from "@/lib/error-handler"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from "@/components/ui/popover"
+import {
+    Command,
+    CommandEmpty,
+    CommandInput,
+    CommandItem,
+    CommandList,
+} from "@/components/ui/command"
+
+export default function NewCropGroupPage() {
+    const router = useRouter()
+
+    const [name, setName] = useState("")
+    const [description, setDescription] = useState("")
+    const [selectedCrops, setSelectedCrops] = useState<Array<{ id: string; name: string }>>([])
+    const [searchCrop, setSearchCrop] = useState("")
+    const [openCrops, setOpenCrops] = useState(false)
+
+    const [debouncedCropQuery] = useDebounce(searchCrop, 1000)
+
+    const hasShownError = useRef(false)
+
+    const { data: cropData, isError: cropError, error: cropFetchError, refetch: cropRefetch } = useQuery({
+        queryKey: ["farm-produce-search", { search: debouncedCropQuery }],
+        queryFn: () => queryFarmProduce({ search: debouncedCropQuery }),
+        enabled: debouncedCropQuery.length >= 2,
+        refetchOnWindowFocus: false
+    })
+
+    useEffect(() => {
+        if (cropError && !hasShownError.current) {
+            hasShownError.current = true
+            handleFetchError(cropFetchError, {
+                onRetry: () => {
+                    hasShownError.current = false
+                    cropRefetch()
+                },
+                context: "farm produce"
+            })
+        }
+        if (!cropError) {
+            hasShownError.current = false
+        }
+    }, [cropError, cropFetchError, cropRefetch])
+
+    const farmProduceList = cropData?.data?.data as FarmProduce[]
+
+    const handleToggleCrop = (crop: FarmProduce) => {
+        const exists = selectedCrops.find(c => c.id === crop.id)
+        if (exists) {
+            setSelectedCrops(selectedCrops.filter(c => c.id !== crop.id))
+        } else {
+            setSelectedCrops([...selectedCrops, { id: crop.id, name: crop.name }])
+        }
+    }
+
+    const { mutate, isPending } = useMutation({
+        mutationFn: addCropGroup,
+        onSuccess: () => {
+            toast({
+                description: "Crop group added successfully",
+            })
+            router.push("/dashboard/crop-groups")
+        },
+        onError: (error) => {
+            handleApiError(error, {
+                context: "crop group creation"
+            })
+        },
+    })
+
+    function onSubmit(e: React.FormEvent) {
+        e.preventDefault()
+
+        if (!name.trim()) {
+            toast({ description: "Name is required", variant: "destructive" })
+            return
+        }
+
+        if (selectedCrops.length === 0) {
+            toast({ description: "At least one crop is required", variant: "destructive" })
+            return
+        }
+
+        mutate({
+            name: name.trim(),
+            description: description.trim(),
+            farm_produce_ids: selectedCrops.map(c => c.id),
+        })
+    }
+
+    return (
+        <div className="space-y-10">
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+                        Add Crop Group
+                    </h1>
+                    <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                        Create a new crop group for batch dosage rate entry.
+                    </p>
+                </div>
+                <Link
+                    href="/dashboard/crop-groups"
+                    className={cn(buttonVariants({ variant: "ghost" }))}
+                >
+                    <Icons.close className="w-4 h-4 mr-2" />
+                    Close
+                </Link>
+            </div>
+
+            <form onSubmit={onSubmit}>
+                <div className="space-y-12">
+                    <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
+                        <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                            Group Information
+                        </h2>
+                        <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                            Crop groups let you apply the same dosage rate to multiple crops at once (e.g., Cucurbits, Brassicas).
+                        </p>
+
+                        <div className="mt-10 space-y-8">
+                            <div className="px-1">
+                                <label
+                                    htmlFor="name"
+                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                >
+                                    Group Name
+                                </label>
+                                <div className="mt-2">
+                                    <Input
+                                        id="name"
+                                        placeholder="e.g., Cucurbits, Brassicas, Stone Fruits"
+                                        value={name}
+                                        onChange={(e) => setName(e.target.value)}
+                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                    />
+                                </div>
+                                <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                    Enter a name for this crop group.
+                                </p>
+                            </div>
+
+                            <div className="px-1">
+                                <label
+                                    htmlFor="description"
+                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                >
+                                    Description
+                                </label>
+                                <div className="mt-2">
+                                    <Textarea
+                                        id="description"
+                                        placeholder="Describe this crop group"
+                                        rows={3}
+                                        value={description}
+                                        onChange={(e) => setDescription(e.target.value)}
+                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                    />
+                                </div>
+                                <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                    Optional description (max 500 characters).
+                                </p>
+                            </div>
+
+                            <div className="px-1">
+                                <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                                    Crops in this Group
+                                </label>
+
+                                {selectedCrops.length > 0 && (
+                                    <div className="flex flex-wrap gap-2 mt-2 mb-3">
+                                        {selectedCrops.map(crop => (
+                                            <span
+                                                key={crop.id}
+                                                className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-sm bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-300 cursor-pointer hover:bg-blue-100 dark:hover:bg-blue-900/40"
+                                                onClick={() => setSelectedCrops(selectedCrops.filter(c => c.id !== crop.id))}
+                                            >
+                                                {crop.name}
+                                                <Icons.close className="w-3 h-3" />
+                                            </span>
+                                        ))}
+                                    </div>
+                                )}
+
+                                <Popover open={openCrops} onOpenChange={setOpenCrops}>
+                                    <PopoverTrigger asChild>
+                                        <Button
+                                            type="button"
+                                            variant="outline"
+                                            role="combobox"
+                                            aria-expanded={openCrops}
+                                            className="w-full justify-start text-left font-normal"
+                                        >
+                                            <Icons.search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+                                            Search and add crops...
+                                        </Button>
+                                    </PopoverTrigger>
+                                    <PopoverContent className="w-full p-0" align="start">
+                                        <Command shouldFilter={false}>
+                                            <CommandInput
+                                                placeholder="Type crop name (min 2 chars)..."
+                                                value={searchCrop}
+                                                onValueChange={setSearchCrop}
+                                            />
+                                            <CommandList>
+                                                <CommandEmpty>
+                                                    {debouncedCropQuery.length < 2
+                                                        ? "Type at least 2 characters to search"
+                                                        : "No crops found"
+                                                    }
+                                                </CommandEmpty>
+                                                {farmProduceList?.map((crop) => {
+                                                    const isSelected = selectedCrops.some(c => c.id === crop.id)
+                                                    return (
+                                                        <CommandItem
+                                                            key={crop.id}
+                                                            value={crop.id}
+                                                            onSelect={() => handleToggleCrop(crop)}
+                                                        >
+                                                            <span className={cn(
+                                                                "mr-2 flex h-4 w-4 items-center justify-center rounded-sm border",
+                                                                isSelected
+                                                                    ? "bg-primary border-primary text-primary-foreground"
+                                                                    : "border-gray-300 dark:border-gray-600"
+                                                            )}>
+                                                                {isSelected && <Icons.check className="w-3 h-3" />}
+                                                            </span>
+                                                            {crop.name}
+                                                        </CommandItem>
+                                                    )
+                                                })}
+                                            </CommandList>
+                                        </Command>
+                                    </PopoverContent>
+                                </Popover>
+                                <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                    Select the crops that belong to this group. At least one crop is required.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div className="mt-6 flex items-center justify-end gap-x-6">
+                    <button
+                        type="button"
+                        onClick={() => router.push("/dashboard/crop-groups")}
+                        className="text-sm/6 font-semibold text-gray-900 dark:text-white"
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        type="submit"
+                        disabled={isPending}
+                        className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
+                    >
+                        {isPending && <Icons.spinner className="w-4 h-4 mr-2 animate-spin" />}
+                        Save
+                    </button>
+                </div>
+            </form>
+        </div>
+    )
+}

--- a/apps/admin-fnp/app/(dashboard)/dashboard/crop-groups/page.tsx
+++ b/apps/admin-fnp/app/(dashboard)/dashboard/crop-groups/page.tsx
@@ -1,0 +1,15 @@
+import { DashboardHeader } from "@/components/state/dashboardHeader"
+import { DashboardShell } from "@/components/state/dashboardShell"
+import { CropGroupsTable } from "@/components/structures/tables/cropGroups"
+
+export default async function CropGroupsPage() {
+  return (
+    <DashboardShell>
+      <DashboardHeader
+        heading="Crop Groups"
+        text="Manage crop groups (e.g., Cucurbits, Brassicas, Stone Fruits) for batch dosage rate entry."
+      ></DashboardHeader>
+      <CropGroupsTable />
+    </DashboardShell>
+  )
+}

--- a/apps/admin-fnp/components/icons/lucide.ts
+++ b/apps/admin-fnp/components/icons/lucide.ts
@@ -50,7 +50,8 @@ import {
   Tag,
   ClipboardList,
   Beaker,
-  Bug
+  Bug,
+  Layers
 } from "lucide-react"
 
 export type Icon = LucideIcon
@@ -108,5 +109,6 @@ export const Icons = {
   tag: Tag,
   clipboardList: ClipboardList,
   beaker: Beaker,
-  bug: Bug
+  bug: Bug,
+  layers: Layers
 }

--- a/apps/admin-fnp/components/structures/columns/cropGroups.tsx
+++ b/apps/admin-fnp/components/structures/columns/cropGroups.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { ColumnDef } from "@tanstack/react-table"
+import { CropGroup } from "@/lib/schemas"
+import { Checkbox } from "@/components/ui/checkbox"
+import { formatDate } from "@/lib/utilities"
+import { CropGroupControlDropDown } from "@/components/structures/dropdowns/cropGroup-dropdown"
+
+export const cropGroupColumns: ColumnDef<CropGroup>[] = [
+  {
+    id: "select",
+    header: ({ table }) => (
+      <Checkbox
+        checked={table.getIsAllPageRowsSelected()}
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Select all"
+        className="translate-y-[2px]"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label="Select row"
+        className="translate-y-[2px]"
+      />
+    ),
+    enableSorting: false,
+    enableHiding: false,
+  },
+  {
+    accessorKey: "name",
+    header: "Name",
+  },
+  {
+    accessorKey: "description",
+    header: "Description",
+    cell: ({ row }) => {
+      const description = row.original.description
+      return (
+        <span className="max-w-md truncate">
+          {description || "-"}
+        </span>
+      )
+    },
+  },
+  {
+    id: "crops",
+    header: "Crops",
+    cell: ({ row }) => {
+      const count = row.original.farm_produce_ids?.length || 0
+      return <span>{count} {count === 1 ? "crop" : "crops"}</span>
+    },
+  },
+  {
+    accessorKey: "created",
+    header: "Date Created",
+    cell: ({ row }) => {
+      const created = row.original.created
+      return <span>{formatDate(created)}</span>
+    },
+  },
+  {
+    id: "actions",
+    cell: ({ row }) => {
+      const cropGroup = row?.original
+      return <CropGroupControlDropDown cropGroup={cropGroup} />
+    },
+  },
+]

--- a/apps/admin-fnp/components/structures/dropdowns/cropGroup-dropdown.tsx
+++ b/apps/admin-fnp/components/structures/dropdowns/cropGroup-dropdown.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import Link from "next/link"
+import { MoreHorizontal } from "lucide-react"
+
+import { CropGroup } from "@/lib/schemas"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+interface CropGroupControlDropDownProps {
+  cropGroup?: CropGroup
+}
+
+export function CropGroupControlDropDown({
+  cropGroup,
+}: CropGroupControlDropDownProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className="w-8 h-8 p-0">
+          <span className="sr-only">Open menu</span>
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Actions</DropdownMenuLabel>
+        <DropdownMenuItem>
+          <Link
+            className="w-full"
+            href={`/dashboard/crop-groups/${cropGroup?.id}/edit`}
+          >
+            Edit
+          </Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/admin-fnp/components/structures/forms/dosageRatesSelect.tsx
+++ b/apps/admin-fnp/components/structures/forms/dosageRatesSelect.tsx
@@ -9,8 +9,8 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { cn } from "@/lib/utilities"
-import { queryFarmProduce, queryAgroChemicalTargets } from "@/lib/query"
-import { FarmProduce, AgroChemicalTarget } from "@/lib/schemas"
+import { queryFarmProduce, queryAgroChemicalTargets, queryCropGroups, queryCropGroup } from "@/lib/query"
+import { FarmProduce, AgroChemicalTarget, CropGroup } from "@/lib/schemas"
 import { handleFetchError } from "@/lib/error-handler"
 import {
     Command,
@@ -36,6 +36,8 @@ export interface DosageRate {
     id: string
     crop: string
     crop_id: string
+    crop_group?: string
+    crop_group_id?: string
     targets: string
     target_ids: string[]
     entries: Array<{
@@ -88,6 +90,14 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
     const [remarkInput, setRemarkInput] = useState("")
     const [remarksList, setRemarksList] = useState<string[]>([])
 
+    // Crop group state
+    const [isGroupMode, setIsGroupMode] = useState(false)
+    const [cropGroupId, setCropGroupId] = useState("")
+    const [cropGroupName, setCropGroupName] = useState("")
+    const [groupCrops, setGroupCrops] = useState<Array<{ id: string; name: string }>>([])
+    const [openCropGroup, setOpenCropGroup] = useState(false)
+    const [searchCropGroup, setSearchCropGroup] = useState("")
+
     const [openCrop, setOpenCrop] = useState(false)
     const [openTargets, setOpenTargets] = useState(false)
     const [searchCrop, setSearchCrop] = useState("")
@@ -96,6 +106,31 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
     // Debounce search queries
     const [debouncedCropQuery] = useDebounce(searchCrop, 1000)
     const [debouncedTargetQuery] = useDebounce(searchTarget, 1000)
+    const [debouncedCropGroupQuery] = useDebounce(searchCropGroup, 1000)
+
+    // Fetch crop groups
+    const { data: cropGroupData } = useQuery({
+        queryKey: ["crop-groups-search", { search: debouncedCropGroupQuery }],
+        queryFn: () => queryCropGroups({ search: debouncedCropGroupQuery }),
+        enabled: debouncedCropGroupQuery.length >= 2,
+    })
+    const cropGroups = cropGroupData?.data?.data as CropGroup[]
+
+    // Fetch selected crop group detail
+    const { data: selectedGroupData } = useQuery({
+        queryKey: ["crop-group-detail", cropGroupId],
+        queryFn: () => queryCropGroup(cropGroupId),
+        enabled: !!cropGroupId,
+    })
+
+    useEffect(() => {
+        if (selectedGroupData?.data?.farm_produce_items) {
+            setGroupCrops(selectedGroupData.data.farm_produce_items.map((p: FarmProduce) => ({
+                id: p.id,
+                name: p.name,
+            })))
+        }
+    }, [selectedGroupData])
 
     // Fetch farm produce
     const {
@@ -164,29 +199,52 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
     }, [isTargetError, targetError, refetchTargets])
 
     const handleAdd = () => {
-        if (!cropId || !cropName || targetIds.length === 0 || entriesList.length === 0) {
-            return
-        }
+        if (isGroupMode) {
+            // Group mode: create one DosageRate per crop in the group
+            if (!cropGroupId || groupCrops.length === 0 || targetIds.length === 0 || entriesList.length === 0) {
+                return
+            }
 
-        const rateData: DosageRate = {
-            id: editingId || Date.now().toString(),
-            crop: cropName,
-            crop_id: cropId,
-            targets: targetNames.join(", "),
-            target_ids: targetIds,
-            entries: entriesList,
-        }
+            const newRates: DosageRate[] = groupCrops.map((crop, index) => ({
+                id: editingId ? `${cropGroupId}-${index}` : `${Date.now()}-${index}`,
+                crop: crop.name,
+                crop_id: crop.id,
+                crop_group: cropGroupName,
+                crop_group_id: cropGroupId,
+                targets: targetNames.join(", "),
+                target_ids: targetIds,
+                entries: entriesList,
+            }))
 
-        console.log("Saving dosage rate:", rateData)
-        console.log("Target IDs:", targetIds)
-        console.log("Target Names:", targetNames)
-
-        if (editingId) {
-            // Update existing rate
-            onChange(value.map(rate => rate.id === editingId ? rateData : rate))
+            if (editingId) {
+                // Remove all rates with this crop_group_id, then add new ones
+                const filtered = value.filter(r => r.crop_group_id !== cropGroupId)
+                onChange([...filtered, ...newRates])
+            } else {
+                onChange([...value, ...newRates])
+            }
         } else {
-            // Add new rate
-            onChange([...value, rateData])
+            // Individual mode: existing single-crop logic
+            if (!cropId || !cropName || targetIds.length === 0 || entriesList.length === 0) {
+                return
+            }
+
+            const rateData: DosageRate = {
+                id: editingId || Date.now().toString(),
+                crop: cropName,
+                crop_id: cropId,
+                crop_group: "",
+                crop_group_id: "",
+                targets: targetNames.join(", "),
+                target_ids: targetIds,
+                entries: entriesList,
+            }
+
+            if (editingId) {
+                onChange(value.map(rate => rate.id === editingId ? rateData : rate))
+            } else {
+                onChange([...value, rateData])
+            }
         }
 
         // Reset form
@@ -196,6 +254,10 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
     const resetForm = () => {
         setCropId("")
         setCropName("")
+        setCropGroupId("")
+        setCropGroupName("")
+        setGroupCrops([])
+        setIsGroupMode(false)
         setTargetIds([])
         setTargetNames([])
         setEntriesList([])
@@ -213,14 +275,25 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
     }
 
     const handleEdit = (rate: DosageRate) => {
-        console.log("Editing rate:", rate)
+        if (rate.crop_group_id) {
+            // Group mode: find all rates with same crop_group_id
+            const groupRates = value.filter(r => r.crop_group_id === rate.crop_group_id)
+            setIsGroupMode(true)
+            setCropGroupId(rate.crop_group_id)
+            setCropGroupName(rate.crop_group || "")
+            setGroupCrops(groupRates.map(r => ({ id: r.crop_id, name: r.crop })))
+            setCropId("")
+            setCropName("")
+        } else {
+            setIsGroupMode(false)
+            setCropId(rate.crop_id)
+            setCropName(rate.crop)
+        }
 
-        setCropId(rate.crop_id)
-        setCropName(rate.crop)
         setTargetIds(rate.target_ids)
         setTargetNames(rate.targets ? rate.targets.split(", ") : [])
 
-        // Load entries
+        // Load entries (from first rate — all rates in a group share the same entries)
         const entriesArray = Array.isArray(rate.entries) ? rate.entries : []
         setEntriesList(entriesArray)
 
@@ -242,6 +315,8 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
             id: Date.now().toString(),
             crop: rate.crop,
             crop_id: rate.crop_id,
+            crop_group: rate.crop_group,
+            crop_group_id: rate.crop_group_id,
             targets: rate.targets || "",
             target_ids: [...rate.target_ids],
             entries: rate.entries.map(entry => ({
@@ -398,128 +473,197 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
             {/* Display existing rates - hide when editing */}
             {value.length > 0 && !showForm && (
                 <div className="space-y-3">
-                    {value.map((rate) => (
-                        <div
-                            key={rate.id}
-                            className="flex items-start justify-between rounded-md border border-gray-300 bg-gray-50 p-3 dark:border-white/10 dark:bg-gray-900"
-                        >
-                            <div className="flex-1 space-y-2">
-                                <div className="flex items-start justify-between">
-                                    <div>
-                                        <div className="font-medium text-gray-900 dark:text-white text-base">
-                                            {rate.crop}
-                                        </div>
-                                        {rate.targets && (
-                                            <div className="text-sm text-gray-600 dark:text-gray-400 mt-1">
-                                                <span className="font-medium">Targets:</span> {rate.targets}
-                                            </div>
-                                        )}
-                                        {(!rate.targets && rate.target_ids?.length > 0) && (
-                                            <div className="text-sm text-gray-600 dark:text-gray-400 mt-1">
-                                                <span className="font-medium">Targets:</span> {rate.target_ids.length} selected
-                                            </div>
-                                        )}
-                                    </div>
-                                </div>
+                    {(() => {
+                        const grouped = new Map<string, DosageRate[]>()
+                        const ungrouped: DosageRate[] = []
 
-                                {rate.entries && rate.entries.length > 0 && (
-                                    <div className="mt-3 space-y-3">
-                                        <div className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
-                                            Dosage Entries ({rate.entries.length})
-                                        </div>
-                                        {rate.entries.map((entry, i) => (
-                                            <div
-                                                key={i}
-                                                className="pl-4 border-l-4 border-indigo-400 dark:border-indigo-600 bg-white dark:bg-gray-800 p-3 rounded-r space-y-2"
-                                            >
-                                                <div className="grid grid-cols-2 gap-2">
-                                                    <div>
-                                                        <div className="text-xs text-gray-500 dark:text-gray-400 font-medium">Dosage</div>
-                                                        <div className="text-sm text-gray-900 dark:text-white font-semibold">
-                                                            {entry.dosage.value} {entry.dosage.unit}/{entry.dosage.per}
-                                                        </div>
-                                                    </div>
-                                                    <div>
-                                                        <div className="text-xs text-gray-500 dark:text-gray-400 font-medium">Max Applications</div>
-                                                        <div className="text-sm text-gray-900 dark:text-white">
-                                                            {entry.max_applications.max} times
-                                                        </div>
+                        value.forEach(rate => {
+                            if (rate.crop_group_id) {
+                                const existing = grouped.get(rate.crop_group_id) || []
+                                existing.push(rate)
+                                grouped.set(rate.crop_group_id, existing)
+                            } else {
+                                ungrouped.push(rate)
+                            }
+                        })
+
+                        const renderEntries = (entries: DosageRate["entries"]) => (
+                            entries.length > 0 && (
+                                <div className="mt-3 space-y-3">
+                                    <div className="text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                                        Dosage Entries ({entries.length})
+                                    </div>
+                                    {entries.map((entry, i) => (
+                                        <div
+                                            key={i}
+                                            className="pl-4 border-l-4 border-indigo-400 dark:border-indigo-600 bg-white dark:bg-gray-800 p-3 rounded-r space-y-2"
+                                        >
+                                            <div className="grid grid-cols-2 gap-2">
+                                                <div>
+                                                    <div className="text-xs text-gray-500 dark:text-gray-400 font-medium">Dosage</div>
+                                                    <div className="text-sm text-gray-900 dark:text-white font-semibold">
+                                                        {entry.dosage.value} {entry.dosage.unit}/{entry.dosage.per}
                                                     </div>
                                                 </div>
-
-                                                <div className="grid grid-cols-2 gap-2">
+                                                <div>
+                                                    <div className="text-xs text-gray-500 dark:text-gray-400 font-medium">Max Applications</div>
+                                                    <div className="text-sm text-gray-900 dark:text-white">
+                                                        {entry.max_applications.max} times
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div className="grid grid-cols-2 gap-2">
+                                                <div>
+                                                    <div className="text-xs text-gray-500 dark:text-gray-400 font-medium">Application Interval</div>
+                                                    <div className="text-sm text-gray-900 dark:text-white">
+                                                        {entry.application_interval}
+                                                    </div>
+                                                </div>
+                                                {entry.phi && (
                                                     <div>
-                                                        <div className="text-xs text-gray-500 dark:text-gray-400 font-medium">Application Interval</div>
+                                                        <div className="text-xs text-gray-500 dark:text-gray-400 font-medium">PHI (Pre-Harvest Interval)</div>
                                                         <div className="text-sm text-gray-900 dark:text-white">
-                                                            {entry.application_interval}
+                                                            {entry.phi}
                                                         </div>
                                                     </div>
-                                                    {entry.phi && (
-                                                        <div>
-                                                            <div className="text-xs text-gray-500 dark:text-gray-400 font-medium">PHI (Pre-Harvest Interval)</div>
-                                                            <div className="text-sm text-gray-900 dark:text-white">
-                                                                {entry.phi}
-                                                            </div>
+                                                )}
+                                            </div>
+                                            {entry.max_applications.note && (
+                                                <div className="pt-2 border-t border-gray-200 dark:border-gray-700">
+                                                    <div className="text-xs text-gray-500 dark:text-gray-400 font-medium mb-1">Note</div>
+                                                    <div className="text-sm text-gray-700 dark:text-gray-300 italic">
+                                                        {entry.max_applications.note}
+                                                    </div>
+                                                </div>
+                                            )}
+                                            {entry.remarks.length > 0 && (
+                                                <div className="pt-2 border-t border-gray-200 dark:border-gray-700">
+                                                    <div className="text-xs text-gray-500 dark:text-gray-400 font-medium mb-1">Remarks</div>
+                                                    <ul className="text-sm text-gray-700 dark:text-gray-300 list-disc list-inside space-y-1">
+                                                        {entry.remarks.map((remark, idx) => (
+                                                            <li key={idx}>{remark}</li>
+                                                        ))}
+                                                    </ul>
+                                                </div>
+                                            )}
+                                        </div>
+                                    ))}
+                                </div>
+                            )
+                        )
+
+                        return (
+                            <>
+                                {/* Grouped rates */}
+                                {Array.from(grouped.entries()).map(([groupId, rates]) => (
+                                    <div
+                                        key={groupId}
+                                        className="rounded-md border border-blue-300 bg-blue-50/30 p-3 dark:border-blue-800 dark:bg-blue-950/20"
+                                    >
+                                        <div className="flex items-start justify-between">
+                                            <div className="flex-1 space-y-2">
+                                                <div>
+                                                    <div className="font-medium text-blue-900 dark:text-blue-100 text-base">
+                                                        {rates[0].crop_group} <span className="text-xs font-normal text-blue-600 dark:text-blue-400">(Group)</span>
+                                                    </div>
+                                                    <div className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                                                        <span className="font-medium">Crops:</span> {rates.map(r => r.crop).join(", ")}
+                                                    </div>
+                                                    {rates[0].targets && (
+                                                        <div className="text-sm text-gray-600 dark:text-gray-400">
+                                                            <span className="font-medium">Targets:</span> {rates[0].targets}
                                                         </div>
                                                     )}
                                                 </div>
-
-                                                {entry.max_applications.note && (
-                                                    <div className="pt-2 border-t border-gray-200 dark:border-gray-700">
-                                                        <div className="text-xs text-gray-500 dark:text-gray-400 font-medium mb-1">Note</div>
-                                                        <div className="text-sm text-gray-700 dark:text-gray-300 italic">
-                                                            {entry.max_applications.note}
-                                                        </div>
-                                                    </div>
-                                                )}
-
-                                                {entry.remarks.length > 0 && (
-                                                    <div className="pt-2 border-t border-gray-200 dark:border-gray-700">
-                                                        <div className="text-xs text-gray-500 dark:text-gray-400 font-medium mb-1">Remarks</div>
-                                                        <ul className="text-sm text-gray-700 dark:text-gray-300 list-disc list-inside space-y-1">
-                                                            {entry.remarks.map((remark, idx) => (
-                                                                <li key={idx}>{remark}</li>
-                                                            ))}
-                                                        </ul>
-                                                    </div>
-                                                )}
+                                                {rates[0].entries && renderEntries(rates[0].entries)}
                                             </div>
-                                        ))}
+                                            <div className="flex gap-1">
+                                                <Button
+                                                    type="button"
+                                                    variant="ghost"
+                                                    size="sm"
+                                                    onClick={() => handleEdit(rates[0])}
+                                                    title="Edit group dosage rate"
+                                                >
+                                                    <Pencil className="h-4 w-4" />
+                                                </Button>
+                                                <Button
+                                                    type="button"
+                                                    variant="ghost"
+                                                    size="sm"
+                                                    onClick={() => {
+                                                        onChange(value.filter(r => r.crop_group_id !== groupId))
+                                                    }}
+                                                    title="Remove group dosage rate"
+                                                >
+                                                    <X className="h-4 w-4" />
+                                                </Button>
+                                            </div>
+                                        </div>
                                     </div>
-                                )}
-                            </div>
-                            <div className="flex gap-1">
-                                <Button
-                                    type="button"
-                                    variant="ghost"
-                                    size="sm"
-                                    onClick={() => handleDuplicate(rate)}
-                                    className="ml-2"
-                                    title="Duplicate dosage rate"
-                                >
-                                    <Copy className="h-4 w-4" />
-                                </Button>
-                                <Button
-                                    type="button"
-                                    variant="ghost"
-                                    size="sm"
-                                    onClick={() => handleEdit(rate)}
-                                    title="Edit dosage rate"
-                                >
-                                    <Pencil className="h-4 w-4" />
-                                </Button>
-                                <Button
-                                    type="button"
-                                    variant="ghost"
-                                    size="sm"
-                                    onClick={() => handleRemove(rate.id)}
-                                    title="Remove dosage rate"
-                                >
-                                    <X className="h-4 w-4" />
-                                </Button>
-                            </div>
-                        </div>
-                    ))}
+                                ))}
+
+                                {/* Ungrouped rates */}
+                                {ungrouped.map((rate) => (
+                                    <div
+                                        key={rate.id}
+                                        className="flex items-start justify-between rounded-md border border-gray-300 bg-gray-50 p-3 dark:border-white/10 dark:bg-gray-900"
+                                    >
+                                        <div className="flex-1 space-y-2">
+                                            <div className="flex items-start justify-between">
+                                                <div>
+                                                    <div className="font-medium text-gray-900 dark:text-white text-base">
+                                                        {rate.crop}
+                                                    </div>
+                                                    {rate.targets && (
+                                                        <div className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                                                            <span className="font-medium">Targets:</span> {rate.targets}
+                                                        </div>
+                                                    )}
+                                                    {(!rate.targets && rate.target_ids?.length > 0) && (
+                                                        <div className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                                                            <span className="font-medium">Targets:</span> {rate.target_ids.length} selected
+                                                        </div>
+                                                    )}
+                                                </div>
+                                            </div>
+                                            {rate.entries && renderEntries(rate.entries)}
+                                        </div>
+                                        <div className="flex gap-1">
+                                            <Button
+                                                type="button"
+                                                variant="ghost"
+                                                size="sm"
+                                                onClick={() => handleDuplicate(rate)}
+                                                className="ml-2"
+                                                title="Duplicate dosage rate"
+                                            >
+                                                <Copy className="h-4 w-4" />
+                                            </Button>
+                                            <Button
+                                                type="button"
+                                                variant="ghost"
+                                                size="sm"
+                                                onClick={() => handleEdit(rate)}
+                                                title="Edit dosage rate"
+                                            >
+                                                <Pencil className="h-4 w-4" />
+                                            </Button>
+                                            <Button
+                                                type="button"
+                                                variant="ghost"
+                                                size="sm"
+                                                onClick={() => handleRemove(rate.id)}
+                                                title="Remove dosage rate"
+                                            >
+                                                <X className="h-4 w-4" />
+                                            </Button>
+                                        </div>
+                                    </div>
+                                ))}
+                            </>
+                        )
+                    })()}
                 </div>
             )}
 
@@ -553,60 +697,152 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
                     </Button>
                 </div>
             <div className="grid gap-4 px-1">
+                {/* Mode toggle */}
+                <div>
+                    <Label>Crop Selection Mode</Label>
+                    <div className="flex gap-2 mt-2">
+                        <Button
+                            type="button"
+                            variant={!isGroupMode ? "default" : "outline"}
+                            size="sm"
+                            onClick={() => {
+                                setIsGroupMode(false)
+                                setCropGroupId("")
+                                setCropGroupName("")
+                                setGroupCrops([])
+                            }}
+                        >
+                            Individual Crop
+                        </Button>
+                        <Button
+                            type="button"
+                            variant={isGroupMode ? "default" : "outline"}
+                            size="sm"
+                            onClick={() => {
+                                setIsGroupMode(true)
+                                setCropId("")
+                                setCropName("")
+                            }}
+                        >
+                            Crop Group
+                        </Button>
+                    </div>
+                </div>
+
                 <div className="grid grid-cols-2 gap-4">
                     <div>
-                        <Label>Crop</Label>
-                        <Popover open={openCrop} onOpenChange={setOpenCrop}>
-                            <PopoverTrigger asChild>
-                                <Button
-                                    variant="outline"
-                                    role="combobox"
-                                    className={cn(
-                                        "w-full justify-between mt-2",
-                                        !cropId && "text-muted-foreground"
-                                    )}
-                                >
-                                    <span className="truncate">
-                                        {cropId ? cropName : "Select crop"}
-                                    </span>
-                                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                                </Button>
-                            </PopoverTrigger>
-                            <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
-                                <Command>
-                                    <CommandInput
-                                        placeholder="Search crop..."
-                                        onValueChange={(value) => setSearchCrop(value)}
-                                    />
-                                    <CommandList>
-                                        <CommandEmpty>
-                                            {searchCrop.length < 2
-                                                ? "Type at least 2 characters to search"
-                                                : "No crop found."}
-                                        </CommandEmpty>
-                                        {crops?.map((crop) => (
-                                            <CommandItem
-                                                value={crop.name}
-                                                key={crop.id}
-                                                onSelect={() => {
-                                                    setCropId(crop.id)
-                                                    setCropName(crop.name)
-                                                    setOpenCrop(false)
-                                                }}
-                                            >
-                                                <Check
-                                                    className={cn(
-                                                        "mr-2 h-4 w-4",
-                                                        crop.id === cropId ? "opacity-100" : "opacity-0"
-                                                    )}
-                                                />
-                                                {crop.name}
-                                            </CommandItem>
-                                        ))}
-                                    </CommandList>
-                                </Command>
-                            </PopoverContent>
-                        </Popover>
+                        {!isGroupMode ? (
+                            <>
+                                <Label>Crop</Label>
+                                <Popover open={openCrop} onOpenChange={setOpenCrop}>
+                                    <PopoverTrigger asChild>
+                                        <Button
+                                            variant="outline"
+                                            role="combobox"
+                                            className={cn(
+                                                "w-full justify-between mt-2",
+                                                !cropId && "text-muted-foreground"
+                                            )}
+                                        >
+                                            <span className="truncate">
+                                                {cropId ? cropName : "Select crop"}
+                                            </span>
+                                            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                                        </Button>
+                                    </PopoverTrigger>
+                                    <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
+                                        <Command>
+                                            <CommandInput
+                                                placeholder="Search crop..."
+                                                onValueChange={(value) => setSearchCrop(value)}
+                                            />
+                                            <CommandList>
+                                                <CommandEmpty>
+                                                    {searchCrop.length < 2
+                                                        ? "Type at least 2 characters to search"
+                                                        : "No crop found."}
+                                                </CommandEmpty>
+                                                {crops?.map((crop) => (
+                                                    <CommandItem
+                                                        value={crop.name}
+                                                        key={crop.id}
+                                                        onSelect={() => {
+                                                            setCropId(crop.id)
+                                                            setCropName(crop.name)
+                                                            setOpenCrop(false)
+                                                        }}
+                                                    >
+                                                        <Check
+                                                            className={cn(
+                                                                "mr-2 h-4 w-4",
+                                                                crop.id === cropId ? "opacity-100" : "opacity-0"
+                                                            )}
+                                                        />
+                                                        {crop.name}
+                                                    </CommandItem>
+                                                ))}
+                                            </CommandList>
+                                        </Command>
+                                    </PopoverContent>
+                                </Popover>
+                            </>
+                        ) : (
+                            <>
+                                <Label>Crop Group</Label>
+                                <Popover open={openCropGroup} onOpenChange={setOpenCropGroup}>
+                                    <PopoverTrigger asChild>
+                                        <Button
+                                            variant="outline"
+                                            role="combobox"
+                                            className={cn(
+                                                "w-full justify-between mt-2",
+                                                !cropGroupId && "text-muted-foreground"
+                                            )}
+                                        >
+                                            <span className="truncate">
+                                                {cropGroupId ? cropGroupName : "Select crop group"}
+                                            </span>
+                                            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                                        </Button>
+                                    </PopoverTrigger>
+                                    <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
+                                        <Command shouldFilter={false}>
+                                            <CommandInput
+                                                placeholder="Search crop group..."
+                                                value={searchCropGroup}
+                                                onValueChange={setSearchCropGroup}
+                                            />
+                                            <CommandList>
+                                                <CommandEmpty>
+                                                    {searchCropGroup.length < 2
+                                                        ? "Type at least 2 characters to search"
+                                                        : "No crop group found."}
+                                                </CommandEmpty>
+                                                {cropGroups?.map((group) => (
+                                                    <CommandItem
+                                                        value={group.id}
+                                                        key={group.id}
+                                                        onSelect={() => {
+                                                            setCropGroupId(group.id)
+                                                            setCropGroupName(group.name)
+                                                            setOpenCropGroup(false)
+                                                        }}
+                                                    >
+                                                        <Check
+                                                            className={cn(
+                                                                "mr-2 h-4 w-4",
+                                                                group.id === cropGroupId ? "opacity-100" : "opacity-0"
+                                                            )}
+                                                        />
+                                                        {group.name}
+                                                    </CommandItem>
+                                                ))}
+                                            </CommandList>
+                                        </Command>
+                                    </PopoverContent>
+                                </Popover>
+                            </>
+                        )}
                     </div>
                     <div>
                         <Label>Targets (Pests/Diseases)</Label>
@@ -698,6 +934,23 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
                         </Popover>
                     </div>
                 </div>
+
+                {/* Display group crops when a crop group is selected */}
+                {isGroupMode && cropGroupId && groupCrops.length > 0 && (
+                    <div>
+                        <Label>Crops in Group ({groupCrops.length})</Label>
+                        <div className="flex flex-wrap gap-2 mt-2">
+                            {groupCrops.map(crop => (
+                                <span
+                                    key={crop.id}
+                                    className="inline-flex items-center px-2.5 py-1 rounded-md text-sm bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-300"
+                                >
+                                    {crop.name}
+                                </span>
+                            ))}
+                        </div>
+                    </div>
+                )}
 
                 {/* Display added entries - hide when editing an entry */}
                 {entriesList.length > 0 && editingEntryIndex === null && (
@@ -816,7 +1069,7 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
                                 />
                             </div>
                             <div>
-                                <Label className="text-sm">Interval</Label>
+                                <Label className="text-sm">Application Interval</Label>
                                 <Input
                                     placeholder="e.g., 7 - 14 days"
                                     value={interval}
@@ -937,7 +1190,11 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
                         <Button
                             type="button"
                             onClick={handleAdd}
-                            disabled={!cropId || targetIds.length === 0 || entriesList.length === 0}
+                            disabled={
+                                isGroupMode
+                                    ? (!cropGroupId || groupCrops.length === 0 || targetIds.length === 0 || entriesList.length === 0)
+                                    : (!cropId || targetIds.length === 0 || entriesList.length === 0)
+                            }
                             variant="outline"
                             className={editingId ? "flex-1" : "w-full"}
                         >

--- a/apps/admin-fnp/components/structures/tables/cropGroups.tsx
+++ b/apps/admin-fnp/components/structures/tables/cropGroups.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import { useState, useEffect, useRef } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { PaginationState } from "@tanstack/react-table"
+
+import { queryCropGroups } from "@/lib/query"
+import { CropGroup } from "@/lib/schemas"
+import { handleFetchError } from "@/lib/error-handler"
+import { Placeholder } from "@/components/state/placeholder"
+import { DataTable } from "@/components/structures/data-table"
+import { cropGroupColumns } from "@/components/structures/columns/cropGroups"
+
+export function CropGroupsTable() {
+  const [search, setSearch] = useState("")
+
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 1,
+    pageSize: 20,
+  })
+
+  const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
+    queryKey: ["dashboard-crop-groups", { p: pagination.pageIndex, search }],
+    queryFn: () =>
+      queryCropGroups({
+        p: pagination.pageIndex,
+        search: search,
+      }),
+    refetchOnWindowFocus: false
+  })
+
+  const groups = data?.data?.data as CropGroup[]
+  const total = data?.data?.total as number
+
+  // Show error toast only once when error occurs
+  const hasShownError = useRef(false)
+  useEffect(() => {
+    if (isError && !hasShownError.current) {
+      hasShownError.current = true
+      handleFetchError(error, {
+        onRetry: () => {
+          hasShownError.current = false
+          refetch()
+        },
+        context: "crop groups"
+      })
+    }
+    if (!isError) {
+      hasShownError.current = false
+    }
+  }, [isError, error, refetch])
+
+  if (isError) {
+    return (
+      <Placeholder>
+        <Placeholder.Icon name="close" />
+        <Placeholder.Title>Error Fetching Crop Groups</Placeholder.Title>
+        <Placeholder.Description>
+          Error fetching crop groups from the database
+        </Placeholder.Description>
+      </Placeholder>
+    )
+  }
+
+  if (isLoading || isFetching) {
+    return (
+      <Placeholder>
+        <Placeholder.Title>Fetching Crop Groups</Placeholder.Title>
+      </Placeholder>
+    )
+  }
+
+  return (
+    <DataTable
+      columns={cropGroupColumns}
+      data={groups}
+      newUrl="/dashboard/crop-groups/new"
+      tableName="Crop Group"
+      total={total}
+      pagination={pagination}
+      setPagination={setPagination}
+      search={search}
+      setSearch={setSearch}
+    />
+  )
+}

--- a/apps/admin-fnp/config/dashboard.ts
+++ b/apps/admin-fnp/config/dashboard.ts
@@ -34,6 +34,11 @@ export const dashboardConfig: DashboardConfig = {
       icon: "bug",
     },
     {
+      title: "Crop Groups",
+      href: "/dashboard/crop-groups",
+      icon: "layers",
+    },
+    {
       title: "Brands",
       href: "/dashboard/brands",
       icon: "tag",

--- a/apps/admin-fnp/lib/query.ts
+++ b/apps/admin-fnp/lib/query.ts
@@ -328,6 +328,43 @@ export function deleteAgroChemicalTargets(targetIds: string[]) {
   return api.post(url, { target_ids: targetIds })
 }
 
+// Crop Group functions
+export function queryCropGroups(pagination?: pagination) {
+  let url: string
+
+  if (pagination?.p !== undefined && pagination.p >= 2) {
+    url = `${baseUrl}/user/crop-groups?p=${pagination.p}`
+  } else {
+    url = `${baseUrl}/user/crop-groups`
+  }
+
+  if (pagination?.search !== undefined && pagination.search.length >= 2) {
+    url = `${baseUrl}/user/crop-groups?search=${pagination.search}`
+  }
+
+  return api.get(url)
+}
+
+export function queryCropGroup(id: string) {
+  const url = `${baseUrl}/user/crop-groups/${id}`
+  return api.get(url)
+}
+
+export function addCropGroup(data: { name: string; description: string; farm_produce_ids: string[] }) {
+  let url = `${baseUrl}/user/crop-groups/add`
+  return api.post(url, data)
+}
+
+export function updateCropGroup(data: { id: string; name: string; description: string; farm_produce_ids: string[] }) {
+  let url = `${baseUrl}/user/crop-groups/update`
+  return api.post(url, data)
+}
+
+export function deleteCropGroups(groupIds: string[]) {
+  let url = `${baseUrl}/user/crop-groups/delete`
+  return api.post(url, { group_ids: groupIds })
+}
+
 export function queryFarmProduceCategories(pagination?: pagination) {
   let url: string
 

--- a/apps/admin-fnp/lib/schemas.ts
+++ b/apps/admin-fnp/lib/schemas.ts
@@ -381,6 +381,28 @@ export const FormAgroChemicalTargetSchema = AgroChemicalTargetSchema.pick({
   remark: true,
 })
 
+export const CropGroupSchema = z.object({
+  id: z.string(),
+  name: z.string().min(1, "Name is required"),
+  slug: z.string().optional(),
+  description: z.string().max(500, "Description cannot exceed 500 characters"),
+  farm_produce_ids: z.array(z.string()).min(1, "At least one crop is required"),
+  farm_produce_items: z.array(z.object({
+    id: z.string(),
+    name: z.string(),
+    slug: z.string(),
+  })).optional(),
+  created: z.string().optional(),
+  updated: z.string().optional(),
+})
+
+export const FormCropGroupSchema = CropGroupSchema.pick({
+  id: true,
+  name: true,
+  description: true,
+  farm_produce_ids: true,
+})
+
 export const AgroChemicalDosageRateSchema = z.object({
   id: z.string(),
   agrochemical_id: z.string().min(1, "AgroChemical is required"),
@@ -438,6 +460,8 @@ export const AgroChemicalSchema = z.object({
     id: z.string(),
     crop: z.string(),
     crop_id: z.string(),
+    crop_group: z.string().optional(),
+    crop_group_id: z.string().optional(),
     targets: z.string(),
     target_ids: z.array(z.string()),
     entries: z.array(z.object({
@@ -470,6 +494,8 @@ export const DosageRateSchema = z.object({
   id: z.string(),
   crop: z.string(),
   crop_id: z.string(),
+  crop_group: z.string().optional(),
+  crop_group_id: z.string().optional(),
   targets: z.string(),
   target_ids: z.array(z.string()),
   entries: z.array(z.object({
@@ -544,6 +570,8 @@ export type AgroChemicalTarget = z.infer<typeof AgroChemicalTargetSchema>
 export type FormAgroChemicalTargetModel = z.infer<typeof FormAgroChemicalTargetSchema>
 export type AgroChemicalItem = z.infer<typeof AgroChemicalSchema>
 export type FormAgroChemicalModel = z.infer<typeof FormAgroChemicalSchema>
+export type CropGroup = z.infer<typeof CropGroupSchema>
+export type FormCropGroupModel = z.infer<typeof FormCropGroupSchema>
 
 export type ImageModel = {
   img: {

--- a/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/[slug]/page.tsx
@@ -311,63 +311,108 @@ export default function AgroChemicalGuidePage({ params }: GuidePageProps) {
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    {chemical.dosage_rates.map((rate: any, rateIdx: number) => {
-                                        const entries = rate.entries || []
-                                        const entryCount = entries.length || 1
-                                        return entries.map((entry: any, entryIdx: number) => (
-                                            <tr key={`${rateIdx}-${entryIdx}`} className="border-b border-border hover:bg-muted/30 transition-colors">
-                                                {/* Crop - only on first entry row, spans all entries */}
-                                                {entryIdx === 0 && (
-                                                    <td className="p-3 align-top" rowSpan={entryCount}>
-                                                        <div className="font-semibold capitalize text-sm text-foreground">{rate.crop}</div>
-                                                        {rate.category_name && (
-                                                            <div className="text-xs text-muted-foreground mt-0.5">{rate.category_name}</div>
+                                    {(() => {
+                                        const grouped = new Map<string, any[]>()
+                                        const ungrouped: any[] = []
+
+                                        chemical.dosage_rates.forEach((rate: any) => {
+                                            if (rate.crop_group_id) {
+                                                const existing = grouped.get(rate.crop_group_id) || []
+                                                existing.push(rate)
+                                                grouped.set(rate.crop_group_id, existing)
+                                            } else {
+                                                ungrouped.push(rate)
+                                            }
+                                        })
+
+                                        const renderEntryRows = (rate: any, rateKey: string, cropCell: React.ReactNode, targetCell: React.ReactNode) => {
+                                            const entries = rate.entries || []
+                                            const lastIdx = entries.length - 1
+                                            return entries.map((entry: any, entryIdx: number) => (
+                                                <tr key={`${rateKey}-${entryIdx}`} className={`hover:bg-muted/30 transition-colors ${entryIdx === 0 ? "border-t border-border" : ""} ${entryIdx === lastIdx ? "border-b border-border" : ""}`}>
+                                                    <td className="p-3 align-top">
+                                                        {entryIdx === 0 ? cropCell : null}
+                                                    </td>
+                                                    <td className="p-3 align-top">
+                                                        {entryIdx === 0 ? targetCell : null}
+                                                    </td>
+                                                    <td className="p-3 align-top">
+                                                        <div className="font-bold text-blue-600 dark:text-blue-400 text-base">
+                                                            {entry.dosage.value} {entry.dosage.unit}
+                                                        </div>
+                                                        <div className="text-xs text-muted-foreground">per {entry.dosage.per}</div>
+                                                    </td>
+                                                    <td className="p-3 align-top">
+                                                        <div className="font-semibold text-orange-700 dark:text-orange-300">{entry.max_applications.max}</div>
+                                                        {entry.max_applications.note && entry.max_applications.note.trim() !== '' && (
+                                                            <div className="text-xs text-muted-foreground mt-1">{entry.max_applications.note}</div>
                                                         )}
                                                     </td>
-                                                )}
-                                                {/* Target - only on first entry row, spans all entries */}
-                                                {entryIdx === 0 && (
-                                                    <td className="p-3 align-top" rowSpan={entryCount}>
-                                                        <div className="text-sm text-muted-foreground">{rate.targets}</div>
+                                                    <td className="p-3 align-top">
+                                                        <div className="font-semibold text-teal-700 dark:text-teal-300 text-sm">{entry.application_interval}</div>
                                                     </td>
-                                                )}
-                                                {/* Dosage */}
-                                                <td className="p-3 align-top">
-                                                    <div className="font-bold text-blue-600 dark:text-blue-400 text-base">
-                                                        {entry.dosage.value} {entry.dosage.unit}
-                                                    </div>
-                                                    <div className="text-xs text-muted-foreground">per {entry.dosage.per}</div>
-                                                </td>
-                                                {/* Max Applications */}
-                                                <td className="p-3 align-top">
-                                                    <div className="font-semibold text-orange-700 dark:text-orange-300">{entry.max_applications.max}</div>
-                                                    {entry.max_applications.note && entry.max_applications.note.trim() !== '' && (
-                                                        <div className="text-xs text-muted-foreground mt-1">{entry.max_applications.note}</div>
-                                                    )}
-                                                </td>
-                                                {/* Application Interval */}
-                                                <td className="p-3 align-top">
-                                                    <div className="font-semibold text-teal-700 dark:text-teal-300 text-sm">{entry.application_interval}</div>
-                                                </td>
-                                                {/* PHI */}
-                                                <td className="p-3 align-top">
-                                                    <div className="font-semibold text-rose-700 dark:text-rose-300 text-sm">{entry.phi}</div>
-                                                </td>
-                                                {/* Remarks */}
-                                                <td className="p-3 align-top">
-                                                    {entry.remarks && entry.remarks.length > 0 ? (
-                                                        <ul className="list-disc list-inside space-y-1">
-                                                            {entry.remarks.map((remark: string, remarkIdx: number) => (
-                                                                <li key={remarkIdx} className="text-xs text-foreground">{remark}</li>
-                                                            ))}
-                                                        </ul>
-                                                    ) : (
-                                                        <span className="text-xs text-muted-foreground">—</span>
-                                                    )}
-                                                </td>
-                                            </tr>
-                                        ))
-                                    })}
+                                                    <td className="p-3 align-top">
+                                                        <div className="font-semibold text-rose-700 dark:text-rose-300 text-sm">{entry.phi}</div>
+                                                    </td>
+                                                    <td className="p-3 align-top">
+                                                        {entry.remarks && entry.remarks.length > 0 ? (
+                                                            <ul className="list-disc list-inside space-y-1">
+                                                                {entry.remarks.map((remark: string, remarkIdx: number) => (
+                                                                    <li key={remarkIdx} className="text-xs text-foreground">{remark}</li>
+                                                                ))}
+                                                            </ul>
+                                                        ) : (
+                                                            <span className="text-xs text-muted-foreground">—</span>
+                                                        )}
+                                                    </td>
+                                                </tr>
+                                            ))
+                                        }
+
+                                        return (
+                                            <>
+                                                {/* Grouped rates - show group name with crops listed */}
+                                                {Array.from(grouped.entries()).map(([groupId, rates]) => {
+                                                    const firstRate = rates[0]
+                                                    const cropCell = (
+                                                        <div>
+                                                            <div className="font-semibold text-sm text-blue-700 dark:text-blue-300">
+                                                                {firstRate.crop_group}
+                                                            </div>
+                                                            <div className="mt-1 space-y-0.5">
+                                                                {rates.map((r: any, idx: number) => (
+                                                                    <div key={idx} className="text-xs text-muted-foreground capitalize flex items-start gap-1">
+                                                                        <span className="h-1 w-1 mt-1.5 rounded-full bg-blue-400 flex-shrink-0" />
+                                                                        <span className="flex-1">{r.crop}</span>
+                                                                    </div>
+                                                                ))}
+                                                            </div>
+                                                        </div>
+                                                    )
+                                                    const targetCell = (
+                                                        <div className="text-sm text-muted-foreground">{firstRate.targets}</div>
+                                                    )
+                                                    return renderEntryRows(firstRate, `group-${groupId}`, cropCell, targetCell)
+                                                })}
+
+                                                {/* Ungrouped rates - individual rows */}
+                                                {ungrouped.map((rate: any, rateIdx: number) => {
+                                                    const cropCell = (
+                                                        <div>
+                                                            <div className="font-semibold capitalize text-sm text-foreground">{rate.crop}</div>
+                                                            {rate.category_name && (
+                                                                <div className="text-xs text-muted-foreground mt-0.5">{rate.category_name}</div>
+                                                            )}
+                                                        </div>
+                                                    )
+                                                    const targetCell = (
+                                                        <div className="text-sm text-muted-foreground">{rate.targets}</div>
+                                                    )
+                                                    return renderEntryRows(rate, `rate-${rateIdx}`, cropCell, targetCell)
+                                                })}
+                                            </>
+                                        )
+                                    })()}
                                 </tbody>
                             </table>
                         </div>

--- a/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/[slug]/page.tsx
@@ -311,17 +311,26 @@ export default function AgroChemicalGuidePage({ params }: GuidePageProps) {
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    {chemical.dosage_rates.map((rate: any, rateIdx: number) => (
-                                        rate.entries && rate.entries.map((entry: any, entryIdx: number) => (
+                                    {chemical.dosage_rates.map((rate: any, rateIdx: number) => {
+                                        const entries = rate.entries || []
+                                        const entryCount = entries.length || 1
+                                        return entries.map((entry: any, entryIdx: number) => (
                                             <tr key={`${rateIdx}-${entryIdx}`} className="border-b border-border hover:bg-muted/30 transition-colors">
-                                                {/* Crop */}
-                                                <td className="p-3 align-top">
-                                                    <div className="font-semibold capitalize text-sm text-foreground">{rate.crop}</div>
-                                                </td>
-                                                {/* Target */}
-                                                <td className="p-3 align-top">
-                                                    <div className="text-sm text-muted-foreground">{rate.targets}</div>
-                                                </td>
+                                                {/* Crop - only on first entry row, spans all entries */}
+                                                {entryIdx === 0 && (
+                                                    <td className="p-3 align-top" rowSpan={entryCount}>
+                                                        <div className="font-semibold capitalize text-sm text-foreground">{rate.crop}</div>
+                                                        {rate.category_name && (
+                                                            <div className="text-xs text-muted-foreground mt-0.5">{rate.category_name}</div>
+                                                        )}
+                                                    </td>
+                                                )}
+                                                {/* Target - only on first entry row, spans all entries */}
+                                                {entryIdx === 0 && (
+                                                    <td className="p-3 align-top" rowSpan={entryCount}>
+                                                        <div className="text-sm text-muted-foreground">{rate.targets}</div>
+                                                    </td>
+                                                )}
                                                 {/* Dosage */}
                                                 <td className="p-3 align-top">
                                                     <div className="font-bold text-blue-600 dark:text-blue-400 text-base">
@@ -358,7 +367,7 @@ export default function AgroChemicalGuidePage({ params }: GuidePageProps) {
                                                 </td>
                                             </tr>
                                         ))
-                                    ))}
+                                    })}
                                 </tbody>
                             </table>
                         </div>

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Summary
- Add crop group admin pages (list, create, edit) with full CRUD
- Add crop group mode toggle in dosage rate form (individual crop vs crop group)
- Group dosage rates by crop group on client product display
- Add schemas, API queries, nav sidebar item, and table columns

## Test Plan
- [x] Tested crop group CRUD locally
- [x] Tested dosage rate group mode
- [x] Verified client-side grouped display