### PR TITLE
Add weed groups feature

### DIFF
--- a/apps/admin-fnp/app/(dashboard)/dashboard/weed-groups/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/(dashboard)/dashboard/weed-groups/[slug]/edit/page.tsx
@@ -1,0 +1,339 @@
+"use client"
+
+import { use, useState, useRef, useEffect } from "react"
+import Link from "next/link"
+import { useMutation, useQuery } from "@tanstack/react-query"
+import { useRouter } from "next/navigation"
+import { useDebounce } from "use-debounce"
+
+import { updateWeedGroup, queryWeedGroup, queryAgroChemicalTargets } from "@/lib/query"
+import { AgroChemicalTarget } from "@/lib/schemas"
+import { cn } from "@/lib/utilities"
+import { buttonVariants } from "@/components/ui/button"
+import { Button } from "@/components/ui/button"
+import { Icons } from "@/components/icons/lucide"
+import { toast } from "@/components/ui/use-toast"
+import { handleApiError, handleFetchError } from "@/lib/error-handler"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from "@/components/ui/popover"
+import {
+    Command,
+    CommandEmpty,
+    CommandInput,
+    CommandItem,
+    CommandList,
+} from "@/components/ui/command"
+
+export default function EditWeedGroupPage({ params }: { params: Promise<{ slug: string }> }) {
+    const router = useRouter()
+    const { slug } = use(params)
+    const groupId = slug
+
+    const [name, setName] = useState("")
+    const [description, setDescription] = useState("")
+    const [selectedTargets, setSelectedTargets] = useState<Array<{ id: string; name: string }>>([])
+    const [searchTarget, setSearchTarget] = useState("")
+    const [openTargets, setOpenTargets] = useState(false)
+    const [initialized, setInitialized] = useState(false)
+
+    const [debouncedTargetQuery] = useDebounce(searchTarget, 1000)
+
+    const hasShownError = useRef(false)
+
+    const { data: groupData, isLoading } = useQuery({
+        queryKey: ["weed-group", groupId],
+        queryFn: () => queryWeedGroup(groupId),
+    })
+
+    const group = groupData?.data
+
+    // Initialize form with fetched data
+    useEffect(() => {
+        if (group && !initialized) {
+            setName(group.name || "")
+            setDescription(group.description || "")
+            if (group.target_items) {
+                setSelectedTargets(group.target_items.map((item: AgroChemicalTarget) => ({
+                    id: item.id,
+                    name: item.name,
+                })))
+            }
+            setInitialized(true)
+        }
+    }, [group, initialized])
+
+    const { data: targetData, isError: targetError, error: targetFetchError, refetch: targetRefetch } = useQuery({
+        queryKey: ["agrochemical-targets-search", { search: debouncedTargetQuery }],
+        queryFn: () => queryAgroChemicalTargets({ search: debouncedTargetQuery }),
+        enabled: debouncedTargetQuery.length >= 2,
+        refetchOnWindowFocus: false
+    })
+
+    useEffect(() => {
+        if (targetError && !hasShownError.current) {
+            hasShownError.current = true
+            handleFetchError(targetFetchError, {
+                onRetry: () => {
+                    hasShownError.current = false
+                    targetRefetch()
+                },
+                context: "agrochemical targets"
+            })
+        }
+        if (!targetError) {
+            hasShownError.current = false
+        }
+    }, [targetError, targetFetchError, targetRefetch])
+
+    const targetList = targetData?.data?.data as AgroChemicalTarget[]
+
+    const handleToggleTarget = (target: AgroChemicalTarget) => {
+        const exists = selectedTargets.find(t => t.id === target.id)
+        if (exists) {
+            setSelectedTargets(selectedTargets.filter(t => t.id !== target.id))
+        } else {
+            setSelectedTargets([...selectedTargets, { id: target.id, name: target.name }])
+        }
+    }
+
+    const { mutate, isPending } = useMutation({
+        mutationFn: updateWeedGroup,
+        onSuccess: () => {
+            toast({
+                description: "Weed group updated successfully",
+            })
+            router.push("/dashboard/weed-groups")
+        },
+        onError: (error) => {
+            handleApiError(error, {
+                context: "weed group update"
+            })
+        },
+    })
+
+    function onSubmit(e: React.FormEvent) {
+        e.preventDefault()
+
+        if (!name.trim()) {
+            toast({ description: "Name is required", variant: "destructive" })
+            return
+        }
+
+        if (selectedTargets.length === 0) {
+            toast({ description: "At least one target is required", variant: "destructive" })
+            return
+        }
+
+        mutate({
+            id: groupId,
+            name: name.trim(),
+            description: description.trim(),
+            target_ids: selectedTargets.map(t => t.id),
+        })
+    }
+
+    if (isLoading) {
+        return (
+            <div className="flex justify-center py-12">
+                <Icons.spinner className="w-8 h-8 animate-spin text-gray-400" />
+            </div>
+        )
+    }
+
+    if (!group) {
+        return (
+            <div className="text-center py-12">
+                <p className="text-sm text-red-600 dark:text-red-400">
+                    Weed group not found.
+                </p>
+            </div>
+        )
+    }
+
+    return (
+        <div className="space-y-10">
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+                        Edit Weed Group
+                    </h1>
+                    <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                        Update the weed group information.
+                    </p>
+                </div>
+                <Link
+                    href="/dashboard/weed-groups"
+                    className={cn(buttonVariants({ variant: "ghost" }))}
+                >
+                    <Icons.close className="w-4 h-4 mr-2" />
+                    Close
+                </Link>
+            </div>
+
+            <form onSubmit={onSubmit}>
+                <div className="space-y-12">
+                    <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
+                        <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                            Group Information
+                        </h2>
+                        <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                            Weed groups let you select multiple targets at once when creating dosage rates.
+                        </p>
+
+                        <div className="mt-10 space-y-8">
+                            <div className="px-1">
+                                <label
+                                    htmlFor="name"
+                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                >
+                                    Group Name
+                                </label>
+                                <div className="mt-2">
+                                    <Input
+                                        id="name"
+                                        placeholder="e.g., Annual Grasses, Broadleaf Weeds"
+                                        value={name}
+                                        onChange={(e) => setName(e.target.value)}
+                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                    />
+                                </div>
+                            </div>
+
+                            <div className="px-1">
+                                <label
+                                    htmlFor="description"
+                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                >
+                                    Description
+                                </label>
+                                <div className="mt-2">
+                                    <Textarea
+                                        id="description"
+                                        placeholder="Describe this weed group"
+                                        rows={3}
+                                        value={description}
+                                        onChange={(e) => setDescription(e.target.value)}
+                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                    />
+                                </div>
+                            </div>
+
+                            <div className="px-1">
+                                <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                                    Targets in this Group
+                                </label>
+
+                                {selectedTargets.length > 0 && (
+                                    <div className="flex flex-wrap gap-2 mt-2 mb-3">
+                                        {selectedTargets.map(target => (
+                                            <span
+                                                key={target.id}
+                                                className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-sm bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-300 cursor-pointer hover:bg-blue-100 dark:hover:bg-blue-900/40"
+                                                onClick={() => setSelectedTargets(selectedTargets.filter(t => t.id !== target.id))}
+                                            >
+                                                {target.name}
+                                                <Icons.close className="w-3 h-3" />
+                                            </span>
+                                        ))}
+                                    </div>
+                                )}
+
+                                <Popover open={openTargets} onOpenChange={setOpenTargets}>
+                                    <PopoverTrigger asChild>
+                                        <Button
+                                            type="button"
+                                            variant="outline"
+                                            role="combobox"
+                                            aria-expanded={openTargets}
+                                            className="w-full justify-start text-left font-normal"
+                                        >
+                                            <Icons.search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+                                            Search and add targets...
+                                        </Button>
+                                    </PopoverTrigger>
+                                    <PopoverContent className="w-full p-0" align="start">
+                                        <Command shouldFilter={false}>
+                                            <CommandInput
+                                                placeholder="Type target name (min 2 chars)..."
+                                                value={searchTarget}
+                                                onValueChange={setSearchTarget}
+                                            />
+                                            <CommandList>
+                                                <CommandEmpty>
+                                                    {debouncedTargetQuery.length < 2
+                                                        ? "Type at least 2 characters to search"
+                                                        : "No targets found"
+                                                    }
+                                                </CommandEmpty>
+                                                {targetList?.map((target) => {
+                                                    const isSelected = selectedTargets.some(t => t.id === target.id)
+                                                    return (
+                                                        <CommandItem
+                                                            key={target.id}
+                                                            value={target.id}
+                                                            onSelect={() => handleToggleTarget(target)}
+                                                        >
+                                                            <span className={cn(
+                                                                "mr-2 flex h-4 w-4 items-center justify-center rounded-sm border",
+                                                                isSelected
+                                                                    ? "bg-primary border-primary text-primary-foreground"
+                                                                    : "border-gray-300 dark:border-gray-600"
+                                                            )}>
+                                                                {isSelected && <Icons.check className="w-3 h-3" />}
+                                                            </span>
+                                                            {target.name}
+                                                            {target.scientific_name && (
+                                                                <span className="ml-2 text-xs text-gray-400">({target.scientific_name})</span>
+                                                            )}
+                                                        </CommandItem>
+                                                    )
+                                                })}
+                                            </CommandList>
+                                        </Command>
+                                    </PopoverContent>
+                                </Popover>
+                                <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                    Select the targets that belong to this group.
+                                </p>
+                            </div>
+
+                            <div className="px-1">
+                                <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                                    Current Slug
+                                </label>
+                                <div className="mt-2">
+                                    <div className="block w-full rounded-md bg-gray-50 px-3 py-1.5 text-base text-gray-500 outline outline-1 outline-gray-300 sm:text-sm/6 dark:bg-gray-900 dark:text-gray-400 dark:outline-white/10">
+                                        {group.slug}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div className="mt-6 flex items-center justify-end gap-x-6">
+                    <button
+                        type="button"
+                        onClick={() => router.push("/dashboard/weed-groups")}
+                        className="text-sm/6 font-semibold text-gray-900 dark:text-white"
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        type="submit"
+                        disabled={isPending}
+                        className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
+                    >
+                        {isPending && <Icons.spinner className="w-4 h-4 mr-2 animate-spin" />}
+                        Save
+                    </button>
+                </div>
+            </form>
+        </div>
+    )
+}

