### PR TITLE
Improve dosage rate target display and UI enhancements

### DIFF
--- a/apps/admin-fnp/components/structures/forms/dosageRatesSelect.tsx
+++ b/apps/admin-fnp/components/structures/forms/dosageRatesSelect.tsx
@@ -40,7 +40,7 @@ export interface DosageRate {
     crop_group_id?: string
     weed_group?: string
     weed_group_id?: string
-    targets: string
+    targets: string[]
     target_ids: string[]
     entries: Array<{
         dosage: {
@@ -246,7 +246,7 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
                 crop_group_id: cropGroupId,
                 weed_group: weedGroupName || "",
                 weed_group_id: weedGroupId || "",
-                targets: targetNames.join(", "),
+                targets: [...targetNames],
                 target_ids: targetIds,
                 entries: entriesList,
             }))
@@ -272,7 +272,7 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
                 crop_group_id: "",
                 weed_group: weedGroupName || "",
                 weed_group_id: weedGroupId || "",
-                targets: targetNames.join(", "),
+                targets: [...targetNames],
                 target_ids: targetIds,
                 entries: entriesList,
             }
@@ -341,7 +341,7 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
         }
 
         setTargetIds(rate.target_ids)
-        setTargetNames(rate.targets ? rate.targets.split(", ") : [])
+        setTargetNames(rate.targets || [])
 
         // Load entries (from first rate — all rates in a group share the same entries)
         const entriesArray = Array.isArray(rate.entries) ? rate.entries : []
@@ -351,8 +351,8 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
         setShowForm(true)
 
         // Trigger a search to load targets so selected ones can be displayed