--- a/apps/admin-fnp/app/(dashboard)/dashboard/weed-groups/new/page.tsx
+++ b/apps/admin-fnp/app/(dashboard)/dashboard/weed-groups/new/page.tsx
@@ -1,0 +1,290 @@
+"use client"
+
+import { useState, useRef, useEffect } from "react"
+import Link from "next/link"
+import { useMutation, useQuery } from "@tanstack/react-query"
+import { useRouter } from "next/navigation"
+import { useDebounce } from "use-debounce"
+
+import { addWeedGroup, queryAgroChemicalTargets } from "@/lib/query"
+import { AgroChemicalTarget } from "@/lib/schemas"
+import { cn } from "@/lib/utilities"
+import { buttonVariants } from "@/components/ui/button"
+import { Button } from "@/components/ui/button"
+import { Icons } from "@/components/icons/lucide"
+import { toast } from "@/components/ui/use-toast"
+import { handleApiError, handleFetchError } from "@/lib/error-handler"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from "@/components/ui/popover"
+import {
+    Command,
+    CommandEmpty,
+    CommandInput,
+    CommandItem,
+    CommandList,
+} from "@/components/ui/command"
+
+export default function NewWeedGroupPage() {
+    const router = useRouter()
+
+    const [name, setName] = useState("")
+    const [description, setDescription] = useState("")
+    const [selectedTargets, setSelectedTargets] = useState<Array<{ id: string; name: string }>>([])
+    const [searchTarget, setSearchTarget] = useState("")
+    const [openTargets, setOpenTargets] = useState(false)
+
+    const [debouncedTargetQuery] = useDebounce(searchTarget, 1000)
+
+    const hasShownError = useRef(false)
+
+    const { data: targetData, isError: targetError, error: targetFetchError, refetch: targetRefetch } = useQuery({
+        queryKey: ["agrochemical-targets-search", { search: debouncedTargetQuery }],
+        queryFn: () => queryAgroChemicalTargets({ search: debouncedTargetQuery }),
+        enabled: debouncedTargetQuery.length >= 2,
+        refetchOnWindowFocus: false
+    })
+
+    useEffect(() => {
+        if (targetError && !hasShownError.current) {
+            hasShownError.current = true
+            handleFetchError(targetFetchError, {
+                onRetry: () => {
+                    hasShownError.current = false
+                    targetRefetch()
+                },
+                context: "agrochemical targets"
+            })
+        }
+        if (!targetError) {
+            hasShownError.current = false
+        }
+    }, [targetError, targetFetchError, targetRefetch])
+
+    const targetList = targetData?.data?.data as AgroChemicalTarget[]
+
+    const handleToggleTarget = (target: AgroChemicalTarget) => {
+        const exists = selectedTargets.find(t => t.id === target.id)
+        if (exists) {
+            setSelectedTargets(selectedTargets.filter(t => t.id !== target.id))
+        } else {
+            setSelectedTargets([...selectedTargets, { id: target.id, name: target.name }])
+        }
+    }
+
+    const { mutate, isPending } = useMutation({
+        mutationFn: addWeedGroup,
+        onSuccess: () => {
+            toast({
+                description: "Weed group added successfully",
+            })
+            router.push("/dashboard/weed-groups")
+        },
+        onError: (error) => {
+            handleApiError(error, {
+                context: "weed group creation"
+            })
+        },
+    })
+
+    function onSubmit(e: React.FormEvent) {
+        e.preventDefault()
+
+        if (!name.trim()) {
+            toast({ description: "Name is required", variant: "destructive" })
+            return
+        }
+
+        if (selectedTargets.length === 0) {
+            toast({ description: "At least one target is required", variant: "destructive" })
+            return
+        }
+
+        mutate({
+            name: name.trim(),
+            description: description.trim(),
+            target_ids: selectedTargets.map(t => t.id),
+        })
+    }
+
+    return (
+        <div className="space-y-10">
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+                        Add Weed Group
+                    </h1>
+                    <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                        Create a new weed group for batch target selection in dosage rates.
+                    </p>
+                </div>
+                <Link
+                    href="/dashboard/weed-groups"
+                    className={cn(buttonVariants({ variant: "ghost" }))}
+                >
+                    <Icons.close className="w-4 h-4 mr-2" />
+                    Close
+                </Link>
+            </div>
+
+            <form onSubmit={onSubmit}>
+                <div className="space-y-12">
+                    <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
+                        <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                            Group Information
+                        </h2>
+                        <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                            Weed groups let you select multiple targets at once when creating dosage rates (e.g., Annual Grasses).
+                        </p>
+
+                        <div className="mt-10 space-y-8">
+                            <div className="px-1">
+                                <label
+                                    htmlFor="name"
+                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                >
+                                    Group Name
+                                </label>
+                                <div className="mt-2">
+                                    <Input
+                                        id="name"
+                                        placeholder="e.g., Annual Grasses, Broadleaf Weeds"
+                                        value={name}
+                                        onChange={(e) => setName(e.target.value)}
+                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                    />
+                                </div>
+                                <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                    Enter a name for this weed group.
+                                </p>
+                            </div>
+
+                            <div className="px-1">
+                                <label
+                                    htmlFor="description"
+                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                >
+                                    Description
+                                </label>
+                                <div className="mt-2">
+                                    <Textarea
+                                        id="description"
+                                        placeholder="Describe this weed group"
+                                        rows={3}
+                                        value={description}
+                                        onChange={(e) => setDescription(e.target.value)}
+                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                    />
+                                </div>
+                                <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                    Optional description (max 500 characters).
+                                </p>
+                            </div>
+
+                            <div className="px-1">
+                                <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                                    Targets in this Group
+                                </label>
+
+                                {selectedTargets.length > 0 && (
+                                    <div className="flex flex-wrap gap-2 mt-2 mb-3">
+                                        {selectedTargets.map(target => (
+                                            <span
+                                                key={target.id}
+                                                className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-sm bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-300 cursor-pointer hover:bg-blue-100 dark:hover:bg-blue-900/40"
+                                                onClick={() => setSelectedTargets(selectedTargets.filter(t => t.id !== target.id))}
+                                            >
+                                                {target.name}
+                                                <Icons.close className="w-3 h-3" />
+                                            </span>
+                                        ))}
+                                    </div>
+                                )}
+
+                                <Popover open={openTargets} onOpenChange={setOpenTargets}>
+                                    <PopoverTrigger asChild>
+                                        <Button
+                                            type="button"
+                                            variant="outline"
+                                            role="combobox"
+                                            aria-expanded={openTargets}
+                                            className="w-full justify-start text-left font-normal"
+                                        >
+                                            <Icons.search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+                                            Search and add targets...
+                                        </Button>
+                                    </PopoverTrigger>
+                                    <PopoverContent className="w-full p-0" align="start">
+                                        <Command shouldFilter={false}>
+                                            <CommandInput
+                                                placeholder="Type target name (min 2 chars)..."
+                                                value={searchTarget}
+                                                onValueChange={setSearchTarget}
+                                            />
+                                            <CommandList>
+                                                <CommandEmpty>
+                                                    {debouncedTargetQuery.length < 2
+                                                        ? "Type at least 2 characters to search"
+                                                        : "No targets found"
+                                                    }
+                                                </CommandEmpty>
+                                                {targetList?.map((target) => {
+                                                    const isSelected = selectedTargets.some(t => t.id === target.id)
+                                                    return (
+                                                        <CommandItem
+                                                            key={target.id}
+                                                            value={target.id}
+                                                            onSelect={() => handleToggleTarget(target)}
+                                                        >
+                                                            <span className={cn(
+                                                                "mr-2 flex h-4 w-4 items-center justify-center rounded-sm border",
+                                                                isSelected
+                                                                    ? "bg-primary border-primary text-primary-foreground"
+                                                                    : "border-gray-300 dark:border-gray-600"
+                                                            )}>
+                                                                {isSelected && <Icons.check className="w-3 h-3" />}
+                                                            </span>
+                                                            {target.name}
+                                                            {target.scientific_name && (
+                                                                <span className="ml-2 text-xs text-gray-400">({target.scientific_name})</span>
+                                                            )}
+                                                        </CommandItem>
+                                                    )
+                                                })}
+                                            </CommandList>
+                                        </Command>
+                                    </PopoverContent>
+                                </Popover>
+                                <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                    Select the targets (weeds/pests) that belong to this group. At least one target is required.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div className="mt-6 flex items-center justify-end gap-x-6">
+                    <button
+                        type="button"
+                        onClick={() => router.push("/dashboard/weed-groups")}
+                        className="text-sm/6 font-semibold text-gray-900 dark:text-white"
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        type="submit"
+                        disabled={isPending}
+                        className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
+                    >
+                        {isPending && <Icons.spinner className="w-4 h-4 mr-2 animate-spin" />}
+                        Save
+                    </button>
+                </div>
+            </form>
+        </div>
+    )
+}

--- a/apps/admin-fnp/app/(dashboard)/dashboard/weed-groups/page.tsx
+++ b/apps/admin-fnp/app/(dashboard)/dashboard/weed-groups/page.tsx
@@ -1,0 +1,15 @@
+import { DashboardHeader } from "@/components/state/dashboardHeader"
+import { DashboardShell } from "@/components/state/dashboardShell"
+import { WeedGroupsTable } from "@/components/structures/tables/weedGroups"
+
+export default async function WeedGroupsPage() {
+  return (
+    <DashboardShell>
+      <DashboardHeader
+        heading="Weed Groups"
+        text="Manage weed groups (e.g., Annual Grasses) for batch target selection in dosage rates."
+      ></DashboardHeader>
+      <WeedGroupsTable />
+    </DashboardShell>
+  )
+}

--- a/apps/admin-fnp/components/structures/columns/weedGroups.tsx
+++ b/apps/admin-fnp/components/structures/columns/weedGroups.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { ColumnDef } from "@tanstack/react-table"
+import { WeedGroup } from "@/lib/schemas"
+import { Checkbox } from "@/components/ui/checkbox"
+import { formatDate } from "@/lib/utilities"
+import { WeedGroupControlDropDown } from "@/components/structures/dropdowns/weedGroup-dropdown"
+
+export const weedGroupColumns: ColumnDef<WeedGroup>[] = [
+  {
+    id: "select",
+    header: ({ table }) => (
+      <Checkbox
+        checked={table.getIsAllPageRowsSelected()}
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Select all"
+        className="translate-y-[2px]"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label="Select row"
+        className="translate-y-[2px]"
+      />
+    ),
+    enableSorting: false,
+    enableHiding: false,
+  },
+  {
+    accessorKey: "name",
+    header: "Name",
+  },
+  {
+    accessorKey: "description",
+    header: "Description",
+    cell: ({ row }) => {
+      const description = row.original.description
+      return (
+        <span className="max-w-md truncate">
+          {description || "-"}
+        </span>
+      )
+    },
+  },
+  {
+    id: "targets",
+    header: "Targets",
+    cell: ({ row }) => {
+      const count = row.original.target_ids?.length || 0
+      return <span>{count} {count === 1 ? "target" : "targets"}</span>
+    },
+  },
+  {
+    accessorKey: "created",
+    header: "Date Created",
+    cell: ({ row }) => {
+      const created = row.original.created
+      return <span>{formatDate(created)}</span>
+    },
+  },
+  {
+    id: "actions",
+    cell: ({ row }) => {
+      const weedGroup = row?.original
+      return <WeedGroupControlDropDown weedGroup={weedGroup} />
+    },
+  },
+]