-        if (rate.targets) {
-            const firstTargetName = rate.targets.split(", ")[0]
+        if (rate.targets?.length) {
+            const firstTargetName = rate.targets[0]
             if (firstTargetName) {
                 setSearchTarget(firstTargetName)
             }
@@ -369,7 +369,7 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
             crop_group_id: rate.crop_group_id,
             weed_group: rate.weed_group,
             weed_group_id: rate.weed_group_id,
-            targets: rate.targets || "",
+            targets: [...(rate.targets || [])],
             target_ids: [...rate.target_ids],
             entries: rate.entries.map(entry => ({
                 dosage: { ...entry.dosage },
@@ -621,9 +621,9 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
                                                     <div className="text-sm text-gray-600 dark:text-gray-400 mt-1">
                                                         <span className="font-medium">Crops:</span> {rates.map(r => r.crop).join(", ")}
                                                     </div>
-                                                    {rates[0].targets && (
+                                                    {rates[0].targets?.length > 0 && (
                                                         <div className="text-sm text-gray-600 dark:text-gray-400">
-                                                            <span className="font-medium">Targets:</span> {rates[0].targets}
+                                                            <span className="font-medium">Targets:</span> {rates[0].targets.join(", ")}
                                                             {rates[0].weed_group && (
                                                                 <span className="ml-2 text-xs font-normal text-green-600 dark:text-green-400">({rates[0].weed_group})</span>
                                                             )}
@@ -670,15 +670,15 @@ export function DosageRatesSelect({ value = [], onChange }: DosageRatesSelectPro
                                                     <div className="font-medium text-gray-900 dark:text-white text-base">
                                                         {rate.crop}
                                                     </div>
-                                                    {rate.targets && (
+                                                    {rate.targets?.length > 0 && (
                                                         <div className="text-sm text-gray-600 dark:text-gray-400 mt-1">
-                                                            <span className="font-medium">Targets:</span> {rate.targets}
+                                                            <span className="font-medium">Targets:</span> {rate.targets.join(", ")}
                                                             {rate.weed_group && (
                                                                 <span className="ml-2 text-xs font-normal text-green-600 dark:text-green-400">({rate.weed_group})</span>
                                                             )}
                                                         </div>
                                                     )}
-                                                    {(!rate.targets && rate.target_ids?.length > 0) && (
+                                                    {(!rate.targets?.length && rate.target_ids?.length > 0) && (
                                                         <div className="text-sm text-gray-600 dark:text-gray-400 mt-1">
                                                             <span className="font-medium">Targets:</span> {rate.target_ids.length} selected
                                                         </div>

--- a/apps/admin-fnp/lib/schemas.ts
+++ b/apps/admin-fnp/lib/schemas.ts
@@ -486,7 +486,7 @@ export const AgroChemicalSchema = z.object({
     crop_group_id: z.string().optional(),
     weed_group: z.string().optional(),
     weed_group_id: z.string().optional(),
-    targets: z.string(),
+    targets: z.array(z.string()),
     target_ids: z.array(z.string()),
     entries: z.array(z.object({
       dosage: z.object({
@@ -522,7 +522,7 @@ export const DosageRateSchema = z.object({
   crop_group_id: z.string().optional(),
   weed_group: z.string().optional(),
   weed_group_id: z.string().optional(),
-  targets: z.string(),
+  targets: z.array(z.string()),
   target_ids: z.array(z.string()),
   entries: z.array(z.object({
     dosage: z.object({

--- a/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/[slug]/page.tsx
@@ -7,7 +7,7 @@ import Image from "next/image"
 import { Beaker, AlertTriangle } from "lucide-react"
 import Link from "next/link"
 import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
-import { capitalizeFirstLetter } from "@/lib/utilities"
+import { capitalizeFirstLetter, formatUnit } from "@/lib/utilities"
 
 interface GuidePageProps {
     params: Promise<{
@@ -159,7 +159,7 @@ export default function AgroChemicalGuidePage({ params }: GuidePageProps) {
                     <nav className="flex text-sm text-muted-foreground">
                         <Link href="/" className="hover:text-foreground">Home</Link>
                         <span className="mx-2">/</span>
-                        <Link href="/agrochemical-guides" className="hover:text-foreground">Guides</Link>
+                        <Link href="/agrochemical-guides/all" className="hover:text-foreground">Guides</Link>
                         <span className="mx-2">/</span>
                         <Link href={`/agrochemical-guides/${category}`} className="hover:text-foreground capitalize">{chemical.agrochemical_category?.name || category}</Link>
                         <span className="mx-2">/</span>
@@ -352,6 +352,25 @@ export default function AgroChemicalGuidePage({ params }: GuidePageProps) {
                                             }
                                         })
 
+                                        const renderTargetGrid = (targets: string[]) => (
+                                            <div className="grid grid-cols-2 gap-x-4 gap-y-0.5">
+                                                {targets.map((t: string, i: number) => {
+                                                    const parenIdx = t.indexOf(" (")
+                                                    const mainName = parenIdx > -1 ? t.slice(0, parenIdx) : t
+                                                    const sciName = parenIdx > -1 ? t.slice(parenIdx) : ""
+                                                    return (
+                                                        <div key={i} className="text-sm flex items-start gap-1">
+                                                            <span className="h-1 w-1 mt-1.5 rounded-full bg-muted-foreground/50 flex-shrink-0" />
+                                                            <span>
+                                                                <span className="text-foreground">{mainName}</span>
+                                                                {sciName && <span className="text-muted-foreground text-xs">{sciName}</span>}
+                                                            </span>
+                                                        </div>
+                                                    )
+                                                })}
+                                            </div>
+                                        )
+
                                         const renderEntryRows = (rate: any, rateKey: string, cropCell: React.ReactNode, targetCell: React.ReactNode) => {
                                             const entries = rate.entries || []
                                             const lastIdx = entries.length - 1
@@ -365,7 +384,7 @@ export default function AgroChemicalGuidePage({ params }: GuidePageProps) {
                                                     </td>
                                                     <td className="p-3 align-top">
                                                         <div className="font-bold text-blue-600 dark:text-blue-400 text-base">
-                                                            {entry.dosage.value} {entry.dosage.unit}
+                                                            {entry.dosage.value} {formatUnit(entry.dosage.unit)}
                                                         </div>
                                                         <div className="text-xs text-muted-foreground">per {entry.dosage.per}</div>
                                                     </td>
@@ -419,27 +438,51 @@ export default function AgroChemicalGuidePage({ params }: GuidePageProps) {
                                                             </div>
                                                         </div>
                                                     )
-                                                    const targetCell = (
-                                                        <div className="text-sm text-muted-foreground">{firstRate.targets}</div>
-                                                    )
+                                                    const targetCell = renderTargetGrid(firstRate.targets || [])
                                                     return renderEntryRows(firstRate, `group-${groupId}`, cropCell, targetCell)
                                                 })}
 
-                                                {/* Ungrouped rates - individual rows */}
-                                                {ungrouped.map((rate: any, rateIdx: number) => {
-                                                    const cropCell = (
-                                                        <div>
-                                                            <div className="font-semibold capitalize text-sm text-foreground">{rate.crop}</div>
-                                                            {rate.category_name && (
-                                                                <div className="text-xs text-muted-foreground mt-0.5">{rate.category_name}</div>
-                                                            )}
-                                                        </div>
-                                                    )
-                                                    const targetCell = (
-                                                        <div className="text-sm text-muted-foreground">{rate.targets}</div>
-                                                    )
-                                                    return renderEntryRows(rate, `rate-${rateIdx}`, cropCell, targetCell)
-                                                })}
+                                                {/* Ungrouped rates - group by matching targets */}
+                                                {(() => {
+                                                    const targetGrouped = new Map<string, any[]>()
+                                                    const targetOrder: string[] = []
+                                                    ungrouped.forEach((rate: any) => {
+                                                        const key = Array.isArray(rate.targets) ? rate.targets.slice().sort().join("|") : ""
+                                                        if (!targetGrouped.has(key)) {
+                                                            targetGrouped.set(key, [])
+                                                            targetOrder.push(key)
+                                                        }
+                                                        targetGrouped.get(key)!.push(rate)
+                                                    })
+                                                    return targetOrder.map((targetKey, tgIdx) => {
+                                                        const rates = targetGrouped.get(targetKey)!
+                                                        if (rates.length === 1) {
+                                                            const rate = rates[0]
+                                                            const cropCell = (
+                                                                <div>
+                                                                    <div className="font-semibold capitalize text-sm text-foreground">{rate.crop}</div>
+                                                                    {rate.category_name && (
+                                                                        <div className="text-xs text-muted-foreground mt-0.5">{rate.category_name}</div>
+                                                                    )}
+                                                                </div>
+                                                            )
+                                                            const targetCell = renderTargetGrid(rate.targets || [])
+                                                            return renderEntryRows(rate, `tg-${tgIdx}`, cropCell, targetCell)
+                                                        }
+                                                        return rates.map((rate: any, rateIdx: number) => {
+                                                            const cropCell = (
+                                                                <div>
+                                                                    <div className="font-semibold capitalize text-sm text-foreground">{rate.crop}</div>
+                                                                    {rate.category_name && (
+                                                                        <div className="text-xs text-muted-foreground mt-0.5">{rate.category_name}</div>
+                                                                    )}
+                                                                </div>
+                                                            )
+                                                            const targetCell = rateIdx === 0 ? renderTargetGrid(rate.targets || []) : null
+                                                            return renderEntryRows(rate, `tg-${tgIdx}-${rateIdx}`, cropCell, targetCell)
+                                                        })
+                                                    })
+                                                })()}
                                             </>
                                         )
                                     })()}

--- a/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/page.tsx
+++ b/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/page.tsx
@@ -54,7 +54,7 @@ export default function AgroChemicalCategoryPage({ params }: CategoryPageProps) 
                     <nav className="flex text-sm text-muted-foreground">
                         <Link href="/" className="hover:text-foreground">Home</Link>
                         <span className="mx-2">/</span>
-                        <Link href="/agrochemical-guides" className="hover:text-foreground">Guides</Link>
+                        <Link href="/agrochemical-guides/all" className="hover:text-foreground">Guides</Link>
                         <span className="mx-2">/</span>
                         <span className="text-foreground capitalize">{categoryName}</span>
                     </nav>

--- a/apps/client-fnp/lib/utilities.ts
+++ b/apps/client-fnp/lib/utilities.ts
@@ -87,3 +87,12 @@ export function ucFirst(str: string): string {
   if (!str) return ""
   return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase()
 }
+
+const unitLabels: Record<string, string> = {
+  "l": "litres",
+}
+
+export function formatUnit(unit?: string): string {
+  if (!unit) return ""
+  return unitLabels[unit.toLowerCase()] || unit
+}

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Summary
- Display targets as 2-column grid with styled name/scientific name
- Group rates with same targets to reduce repetition
- Change targets schema from string to array to match backend v4.3.0
- Display "l" unit as "litres" for readability
- Update breadcrumb guides link to /agrochemical-guides/all