--- a/apps/admin-fnp/components/structures/dropdowns/weedGroup-dropdown.tsx
+++ b/apps/admin-fnp/components/structures/dropdowns/weedGroup-dropdown.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import Link from "next/link"
+import { MoreHorizontal } from "lucide-react"
+
+import { WeedGroup } from "@/lib/schemas"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+interface WeedGroupControlDropDownProps {
+  weedGroup?: WeedGroup
+}
+
+export function WeedGroupControlDropDown({
+  weedGroup,
+}: WeedGroupControlDropDownProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className="w-8 h-8 p-0">
+          <span className="sr-only">Open menu</span>
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Actions</DropdownMenuLabel>
+        <DropdownMenuItem>
+          <Link
+            className="w-full"
+            href={`/dashboard/weed-groups/${weedGroup?.id}/edit`}
+          >
+            Edit
+          </Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/admin-fnp/components/structures/forms/dosageRatesSelect.tsx
+++ b/apps/admin-fnp/components/structures/forms/dosageRatesSelect.tsx
@@ -9,8 +9,8 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { cn } from "@/lib/utilities"
-import { queryFarmProduce, queryAgroChemicalTargets, queryCropGroups, queryCropGroup } from "@/lib/query"
-import { FarmProduce, AgroChemicalTarget, CropGroup } from "@/lib/schemas"
+import { queryFarmProduce, queryAgroChemicalTargets, queryCropGroups, queryCropGroup, queryWeedGroups, queryWeedGroup } from "@/lib/query"
+import { FarmProduce, AgroChemicalTarget, CropGroup, WeedGroup } from "@/lib/schemas"
 import { handleFetchError } from "@/lib/error-handler"
 import {
     Command,
@@ -38,6 +38,8 @@ export interface DosageRate {
     crop_id: string
     crop_group?: string
     crop_group_id?: string
+    weed_group?: string
+    weed_group_id?: string
     targets: string
     target_ids: string[]
     entries: Array<{
@@ -98,6 +100,13 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
     const [openCropGroup, setOpenCropGroup] = useState(false)
     const [searchCropGroup, setSearchCropGroup] = useState("")
 
+    // Weed group state
+    const [isWeedGroupMode, setIsWeedGroupMode] = useState(false)
+    const [weedGroupId, setWeedGroupId] = useState("")
+    const [weedGroupName, setWeedGroupName] = useState("")
+    const [openWeedGroup, setOpenWeedGroup] = useState(false)
+    const [searchWeedGroup, setSearchWeedGroup] = useState("")
+
     const [openCrop, setOpenCrop] = useState(false)
     const [openTargets, setOpenTargets] = useState(false)
     const [searchCrop, setSearchCrop] = useState("")
@@ -107,6 +116,7 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
     const [debouncedCropQuery] = useDebounce(searchCrop, 1000)
     const [debouncedTargetQuery] = useDebounce(searchTarget, 1000)
     const [debouncedCropGroupQuery] = useDebounce(searchCropGroup, 1000)
+    const [debouncedWeedGroupQuery] = useDebounce(searchWeedGroup, 1000)
 
     // Fetch crop groups
     const { data: cropGroupData } = useQuery({
@@ -131,6 +141,29 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
             })))
         }
     }, [selectedGroupData])
+
+    // Fetch weed groups
+    const { data: weedGroupData } = useQuery({
+        queryKey: ["weed-groups-search", { search: debouncedWeedGroupQuery }],
+        queryFn: () => queryWeedGroups({ search: debouncedWeedGroupQuery }),
+        enabled: debouncedWeedGroupQuery.length >= 2,
+    })
+    const weedGroups = weedGroupData?.data?.data as WeedGroup[]
+
+    // Fetch selected weed group detail
+    const { data: selectedWeedGroupData } = useQuery({
+        queryKey: ["weed-group-detail", weedGroupId],
+        queryFn: () => queryWeedGroup(weedGroupId),
+        enabled: !!weedGroupId,
+    })
+
+    useEffect(() => {
+        if (selectedWeedGroupData?.data?.target_items) {
+            const items = selectedWeedGroupData.data.target_items as AgroChemicalTarget[]
+            setTargetIds(items.map((t) => t.id))
+            setTargetNames(items.map((t) => t.scientific_name ? `${t.name} (${t.scientific_name})` : t.name))
+        }
+    }, [selectedWeedGroupData])
 
     // Fetch farm produce
     const {
@@ -211,6 +244,8 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
                 crop_id: crop.id,
                 crop_group: cropGroupName,
                 crop_group_id: cropGroupId,
+                weed_group: weedGroupName || "",
+                weed_group_id: weedGroupId || "",
                 targets: targetNames.join(", "),
                 target_ids: targetIds,
                 entries: entriesList,
@@ -235,6 +270,8 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
                 crop_id: cropId,
                 crop_group: "",
                 crop_group_id: "",
+                weed_group: weedGroupName || "",
+                weed_group_id: weedGroupId || "",
                 targets: targetNames.join(", "),
                 target_ids: targetIds,
                 entries: entriesList,
@@ -258,6 +295,9 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
         setCropGroupName("")
         setGroupCrops([])
         setIsGroupMode(false)
+        setWeedGroupId("")
+        setWeedGroupName("")
+        setIsWeedGroupMode(false)
         setTargetIds([])
         setTargetNames([])
         setEntriesList([])
@@ -290,6 +330,16 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
             setCropName(rate.crop)
         }
 
+        if (rate.weed_group_id) {
+            setIsWeedGroupMode(true)
+            setWeedGroupId(rate.weed_group_id)
+            setWeedGroupName(rate.weed_group || "")
+        } else {
+            setIsWeedGroupMode(false)
+            setWeedGroupId("")
+            setWeedGroupName("")
+        }
+
         setTargetIds(rate.target_ids)
         setTargetNames(rate.targets ? rate.targets.split(", ") : [])
 
@@ -317,6 +367,8 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
             crop_id: rate.crop_id,
             crop_group: rate.crop_group,
             crop_group_id: rate.crop_group_id,
+            weed_group: rate.weed_group,
+            weed_group_id: rate.weed_group_id,
             targets: rate.targets || "",
             target_ids: [...rate.target_ids],
             entries: rate.entries.map(entry => ({
@@ -572,6 +624,9 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
                                                     {rates[0].targets && (
                                                         <div className="text-sm text-gray-600 dark:text-gray-400">
                                                             <span className="font-medium">Targets:</span> {rates[0].targets}
+                                                            {rates[0].weed_group && (
+                                                                <span className="ml-2 text-xs font-normal text-green-600 dark:text-green-400">({rates[0].weed_group})</span>
+                                                            )}
                                                         </div>
                                                     )}
                                                 </div>
@@ -618,6 +673,9 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
                                                     {rate.targets && (
                                                         <div className="text-sm text-gray-600 dark:text-gray-400 mt-1">
                                                             <span className="font-medium">Targets:</span> {rate.targets}
+                                                            {rate.weed_group && (
+                                                                <span className="ml-2 text-xs font-normal text-green-600 dark:text-green-400">({rate.weed_group})</span>
+                                                            )}
                                                         </div>
                                                     )}
                                                     {(!rate.targets && rate.target_ids?.length > 0) && (
@@ -845,6 +903,37 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
                         )}
                     </div>
                     <div>
+                        <Label>Target Selection Mode</Label>
+                        <div className="flex gap-2 mt-2 mb-2">
+                            <Button
+                                type="button"
+                                variant={!isWeedGroupMode ? "default" : "outline"}
+                                size="sm"
+                                onClick={() => {
+                                    setIsWeedGroupMode(false)
+                                    setWeedGroupId("")
+                                    setWeedGroupName("")
+                                    setTargetIds([])
+                                    setTargetNames([])
+                                }}
+                            >
+                                Individual Target
+                            </Button>
+                            <Button
+                                type="button"
+                                variant={isWeedGroupMode ? "default" : "outline"}
+                                size="sm"
+                                onClick={() => {
+                                    setIsWeedGroupMode(true)
+                                    setTargetIds([])
+                                    setTargetNames([])
+                                }}
+                            >
+                                Weed Group
+                            </Button>
+                        </div>
+                        {!isWeedGroupMode ? (
+                        <>
                         <Label>Targets (Pests/Diseases)</Label>
                         <Popover open={openTargets} onOpenChange={setOpenTargets}>
                             <PopoverTrigger asChild>
@@ -932,8 +1021,83 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
                                 </Command>
                             </PopoverContent>
                         </Popover>
+                        </>
+                        ) : (
+                        <>
+                            <Label>Weed Group</Label>
+                            <Popover open={openWeedGroup} onOpenChange={setOpenWeedGroup}>
+                                <PopoverTrigger asChild>
+                                    <Button
+                                        variant="outline"
+                                        role="combobox"
+                                        className={cn(
+                                            "w-full justify-between mt-2",
+                                            !weedGroupId && "text-muted-foreground"
+                                        )}
+                                    >
+                                        <span className="truncate">
+                                            {weedGroupId ? weedGroupName : "Select weed group"}
+                                        </span>
+                                        <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                                    </Button>
+                                </PopoverTrigger>
+                                <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
+                                    <Command shouldFilter={false}>
+                                        <CommandInput
+                                            placeholder="Search weed group..."
+                                            value={searchWeedGroup}
+                                            onValueChange={setSearchWeedGroup}
+                                        />
+                                        <CommandList>
+                                            <CommandEmpty>
+                                                {searchWeedGroup.length < 2
+                                                    ? "Type at least 2 characters to search"
+                                                    : "No weed group found."}
+                                            </CommandEmpty>
+                                            {weedGroups?.map((group) => (
+                                                <CommandItem
+                                                    value={group.id}
+                                                    key={group.id}
+                                                    onSelect={() => {
+                                                        setWeedGroupId(group.id)
+                                                        setWeedGroupName(group.name)
+                                                        setOpenWeedGroup(false)
+                                                    }}
+                                                >
+                                                    <Check
+                                                        className={cn(
+                                                            "mr-2 h-4 w-4",
+                                                            group.id === weedGroupId ? "opacity-100" : "opacity-0"
+                                                        )}
+                                                    />
+                                                    {group.name}
+                                                </CommandItem>
+                                            ))}
+                                        </CommandList>
+                                    </Command>
+                                </PopoverContent>
+                            </Popover>
+                        </>
+                        )}
                     </div>
                 </div>
+
+                {/* Display weed group targets when a weed group is selected */}
+                {isWeedGroupMode && weedGroupId && targetIds.length > 0 && (
+                    <div>
+                        <Label>Targets in Group ({targetIds.length})</Label>
+                        <div className="flex flex-wrap gap-2 mt-2">
+                            {targetNames.map((name, idx) => (
+                                <span
+                                    key={targetIds[idx]}
+                                    className="inline-flex items-center px-2.5 py-1 rounded-md text-sm bg-green-50 text-green-700 dark:bg-green-900/20 dark:text-green-300"
+                                >
+                                    {name}
+                                </span>
+                            ))}
+                        </div>
+                    </div>
+                )}
 
                 {/* Display group crops when a crop group is selected */}
                 {isGroupMode && cropGroupId && groupCrops.length > 0 && (

--- a/apps/admin-fnp/components/structures/tables/weedGroups.tsx
+++ b/apps/admin-fnp/components/structures/tables/weedGroups.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import { useState, useEffect, useRef } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { PaginationState } from "@tanstack/react-table"
+
+import { queryWeedGroups } from "@/lib/query"
+import { WeedGroup } from "@/lib/schemas"
+import { handleFetchError } from "@/lib/error-handler"
+import { Placeholder } from "@/components/state/placeholder"
+import { DataTable } from "@/components/structures/data-table"
+import { weedGroupColumns } from "@/components/structures/columns/weedGroups"
+
+export function WeedGroupsTable() {
+  const [search, setSearch] = useState("")
+
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 1,
+    pageSize: 20,
+  })
+
+  const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
+    queryKey: ["dashboard-weed-groups", { p: pagination.pageIndex, search }],
+    queryFn: () =>
+      queryWeedGroups({
+        p: pagination.pageIndex,
+        search: search,
+      }),
+    refetchOnWindowFocus: false
+  })
+
+  const groups = data?.data?.data as WeedGroup[]
+  const total = data?.data?.total as number
+
+  // Show error toast only once when error occurs
+  const hasShownError = useRef(false)
+  useEffect(() => {
+    if (isError && !hasShownError.current) {
+      hasShownError.current = true
+      handleFetchError(error, {
+        onRetry: () => {
+          hasShownError.current = false
+          refetch()
+        },
+        context: "weed groups"
+      })
+    }
+    if (!isError) {
+      hasShownError.current = false
+    }
+  }, [isError, error, refetch])
+
+  if (isError) {
+    return (
+      <Placeholder>
+        <Placeholder.Icon name="close" />
+        <Placeholder.Title>Error Fetching Weed Groups</Placeholder.Title>
+        <Placeholder.Description>
+          Error fetching weed groups from the database
+        </Placeholder.Description>
+      </Placeholder>
+    )
+  }
+
+  if (isLoading || isFetching) {
+    return (
+      <Placeholder>
+        <Placeholder.Title>Fetching Weed Groups</Placeholder.Title>
+      </Placeholder>
+    )
+  }
+
+  return (
+    <DataTable
+      columns={weedGroupColumns}
+      data={groups}
+      newUrl="/dashboard/weed-groups/new"
+      tableName="Weed Group"
+      total={total}
+      pagination={pagination}
+      setPagination={setPagination}
+      search={search}
+      setSearch={setSearch}
+    />
+  )
+}

--- a/apps/admin-fnp/config/dashboard.ts
+++ b/apps/admin-fnp/config/dashboard.ts
@@ -39,6 +39,11 @@ export const dashboardConfig: DashboardConfig = {
       icon: "layers",
     },
     {
+      title: "Weed Groups",
+      href: "/dashboard/weed-groups",
+      icon: "layers",
+    },
+    {
       title: "Brands",
       href: "/dashboard/brands",
       icon: "tag",

--- a/apps/admin-fnp/lib/query.ts
+++ b/apps/admin-fnp/lib/query.ts
@@ -365,6 +365,43 @@ export function deleteCropGroups(groupIds: string[]) {
   return api.post(url, { group_ids: groupIds })
 }
 
+// Weed Group functions
+export function queryWeedGroups(pagination?: pagination) {
+  let url: string
+
+  if (pagination?.p !== undefined && pagination.p >= 2) {
+    url = `${baseUrl}/user/weed-groups?p=${pagination.p}`
+  } else {
+    url = `${baseUrl}/user/weed-groups`
+  }
+
+  if (pagination?.search !== undefined && pagination.search.length >= 2) {
+    url = `${baseUrl}/user/weed-groups?search=${pagination.search}`
+  }
+
+  return api.get(url)
+}
+
+export function queryWeedGroup(id: string) {
+  const url = `${baseUrl}/user/weed-groups/${id}`
+  return api.get(url)
+}
+
+export function addWeedGroup(data: { name: string; description: string; target_ids: string[] }) {
+  let url = `${baseUrl}/user/weed-groups/add`
+  return api.post(url, data)
+}
+
+export function updateWeedGroup(data: { id: string; name: string; description: string; target_ids: string[] }) {
+  let url = `${baseUrl}/user/weed-groups/update`
+  return api.post(url, data)
+}
+
+export function deleteWeedGroups(groupIds: string[]) {
+  let url = `${baseUrl}/user/weed-groups/delete`
+  return api.post(url, { group_ids: groupIds })
+}
+
 export function queryFarmProduceCategories(pagination?: pagination) {
   let url: string
 

--- a/apps/admin-fnp/lib/schemas.ts
+++ b/apps/admin-fnp/lib/schemas.ts
@@ -403,6 +403,28 @@ export const FormCropGroupSchema = CropGroupSchema.pick({
   farm_produce_ids: true,
 })
 
+export const WeedGroupSchema = z.object({
+  id: z.string(),
+  name: z.string().min(1, "Name is required"),
+  slug: z.string().optional(),
+  description: z.string().max(500, "Description cannot exceed 500 characters"),
+  target_ids: z.array(z.string()).min(1, "At least one target is required"),
+  target_items: z.array(z.object({
+    id: z.string(),
+    name: z.string(),
+    slug: z.string(),
+  })).optional(),
+  created: z.string().optional(),
+  updated: z.string().optional(),
+})
+
+export const FormWeedGroupSchema = WeedGroupSchema.pick({
+  id: true,
+  name: true,
+  description: true,
+  target_ids: true,
+})
+
 export const AgroChemicalDosageRateSchema = z.object({
   id: z.string(),
   agrochemical_id: z.string().min(1, "AgroChemical is required"),
@@ -462,6 +484,8 @@ export const AgroChemicalSchema = z.object({
     crop_id: z.string(),
     crop_group: z.string().optional(),
     crop_group_id: z.string().optional(),
+    weed_group: z.string().optional(),
+    weed_group_id: z.string().optional(),
     targets: z.string(),
     target_ids: z.array(z.string()),
     entries: z.array(z.object({
@@ -496,6 +520,8 @@ export const DosageRateSchema = z.object({
   crop_id: z.string(),
   crop_group: z.string().optional(),
   crop_group_id: z.string().optional(),
+  weed_group: z.string().optional(),
+  weed_group_id: z.string().optional(),
   targets: z.string(),
   target_ids: z.array(z.string()),
   entries: z.array(z.object({
@@ -572,6 +598,8 @@ export type AgroChemicalItem = z.infer<typeof AgroChemicalSchema>
 export type FormAgroChemicalModel = z.infer<typeof FormAgroChemicalSchema>
 export type CropGroup = z.infer<typeof CropGroupSchema>
 export type FormCropGroupModel = z.infer<typeof FormCropGroupSchema>
+export type WeedGroup = z.infer<typeof WeedGroupSchema>
+export type FormWeedGroupModel = z.infer<typeof FormWeedGroupSchema>
 
 export type ImageModel = {
   img: {


### PR DESCRIPTION
## Summary
- Add weed group CRUD pages (list, create, edit) to admin dashboard
- Add target selection mode toggle in dosage rates form (Individual Target / Weed Group)
- Add weed group schemas, query functions, table components, and sidebar nav entry

## Test Plan
- [x] Tested locally
- [x] Weed group CRUD verified
- [x] Dosage rates form weed group mode verified