### PR TITLE
Standardize payment terms and redesign client profile

### DIFF
--- a/apps/admin-fnp/components/structures/forms/clientEdit.tsx
+++ b/apps/admin-fnp/components/structures/forms/clientEdit.tsx
@@ -61,7 +61,7 @@ import {
   clientTypes,
   provinces,
   scales,
-  paymentTerms
+  paymentTermsOptions
 } from "@/components/structures/repository/data"
 
 interface EditFormProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -633,9 +633,9 @@ export function EditForm({ client }: EditFormProps) {
                             </SelectTrigger>
                           </FormControl>
                           <SelectContent>
-                            {paymentTerms.map((payment, index) => (
-                              <SelectItem key={index} value={payment}>
-                                {payment}
+                            {paymentTermsOptions.map((option) => (
+                              <SelectItem key={option.value} value={option.value}>
+                                {option.label}
                               </SelectItem>
                             ))}
                           </SelectContent>

--- a/apps/admin-fnp/components/structures/forms/createClient.tsx
+++ b/apps/admin-fnp/components/structures/forms/createClient.tsx
@@ -1,14 +1,21 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { zodResolver } from "@hookform/resolvers/zod"
-import { useMutation } from "@tanstack/react-query"
+import { useMutation, useQuery } from "@tanstack/react-query"
 import { isAxiosError } from "axios"
 import { useForm, useWatch } from "react-hook-form"
 
-import { createClient } from "@/lib/query"
-import { EditApplicationUser, EditApplicationUserSchema } from "@/lib/schemas"
+import { createClient, queryFarmProduceCategories, queryFarmProduceByCategory } from "@/lib/query"
+import {
+  EditApplicationUser,
+  EditApplicationUserSchema,
+  FarmProduceCategory,
+  FarmProduce,
+  FarmProduceCategoriesResponse,
+  FarmProduceResponse,
+} from "@/lib/schemas"
 import { cn, slug } from "@/lib/utilities"
 import { Badge } from "@/components/ui/badge"
 import { buttonVariants } from "@/components/ui/button"
@@ -49,11 +56,9 @@ import { toast } from "@/components/ui/use-toast"
 import { Icons } from "@/components/icons/lucide"
 import {
   clientTypes,
-  mainActivity,
   provinces,
   scales,
-  specializations,
-  paymentTerms
+  paymentTermsOptions
 } from "@/components/structures/repository/data"
 
 interface CreateFormProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -72,6 +77,9 @@ export function CreateForm({ client }: CreateFormProps) {
       phone: client?.phone,
       type: client?.type,
       scale: client?.scale,
+      primary_category_id: client?.primary_category_id,
+      main_produce_id: client?.main_produce_id,
+      other_produce_ids: client?.other_produce_ids || [],
       branches: client?.branches,
       short_description: client?.short_description,
       payment_terms: client?.payment_terms
@@ -79,6 +87,68 @@ export function CreateForm({ client }: CreateFormProps) {
     resolver: zodResolver(EditApplicationUserSchema),
   })
 
+  // Fetch farm produce categories
+  const { data: categoriesData } = useQuery({
+    queryKey: ["farm-produce-categories"],
+    queryFn: async () => {
+      const response = await queryFarmProduceCategories()
+      return response.data as FarmProduceCategoriesResponse
+    },
+  })
+
+  const categories = categoriesData?.data || []
+
+  const selectedOtherProduceIds = useWatch({
+    name: "other_produce_ids",
+    control: form.control,
+  })
+
+  const selectedMainProduceId = useWatch({
+    name: "main_produce_id",
+    control: form.control,
+  })
+
+  const selectedCategoryId = form.watch("primary_category_id")
+
+  // Find the selected category to get its slug
+  const selectedCategory = categories.find(cat => cat.id === selectedCategoryId)
+
+  // Fetch produce for the selected category dynamically
+  const { data: produceData } = useQuery({
+    queryKey: ["farm-produce-by-category", selectedCategory?.slug],
+    queryFn: async () => {
+      const response = await queryFarmProduceByCategory(selectedCategory!.slug)
+      return response.data as FarmProduceResponse
+    },
+    enabled: !!selectedCategory?.slug,
+  })
+
+  const produceItems = produceData?.data || []
+
+  // For "Other Produce", fetch all produce grouped by category
+  const [allProduceByCategory, setAllProduceByCategory] = useState<Record<string, FarmProduce[]>>({})
+
+  useEffect(() => {
+    const fetchAllProduce = async () => {
+      const produceByCategory: Record<string, FarmProduce[]> = {}
+
+      for (const category of categories) {
+        try {
+          const response = await queryFarmProduceByCategory(category.slug)
+          const data = response.data as FarmProduceResponse
+          produceByCategory[category.id] = data.data
+        } catch (error) {
+          console.error(`Failed to fetch produce for ${category.name}`, error)
+        }
+      }
+
+      setAllProduceByCategory(produceByCategory)
+    }
+
+    if (categories.length > 0) {
+      fetchAllProduce()
+    }
+  }, [categories])
 
   const [open, setOpen] = useState(false)
 
@@ -187,6 +257,148 @@ export function CreateForm({ client }: CreateFormProps) {
               </FormItem>
             )}
           />
+          <FormField
+            control={form.control}
+            name="primary_category_id"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Category</FormLabel>
+                <Select onValueChange={field.onChange} defaultValue={field.value}>
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select category" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {categories.map((category) => (
+                      <SelectItem key={category.id} value={category.id}>
+                        {category.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormDescription></FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="main_produce_id"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Main Produce</FormLabel>
+                <Select
+                  onValueChange={field.onChange}
+                  defaultValue={field.value}
+                  disabled={!selectedCategoryId}
+                >
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder={selectedCategoryId ? "Select produce" : "Select category first"} />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {produceItems?.map((produce: FarmProduce) => (
+                      <SelectItem key={produce.id} value={produce.id}>
+                        {produce.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormDescription></FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <div className="col-span-2">
+            <FormField
+              control={form.control}
+              name="other_produce_ids"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Other Produce</FormLabel>
+                  <FormControl>
+                    <Popover open={open} onOpenChange={setOpen}>
+                      <PopoverTrigger asChild>
+                        <div className="min-h-[2.5rem] rounded-md border px-3 py-2 text-sm cursor-pointer">
+                          <div className="flex flex-wrap gap-1">
+                            {selectedOtherProduceIds && selectedOtherProduceIds.length > 0
+                              ? selectedOtherProduceIds.map((produceId: string) => {
+                                let produceName = ""
+                                for (const categoryID in allProduceByCategory) {
+                                  const produce = allProduceByCategory[categoryID].find(p => p.id === produceId)
+                                  if (produce) {
+                                    produceName = produce.name
+                                    break
+                                  }
+                                }
+
+                                if (produceName) {
+                                  return (
+                                    <Badge
+                                      key={produceId}
+                                      className="text-xs bg-green-50 text-green-700 ring-1 ring-inset ring-green-600/20 hover:bg-green-100 hover:text-green-800"
+                                    >
+                                      {produceName}
+                                    </Badge>
+                                  )
+                                }
+                                return null
+                              })
+                              : <span className="text-gray-400">Select additional produce...</span>}
+                          </div>
+                        </div>
+                      </PopoverTrigger>
+                      <PopoverContent className="w-[320px] p-0">
+                        <Command>
+                          <CommandInput placeholder="Search produce..." />
+                          <CommandList>
+                            <CommandEmpty>No results found.</CommandEmpty>
+                            {categories.map((category) => {
+                              const categoryProduce = allProduceByCategory[category.id] || []
+
+                              if (categoryProduce.length === 0) return null
+
+                              return (
+                                <CommandGroup key={category.id} heading={category.name}>
+                                  {categoryProduce.map((produce) => {
+                                    if (selectedMainProduceId !== produce.id) {
+                                      return (
+                                        <CommandItem
+                                          key={produce.id}
+                                          onSelect={() => {
+                                            const currentIds = selectedOtherProduceIds || []
+                                            if (!currentIds.includes(produce.id)) {
+                                              form.setValue("other_produce_ids", [...currentIds, produce.id])
+                                            } else {
+                                              form.setValue("other_produce_ids", currentIds.filter((id: string) => id !== produce.id))
+                                            }
+                                          }}
+                                        >
+                                          {selectedOtherProduceIds?.includes(produce.id) && (
+                                            <Icons.check className="w-4 h-4 mr-2" />
+                                          )}
+                                          <span>{produce.name}</span>
+                                        </CommandItem>
+                                      )
+                                    }
+                                    return null
+                                  })}
+                                </CommandGroup>
+                              )
+                            })}
+                          </CommandList>
+                        </Command>
+                      </PopoverContent>
+                    </Popover>
+                  </FormControl>
+                  <FormDescription>Select any additional produce this client works with.</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
           <FormField
             control={form.control}
             name="address"
@@ -340,17 +552,15 @@ export function CreateForm({ client }: CreateFormProps) {
                 >
                   <FormControl>
                     <SelectTrigger>
-                      <SelectValue placeholder="Select Province..." />
+                      <SelectValue placeholder="Select payment terms..." />
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent className="overflow-visible max-h-44">
-                    {paymentTerms.map((payment: string, index: number) => {
-                      return (
-                        <SelectItem key={index} value={payment}>
-                          {payment}
-                        </SelectItem>
-                      )
-                    })}
+                    {paymentTermsOptions.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
                 <FormDescription></FormDescription>

--- a/apps/admin-fnp/components/structures/repository/data.tsx
+++ b/apps/admin-fnp/components/structures/repository/data.tsx
@@ -1,5 +1,3 @@
-import { string } from "zod"
-
 export const provinces = [
   "bulawayo",
   "harare",
@@ -13,49 +11,9 @@ export const provinces = [
   "midlands",
 ]
 
-export const specializations = [
-  "horticulture",
-  "dairy",
-  "aquaculture",
-  "plantation",
-  "livestock",
-  "grain",
-  "manufacturing",
-  "hospitality",
-  "poultry",
-  "pastures",
-]
-
 export const clientTypes = ["farmer", "buyer", "exporter", "importer"]
 
 export const scales = ["small", "medium", "large"]
-
-export const mainActivity: Record<string, string[]> = {
-  horticulture: ["tomato", "onion", "lettuce", "potato", "sweet potato"],
-  livestock: ["pork", "beef", "cattle", "goat", "sheep", "pig"],
-  dairy: ["milk"],
-  aquaculture: ["bream", "kapenta"],
-  grain: ["maize", "soya bean", "wheat", "groundnut", "sugar bean"],
-  plantation: [
-    "orange",
-    "apple",
-    "peacan nut",
-    "banana",
-    "mango",
-    "avocado",
-    "pineapple",
-    "blueberry",
-    "plum",
-    "melon",
-    "grape",
-    "passion fruit",
-    "granadilla",
-  ],
-  manufacturing: ["food processing"],
-  hospitality: ["catering"],
-  poultry: ["chicken", "turkey"],
-  pastures: ["katambora"],
-}
 
 export const units = ["kg"]
 
@@ -64,4 +22,23 @@ export const pricingBasis = [
   "CDM - Cold Dressed Mass"
 ]
 
-export const paymentTerms = ["Next Day", "2 weeks", "30 Days", "60 Days"]
+export const paymentTermsOptions = [
+  { value: "cod", label: "Cash on Delivery" },
+  { value: "cbd", label: "Cash Before Delivery" },
+  { value: "7-days", label: "7 Days" },
+  { value: "14-days", label: "14 Days" },
+  { value: "30-days", label: "30 Days" },
+  { value: "60-days", label: "60 Days" },
+  { value: "90-days", label: "90 Days" },
+  { value: "negotiable", label: "Negotiable" },
+  { value: "not-provided", label: "Not Provided" },
+]
+
+const paymentTermsMap: Record<string, string> = Object.fromEntries(
+  paymentTermsOptions.map((o) => [o.value, o.label])
+)
+
+export function paymentTermsLabel(slug: string): string {
+  if (!slug) return "Not Provided"
+  return paymentTermsMap[slug] || slug
+}

--- a/apps/admin-fnp/components/structures/tables/clients.tsx
+++ b/apps/admin-fnp/components/structures/tables/clients.tsx
@@ -1,13 +1,13 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useMemo } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { PaginationState } from "@tanstack/react-table"
 import { isAxiosError } from "axios"
 import { useDebounce } from "use-debounce"
 
-import { queryUsers } from "@/lib/query"
-import { ApplicationUser } from "@/lib/schemas"
+import { queryUsers, queryFarmProduceCategories, queryAllFarmProduce } from "@/lib/query"
+import { ApplicationUser, FarmProduceCategoriesResponse, FarmProduceResponse } from "@/lib/schemas"
 import { ToastAction } from "@/components/ui/toast"
 import { toast } from "@/components/ui/use-toast"
 import { Placeholder } from "@/components/state/placeholder"
@@ -18,6 +18,8 @@ import { DataTableFacetedFilter } from "@/components/structures/filters/data-tab
 export function ClientsTable() {
   const [search, setSearch] = useState("")
   const [typeFilter, setTypeFilter] = useState<Set<string>>(new Set())
+  const [categoryFilter, setCategoryFilter] = useState<Set<string>>(new Set())
+  const [produceFilter, setProduceFilter] = useState<Set<string>>(new Set())
 
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
@@ -26,18 +28,49 @@ export function ClientsTable() {
 
   const [debouncedSearchQuery] = useDebounce(search, 1000)
 
+  // Fetch categories and produce for filter options
+  const { data: categoriesData } = useQuery({
+    queryKey: ["filter-categories"],
+    queryFn: () => queryFarmProduceCategories(),
+    refetchOnWindowFocus: false,
+  })
+
+  const { data: produceData } = useQuery({
+    queryKey: ["filter-produce"],
+    queryFn: () => queryAllFarmProduce(),
+    refetchOnWindowFocus: false,
+  })
+
+  const categoryOptions = useMemo(() => {
+    const categories = (categoriesData?.data as FarmProduceCategoriesResponse)?.data || []
+    return categories.map((c) => ({ label: c.name, value: c.slug }))
+  }, [categoriesData])
+
+  const produceOptions = useMemo(() => {
+    const produce = (produceData?.data as FarmProduceResponse)?.data || []
+    return produce.map((p) => ({ label: p.name, value: p.slug }))
+  }, [produceData])
+
   // Reset to page 1 when filters change
   useEffect(() => {
     setPagination((prev) => ({ ...prev, pageIndex: 0 }))
-  }, [typeFilter, debouncedSearchQuery])
+  }, [typeFilter, categoryFilter, produceFilter, debouncedSearchQuery])
 
   const { isError, isLoading, isFetching, refetch, data} = useQuery({
-    queryKey: ["dashboard-clients", { p: pagination.pageIndex + 1, search: debouncedSearchQuery, type: Array.from(typeFilter) }],
+    queryKey: ["dashboard-clients", {
+      p: pagination.pageIndex + 1,
+      search: debouncedSearchQuery,
+      type: Array.from(typeFilter),
+      category: Array.from(categoryFilter),
+      produce: Array.from(produceFilter),
+    }],
     queryFn: () =>
       queryUsers({
         p: pagination.pageIndex + 1,
         search: debouncedSearchQuery,
-        type: Array.from(typeFilter)
+        type: Array.from(typeFilter),
+        category: Array.from(categoryFilter),
+        produce: Array.from(produceFilter),
       }),
     refetchOnWindowFocus: false
   })
@@ -96,12 +129,26 @@ export function ClientsTable() {
       search={search}
       setSearch={setSearch}
       filters={
-        <DataTableFacetedFilter
-          title="Type"
-          options={userTypeOptions}
-          selectedValues={typeFilter}
-          onValueChange={setTypeFilter}
-        />
+        <>
+          <DataTableFacetedFilter
+            title="Type"
+            options={userTypeOptions}
+            selectedValues={typeFilter}
+            onValueChange={setTypeFilter}
+          />
+          <DataTableFacetedFilter
+            title="Category"
+            options={categoryOptions}
+            selectedValues={categoryFilter}
+            onValueChange={setCategoryFilter}
+          />
+          <DataTableFacetedFilter
+            title="Main Produce"
+            options={produceOptions}
+            selectedValues={produceFilter}
+            onValueChange={setProduceFilter}
+          />
+        </>
       }
     />
   )

--- a/apps/admin-fnp/lib/query.ts
+++ b/apps/admin-fnp/lib/query.ts
@@ -44,6 +44,8 @@ type pagination = {
   p?: number
   search?: string
   type?: string[]
+  category?: string[]
+  produce?: string[]
 }
 
 export function queryUsers(pagination?: pagination) {
@@ -59,6 +61,14 @@ export function queryUsers(pagination?: pagination) {
 
   if (pagination?.type !== undefined && pagination.type.length > 0) {
     params.append('type', pagination.type.join(','))
+  }
+
+  if (pagination?.category !== undefined && pagination.category.length > 0) {
+    params.append('category', pagination.category.join(','))
+  }
+
+  if (pagination?.produce !== undefined && pagination.produce.length > 0) {
+    params.append('produce', pagination.produce.join(','))
   }
 
   const queryString = params.toString()
@@ -431,6 +441,11 @@ export function queryFarmProduce(pagination?: pagination) {
     url = `${baseUrl}/farmproduce?search=${pagination.search}`
   }
 
+  return api.get(url)
+}
+
+export function queryAllFarmProduce() {
+  const url = `${baseUrl}/farmproduce/all`
   return api.get(url)
 }
 

--- a/apps/client-fnp/app/(landing)/buyers/[product]/page.tsx
+++ b/apps/client-fnp/app/(landing)/buyers/[product]/page.tsx
@@ -3,7 +3,10 @@ import { Buyers } from "@/components/layouts/buyers"
 import { retrieveUser } from "@/lib/actions"
 import type { Metadata, ResolvingMetadata } from "next";
 import { AppURL, getBuyerSeo } from "@/lib/schemas";
-import { FilterSidebar } from "@/components/generic/filterSidebar"
+import { ClientFilterSidebar } from "@/components/generic/clientFilterSidebar"
+import { ActionsSidebar } from "@/components/generic/actions-sidebar"
+import { CrossSellBanner } from "@/components/monetization/cross-sell-banner"
+import { RelatedMarkets } from "@/components/monetization/related-markets"
 
 
 type Props = {
@@ -70,16 +73,27 @@ export default async function BuyersProductPage({ params }: BuyerProductPageProp
         <p className="text-muted-foreground mb-6">
           Find verified {product} buyers across Zimbabwe. Sell your {product} directly at competitive market prices.
         </p>
-        <div className="lg:flex lg:space-x-10">
 
-          <div className="hidden lg:block lg:w-44 relative">
-            <FilterSidebar />
+        <CrossSellBanner product={product} context="buyer" />
+
+        <div className="lg:flex lg:space-x-10">
+          <div className="hidden lg:block lg:w-64 relative">
+            <ClientFilterSidebar type="buyers" hideProduce hideCategory product={product} />
           </div>
 
-          <div className="lg:w-2/3">
+          <div className="lg:flex-1">
+            <div className="lg:hidden mb-4">
+              <ClientFilterSidebar type="buyers" hideProduce hideCategory product={product} />
+            </div>
             <Buyers user={user} queryBy={product} />
           </div>
+
+          <div className="hidden lg:block lg:w-80 relative">
+            <ActionsSidebar type="buyers" product={product} showPremiumCTA={false} />
+          </div>
         </div>
+
+        <RelatedMarkets currentProduct={product} context="buyer" />
       </div>
     </main>
   )

--- a/apps/client-fnp/app/(landing)/buyers/page.tsx
+++ b/apps/client-fnp/app/(landing)/buyers/page.tsx
@@ -38,6 +38,9 @@ export default async function BuyersPage() {
                     </div>
 
                     <div className="lg:flex-1">
+                        <div className="lg:hidden mb-4">
+                            <ClientFilterSidebar type="buyers" />
+                        </div>
                         <Buyers user={user} />
                     </div>
 

--- a/apps/client-fnp/app/(landing)/farmers/[product]/page.tsx
+++ b/apps/client-fnp/app/(landing)/farmers/[product]/page.tsx
@@ -3,7 +3,10 @@ import { Farmers } from "@/components/layouts/farmers"
 import { retrieveUser } from "@/lib/actions"
 import type { Metadata, ResolvingMetadata } from "next";
 import {AppURL, getFarmerSeo} from "@/lib/schemas";
-import { FilterSidebar } from "@/components/generic/filterSidebar"
+import { ClientFilterSidebar } from "@/components/generic/clientFilterSidebar"
+import { ActionsSidebar } from "@/components/generic/actions-sidebar"
+import { CrossSellBanner } from "@/components/monetization/cross-sell-banner"
+import { RelatedMarkets } from "@/components/monetization/related-markets"
 
 
 type Props = {
@@ -70,16 +73,27 @@ export default async function FarmersProductPage({ params }: FarmerProductPagePr
         <p className="text-muted-foreground mb-6">
           Buy quality {product} directly from trusted farmers across Zimbabwe at fair farm-gate prices.
         </p>
-        <div className="lg:flex lg:space-x-10">
 
-          <div className="hidden lg:block lg:w-44 relative">
-            <FilterSidebar />
+        <CrossSellBanner product={product} context="farmer" />
+
+        <div className="lg:flex lg:space-x-10">
+          <div className="hidden lg:block lg:w-64 relative">
+            <ClientFilterSidebar type="farmers" hideProduce hideCategory product={product} />
           </div>
 
-          <div className="lg:w-2/3">
+          <div className="lg:flex-1">
+            <div className="lg:hidden mb-4">
+              <ClientFilterSidebar type="farmers" hideProduce hideCategory product={product} />
+            </div>
             <Farmers user={user} queryBy={product} />
           </div>
+
+          <div className="hidden lg:block lg:w-80 relative">
+            <ActionsSidebar type="farmers" product={product} showPremiumCTA={false} />
+          </div>
         </div>
+
+        <RelatedMarkets currentProduct={product} context="farmer" />
       </div>
     </main>
   )

--- a/apps/client-fnp/app/(landing)/farmers/page.tsx
+++ b/apps/client-fnp/app/(landing)/farmers/page.tsx
@@ -38,6 +38,9 @@ export default async function FarmersPage() {
           </div>
 
           <div className="lg:flex-1">
+            <div className="lg:hidden mb-4">
+              <ClientFilterSidebar type="farmers" />
+            </div>
             <Farmers user={user} />
           </div>
 

--- a/apps/client-fnp/app/(landing)/prices/page.tsx
+++ b/apps/client-fnp/app/(landing)/prices/page.tsx
@@ -1,5 +1,6 @@
 import { FilterSidebar } from "@/components/generic/filterSidebar"
 import { PriceCardsView } from "@/components/structures/price-cards-view"
+import { ActionsSidebar } from "@/components/generic/actions-sidebar"
 
 export const metadata = {
   title: 'Agricultural Produce Prices – Market Rates | farmnport.com',
@@ -19,27 +20,29 @@ export default async function PricesPage() {
   return (
     <main>
       <div className="mx-auto max-w-7xl px-6 lg:px-8 min-h-[70lvh]">
+        <h1 className="text-3xl font-bold font-heading pt-8 pb-4">
+          Producer Price Lists
+        </h1>
+        <p className="text-muted-foreground mb-6">
+          Browse and compare current market prices from verified buyers and producers across Zimbabwe.
+        </p>
+
         <div className="lg:flex lg:space-x-10">
-          <div className="hidden lg:block lg:w-44 relative">
+          <div className="hidden lg:block lg:w-64 relative">
             <FilterSidebar />
           </div>
 
-          <div className="flex-1 py-8">
-            <div className="mb-8">
-              <h1 className="text-4xl font-bold font-heading">
-                Producer Price Lists
-              </h1>
-              <p className="text-lg text-muted-foreground mt-2">
-                Browse and compare current market prices from verified buyers and producers across Zimbabwe.
-              </p>
-            </div>
-
+          <div className="lg:flex-1">
             {/* Mobile filter button */}
             <div className="lg:hidden mb-6">
               <FilterSidebar />
             </div>
 
             <PriceCardsView />
+          </div>
+
+          <div className="hidden lg:block lg:w-56 shrink-0 relative">
+            <ActionsSidebar type="buyers" />
           </div>
         </div>
       </div>

--- a/apps/client-fnp/components/generic/actions-sidebar.tsx
+++ b/apps/client-fnp/components/generic/actions-sidebar.tsx
@@ -1,28 +1,128 @@
 "use client"
 
 import Link from "next/link"
+import { useSearchParams } from "next/navigation"
+import { sendGTMEvent } from "@next/third-parties/google"
 
 interface ActionsSidebarProps {
   type?: "buyers" | "farmers"
+  product?: string
+  showPremiumCTA?: boolean
 }
 
-export function ActionsSidebar({type = "buyers"}: ActionsSidebarProps) {
+type ActionItem = {
+  title: string
+  description: string
+  cta: string
+  href: string
+  event: string
+  bg: string
+  border: string
+  button: string
+}
+
+const productActions: Record<string, ActionItem[]> = {
+  chicken: [
+    {
+      title: "Order New Chicks Online",
+      description: "Source day-old chicks and point-of-lay hens from trusted hatcheries across Zimbabwe.",
+      cta: "Browse Chick Suppliers",
+      href: "/buyers/chicken",
+      event: "ActionOrderChicks",
+      bg: "bg-emerald-50 dark:bg-emerald-950/30",
+      border: "border-emerald-200 dark:border-emerald-800/50",
+      button: "bg-emerald-600 hover:bg-emerald-700",
+    },
+    {
+      title: "Poultry Health Guides",
+      description: "Vaccines, antibiotics & nutrition guides to keep your flock healthy and productive.",
+      cta: "View Guides",
+      href: "/agrochemical-guides/all",
+      event: "ActionPoultryGuides",
+      bg: "bg-sky-50 dark:bg-sky-950/30",
+      border: "border-sky-200 dark:border-sky-800/50",
+      button: "bg-sky-600 hover:bg-sky-700",
+    },
+  ],
+  cattle: [
+    {
+      title: "Cattle Health Products",
+      description: "Browse dips, vaccines and supplements for your herd.",
+      cta: "View Products",
+      href: "/agrochemical-guides/all",
+      event: "ActionCattleHealth",
+      bg: "bg-amber-50 dark:bg-amber-950/30",
+      border: "border-amber-200 dark:border-amber-800/50",
+      button: "bg-amber-600 hover:bg-amber-700",
+    },
+  ],
+  pork: [
+    {
+      title: "Pig Health Guides",
+      description: "Deworming, vaccines and feed supplements for pig farming.",
+      cta: "View Guides",
+      href: "/agrochemical-guides/all",
+      event: "ActionPigHealth",
+      bg: "bg-rose-50 dark:bg-rose-950/30",
+      border: "border-rose-200 dark:border-rose-800/50",
+      button: "bg-rose-600 hover:bg-rose-700",
+    },
+  ],
+}
+
+const categoryProducts: Record<string, string[]> = {
+  "meat & poultry": ["chicken", "cattle", "pork"],
+}
+
+export function ActionsSidebar({type = "buyers", product, showPremiumCTA = true}: ActionsSidebarProps) {
+  const searchParams = useSearchParams()
+
+  let actions: ActionItem[] | undefined
+
+  if (product) {
+    actions = productActions[product.toLowerCase()]
+  } else {
+    const category = searchParams.get("category")
+    if (category) {
+      const products = categoryProducts[category.toLowerCase()]
+      if (products) {
+        actions = products.flatMap(p => productActions[p] || []).slice(0, 2)
+      }
+    }
+  }
 
   return (
     <aside className="mt-[21px] space-y-6">
-      {/* Join Waiting List */}
-      <div className="bg-primary/5 border-2 border-primary/20 rounded-lg p-6">
-        <h3 className="text-lg font-semibold mb-2">Unlock Premium Features</h3>
-        <p className="text-sm text-muted-foreground mb-4">
-          Get direct contact information and connect with {type === "buyers" ? "buyers" : "sellers"} instantly.
-        </p>
-        <Link
-          href="/waiting-list-paying"
-          className="block w-full bg-primary text-primary-foreground px-4 py-2.5 rounded-lg font-medium hover:bg-primary/90 transition-colors text-sm text-center"
-        >
-          Join Waiting List
-        </Link>
-      </div>
+      {actions?.map((action) => (
+        <div key={action.event} className={`${action.bg} border-2 ${action.border} rounded-lg p-6`}>
+          <h3 className="text-lg font-semibold mb-2">{action.title}</h3>
+          <p className="text-sm text-muted-foreground mb-4">
+            {action.description}
+          </p>
+          <Link
+            href={action.href}
+            className={`block w-full ${action.button} text-white px-4 py-2.5 rounded-lg font-medium transition-colors text-sm text-center`}
+            onClick={() => sendGTMEvent({ event: "click", value: action.event })}
+          >
+            {action.cta}
+          </Link>
+        </div>
+      ))}
+
+      {showPremiumCTA && (
+        <div className="bg-primary/5 border-2 border-primary/20 rounded-lg p-6">
+          <h3 className="text-lg font-semibold mb-2">Unlock Premium Features</h3>
+          <p className="text-sm text-muted-foreground mb-4">
+            Get direct contact information and connect with {type === "buyers" ? "buyers" : "sellers"} instantly.
+          </p>
+          <Link
+            href="/waiting-list-paying"
+            className="block w-full bg-primary text-primary-foreground px-4 py-2.5 rounded-lg font-medium hover:bg-primary/90 transition-colors text-sm text-center"
+          >
+            Join Waiting List
+          </Link>
+        </div>
+      )}
     </aside>
   )
 }

--- a/apps/client-fnp/components/generic/clientFilterSidebar.tsx
+++ b/apps/client-fnp/components/generic/clientFilterSidebar.tsx
@@ -4,15 +4,18 @@ import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { capitalizeFirstLetter } from "@/lib/utilities"
+
 import { Checkbox } from "@/components/ui/checkbox"
 import { useQueryStates, parseAsArrayOf, parseAsString } from "nuqs"
 import { Filter, X, Search } from "lucide-react"
 import { useMediaQuery } from "@/hooks/use-media-query"
 import { useQuery } from "@tanstack/react-query"
 import { useState, useMemo } from "react"
-import { queryClientFilterAggregates } from "@/lib/query"
+import { queryClientFilterAggregates, queryPricesByProduce } from "@/lib/query"
+import { centsToDollars } from "@/lib/utilities"
 import { sendGTMEvent } from "@next/third-parties/google"
+import { paymentTermsLabel } from "@/components/structures/repository/data"
+import Link from "next/link"
 
 interface FilterItem {
   _id: string
@@ -24,6 +27,8 @@ interface ClientFilterAggregates {
   provinces: FilterItem[]
   produce: FilterItem[]
   categories: FilterItem[]
+  payment_terms: FilterItem[]
+  pricing: FilterItem[]
 }
 
 function SearchableCheckboxList({
@@ -78,8 +83,8 @@ function SearchableCheckboxList({
           <p className="text-sm text-muted-foreground py-2">No results found</p>
         ) : (
           filteredItems.map((item) => {
-            const displayName = item.name || item._id
-            const value = displayName.toLowerCase()
+            const displayName = item.name || item._id || ""
+            const value = (item._id || "").toLowerCase()
             const isChecked = selectedItems.includes(value)
 
             return (
@@ -94,8 +99,10 @@ function SearchableCheckboxList({
                   htmlFor={`${filterKey}-${value}`}
                   className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer flex-1 flex items-center justify-between"
                 >
-                  <span>{capitalizeFirstLetter(displayName)}</span>
-                  <span className="text-xs text-muted-foreground ml-2">({item.count})</span>
+                  <span className="capitalize">{displayName}</span>
+                  {item.count > 0 && (
+                    <span className="text-xs text-muted-foreground ml-2">({item.count})</span>
+                  )}
                 </label>
               </div>
             )
@@ -108,15 +115,23 @@ function SearchableCheckboxList({
 
 function FilterContent({
   onClearAll,
-  type
+  type,
+  hideProduce,
+  hideCategory,
+  product
 }: {
   onClearAll: () => void
   type: 'buyers' | 'farmers'
+  hideProduce?: boolean
+  hideCategory?: boolean
+  product?: string
 }) {
   const [queryState, setQueryState] = useQueryStates({
     province: parseAsArrayOf(parseAsString),
     produce: parseAsArrayOf(parseAsString),
     category: parseAsArrayOf(parseAsString),
+    payment_terms: parseAsArrayOf(parseAsString),
+    pricing: parseAsArrayOf(parseAsString),
   })
 
   // Fetch aggregate data for clients
@@ -140,18 +155,85 @@ function FilterContent({
     return aggregateData?.categories || []
   }, [aggregateData])
 
+  const paymentTermsItems = useMemo(() => {
+    return (aggregateData?.payment_terms || []).map((item) => ({
+      ...item,
+      name: paymentTermsLabel(item._id),
+    }))
+  }, [aggregateData])
+
+  const pricingItems = useMemo(() => {
+    return aggregateData?.pricing || []
+  }, [aggregateData])
+
+  // Fetch prices for the product if specified
+  const { data: priceData, isLoading: isLoadingPrices } = useQuery({
+    queryKey: ["prices-by-produce", product],
+    queryFn: async () => {
+      const response = await queryPricesByProduce(product!)
+      return response.data
+    },
+    enabled: !!product,
+  })
+
+  const latestPrices = useMemo(() => {
+    if (!priceData?.data) return []
+    // Group by client, take latest per client, limit to 5
+    const byClient = new Map<string, { client_name: string; delivered: number; collected: number }>()
+    for (const rel of priceData.data) {
+      if (byClient.has(rel.client_id)) continue
+      const pd = rel.price_data
+      if (!pd) continue
+
+      // Find the first grade with pricing data (price_data is a struct like ChickenPrice/BeefPrice with nested grade fields)
+      let delivered = 0
+      let collected = 0
+      if (pd.pricing) {
+        // Direct pricing (simple structure)
+        delivered = pd.pricing.delivered || 0
+        collected = pd.pricing.collected || 0
+      } else {
+        // Nested grades - scan all fields for the first one with pricing
+        for (const key of Object.keys(pd)) {
+          const grade = pd[key]
+          if (grade?.pricing?.delivered > 0 || grade?.pricing?.collected > 0) {
+            delivered = grade.pricing.delivered || 0
+            collected = grade.pricing.collected || 0
+            break
+          }
+        }
+      }
+
+      if (delivered > 0 || collected > 0) {
+        byClient.set(rel.client_id, { client_name: rel.client_name, delivered, collected })
+      }
+      if (byClient.size >= 5) break
+    }
+    return Array.from(byClient.values())
+  }, [priceData])
+
+  const singleSelectKeys = ["pricing", "payment_terms"]
+
   const handleToggle = (filterKey: string, value: string) => {
     const currentValues = queryState[filterKey as keyof typeof queryState] || []
     const isAdding = !currentValues.includes(value)
-    const newValues = isAdding
-      ? [...currentValues, value]
-      : currentValues.filter(v => v !== value)
+
+    let newValues: string[]
+    if (singleSelectKeys.includes(filterKey)) {
+      newValues = isAdding ? [value] : []
+    } else {
+      newValues = isAdding
+        ? [...currentValues, value]
+        : currentValues.filter(v => v !== value)
+    }
 
     // Send GTM event
     const filterTypeMap: Record<string, string> = {
       'province': 'Province',
       'produce': 'Produce',
-      'category': 'Category'
+      'category': 'Category',
+      'payment_terms': 'PaymentTerms',
+      'pricing': 'Pricing'
     }
     const filterType = filterTypeMap[filterKey] || filterKey
     const action = isAdding ? 'Add' : 'Remove'
@@ -167,17 +249,29 @@ function FilterContent({
 
   const filterSections = [
     {
-      name: "Category",
-      key: "category",
-      items: categoryItems,
+      name: "Payment Terms",
+      key: "payment_terms",
+      items: paymentTermsItems,
       isLoading: isLoadingAggregates
     },
     {
+      name: "Pricing",
+      key: "pricing",
+      items: pricingItems,
+      isLoading: isLoadingAggregates
+    },
+    ...(!hideProduce ? [{
       name: "Produce",
       key: "produce",
       items: produceItems,
       isLoading: isLoadingAggregates
-    },
+    }] : []),
+    ...(!hideCategory ? [{
+      name: "Category",
+      key: "category",
+      items: categoryItems,
+      isLoading: isLoadingAggregates
+    }] : []),
     {
       name: "Province",
       key: "province",
@@ -205,7 +299,7 @@ function FilterContent({
         </div>
       )}
 
-      <Accordion type="multiple" className="w-full flex-1" defaultValue={["Category", "Produce"]}>
+      <Accordion type="multiple" className="w-full flex-1" defaultValue={["Payment Terms"]}>
         {filterSections.map((section) => {
           const selectedFilters = queryState[section.key as keyof typeof queryState] || []
 
@@ -235,16 +329,45 @@ function FilterContent({
           )
         })}
       </Accordion>
+
+      {product && latestPrices.length > 0 && (
+        <div className="mt-4 pt-4 border-t">
+          <h4 className="text-sm font-semibold mb-3 capitalize">{product} Prices</h4>
+          <div className="space-y-2">
+            {latestPrices.map((price) => (
+              <div key={price.client_name} className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground truncate mr-2">{price.client_name}</span>
+                <span className="font-medium whitespace-nowrap">
+                  {price.delivered > 0 ? centsToDollars(price.delivered) : centsToDollars(price.collected)}
+                </span>
+              </div>
+            ))}
+          </div>
+          <Link
+            href={`/prices?produce=${product}`}
+            className="text-xs text-primary hover:underline mt-2 block"
+          >
+            View all prices
+          </Link>
+        </div>
+      )}
+      {product && isLoadingPrices && (
+        <div className="mt-4 pt-4 border-t">
+          <p className="text-sm text-muted-foreground">Loading prices...</p>
+        </div>
+      )}
     </div>
   )
 }
 
-export function ClientFilterSidebar({ type }: { type: 'buyers' | 'farmers' }) {
+export function ClientFilterSidebar({ type, hideProduce, hideCategory, product }: { type: 'buyers' | 'farmers', hideProduce?: boolean, hideCategory?: boolean, product?: string }) {
   const isDesktop = useMediaQuery("(min-width: 1024px)")
   const [, setQueryState] = useQueryStates({
     province: parseAsArrayOf(parseAsString),
     produce: parseAsArrayOf(parseAsString),
     category: parseAsArrayOf(parseAsString),
+    payment_terms: parseAsArrayOf(parseAsString),
+    pricing: parseAsArrayOf(parseAsString),
   })
 
   const handleClearAll = () => {
@@ -252,6 +375,8 @@ export function ClientFilterSidebar({ type }: { type: 'buyers' | 'farmers' }) {
       province: null,
       produce: null,
       category: null,
+      payment_terms: null,
+      pricing: null,
     })
   }
 
@@ -259,25 +384,30 @@ export function ClientFilterSidebar({ type }: { type: 'buyers' | 'farmers' }) {
   if (isDesktop) {
     return (
       <div className="sticky top-20 mt-[20px]">
-        <FilterContent onClearAll={handleClearAll} type={type} />
+        <FilterContent onClearAll={handleClearAll} type={type} hideProduce={hideProduce} hideCategory={hideCategory} product={product} />
       </div>
     )
   }
 
   // Mobile: Sheet with trigger button
+  const clientLabel = type === 'buyers' ? 'Buyers' : 'Farmers'
+  const filterTitle = product
+    ? `Filter ${product.charAt(0).toUpperCase() + product.slice(1)} ${clientLabel}`
+    : `Filter ${clientLabel}`
+
   return (
     <Sheet>
       <SheetTrigger asChild>
         <Button variant="outline" className="w-full mb-4">
           <Filter className="mr-2 h-4 w-4" />
-          Filters
+          {filterTitle}
         </Button>
       </SheetTrigger>
       <SheetContent side="left" className="w-[300px] sm:w-[400px] overflow-y-auto">
         <SheetHeader className="mb-4">
-          <SheetTitle>Filter {type === 'buyers' ? 'Buyers' : 'Farmers'}</SheetTitle>
+          <SheetTitle>{filterTitle}</SheetTitle>
         </SheetHeader>
-        <FilterContent onClearAll={handleClearAll} type={type} />
+        <FilterContent onClearAll={handleClearAll} type={type} hideProduce={hideProduce} hideCategory={hideCategory} product={product} />
       </SheetContent>
     </Sheet>
   )

--- a/apps/client-fnp/components/generic/filterSidebar.tsx
+++ b/apps/client-fnp/components/generic/filterSidebar.tsx
@@ -97,9 +97,11 @@ function SearchableCheckboxList({
 }
 
 function FilterContent({
-  onClearAll
+  onClearAll,
+  hideProduce
 }: {
   onClearAll: () => void
+  hideProduce?: boolean
 }) {
   const [queryState, setQueryState] = useQueryStates({
     produce: parseAsArrayOf(parseAsString),
@@ -137,12 +139,12 @@ function FilterContent({
   const totalFilters = Object.values(queryState).reduce((acc, val) => acc + (val?.length || 0), 0)
 
   const filterSections = [
-    {
+    ...(!hideProduce ? [{
       name: "produce",
       key: "produce",
       items: produceItems,
       isLoading: isLoadingAggregates
-    },
+    }] : []),
     {
       name: "clients",
       key: "clients",
@@ -204,7 +206,7 @@ function FilterContent({
   )
 }
 
-export function FilterSidebar() {
+export function FilterSidebar({ hideProduce }: { hideProduce?: boolean } = {}) {
   const isDesktop = useMediaQuery("(min-width: 1024px)")
   const [, setQueryState] = useQueryStates({
     produce: parseAsArrayOf(parseAsString),
@@ -222,7 +224,7 @@ export function FilterSidebar() {
   if (isDesktop) {
     return (
       <div className="sticky top-20 mt-[20px]">
-        <FilterContent onClearAll={handleClearAll} />
+        <FilterContent onClearAll={handleClearAll} hideProduce={hideProduce} />
       </div>
     )
   }
@@ -240,7 +242,7 @@ export function FilterSidebar() {
         <SheetHeader className="mb-4">
           <SheetTitle>Filter Prices</SheetTitle>
         </SheetHeader>
-        <FilterContent onClearAll={handleClearAll} />
+        <FilterContent onClearAll={handleClearAll} hideProduce={hideProduce} />
       </SheetContent>
     </Sheet>
   )

--- a/apps/client-fnp/components/icons/lucide.ts
+++ b/apps/client-fnp/components/icons/lucide.ts
@@ -54,7 +54,8 @@ import {
     Package,
     ShoppingBag,
     Sparkles,
-    BarChart3
+    BarChart3,
+    Lock
 } from "lucide-react"
 
 export type Icon = LucideIcon
@@ -116,5 +117,6 @@ export const Icons = {
     package: Package,
     shoppingBag: ShoppingBag,
     sparkles: Sparkles,
-    barChart: BarChart3
+    barChart: BarChart3,
+    lock: Lock
 }

--- a/apps/client-fnp/components/layouts/buyers.tsx
+++ b/apps/client-fnp/components/layouts/buyers.tsx
@@ -11,6 +11,7 @@ import {Icons} from "@/components/icons/lucide"
 import {Badge} from "@/components/ui/badge"
 
 import {queryClients, queryClientsByProduct} from "@/lib/query"
+import {AdSenseInFeed} from "@/components/ads/AdSenseInFeed"
 import {ApplicationUser, AuthenticatedUser} from "@/lib/schemas"
 import {slug, capitalizeFirstLetter, plural} from "@/lib/utilities"
 
@@ -47,10 +48,12 @@ export function Buyers({user, queryBy}: BuyersPageProps) {
   const provinceFilters = searchParams?.getAll("province") ?? []
   const produceFilters = searchParams?.getAll("produce") ?? []
   const categoryFilters = searchParams?.getAll("category") ?? []
+  const paymentTermsFilters = searchParams?.getAll("payment_terms") ?? []
+  const pricingFilters = searchParams?.getAll("pricing") ?? []
 
   const {data, isError, isFetching} = useQuery({
-    queryKey: ["results-buyers", {p: page, province: provinceFilters, produce: produceFilters, category: categoryFilters}],
-    queryFn: () => queryBy != undefined ? queryClientsByProduct('buyer', queryBy, {p: page}) : queryClients('buyer', {p: page, province: provinceFilters, produce: produceFilters, category: categoryFilters}),
+    queryKey: ["results-buyers", {p: page, province: provinceFilters, produce: produceFilters, category: categoryFilters, payment_terms: paymentTermsFilters, pricing: pricingFilters, queryBy}],
+    queryFn: () => queryBy != undefined ? queryClientsByProduct('buyer', queryBy, {p: page, province: provinceFilters}) : queryClients('buyer', {p: page, province: provinceFilters, produce: produceFilters, category: categoryFilters, payment_terms: paymentTermsFilters, pricing: pricingFilters}),
     refetchOnWindowFocus: false
   })
 
@@ -103,7 +106,9 @@ export function Buyers({user, queryBy}: BuyersPageProps) {
 
       <div className="space-y-3">
         {buyers.map((buyer, buyerIndex) => (
-          <div key={buyerIndex} className="bg-card border rounded-lg p-6 hover:shadow-md hover:border-primary/40 transition-all group">
+          <div key={buyerIndex}>
+          {buyerIndex > 0 && buyerIndex % 3 === 0 && <AdSenseInFeed />}
+          <div className="bg-card border rounded-lg p-6 hover:shadow-md hover:border-primary/40 transition-all group">
             <div className="flex items-start gap-4">
               <div className="flex-shrink-0 w-12 h-12 rounded-lg bg-muted flex items-center justify-center text-muted-foreground">
                 {/* Placeholder for buyer icon/logo */}
@@ -155,6 +160,7 @@ export function Buyers({user, queryBy}: BuyersPageProps) {
                 )}
               </div>
             </div>
+          </div>
           </div>
         ))}
       </div>

--- a/apps/client-fnp/components/layouts/client.tsx
+++ b/apps/client-fnp/components/layouts/client.tsx
@@ -1,18 +1,17 @@
 "use client"
 
-import { useState } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { sendGTMEvent } from "@next/third-parties/google"
 
 import { queryClient, queryClientPricing } from "@/lib/query"
 import { ApplicationUser, AuthenticatedUser } from "@/lib/schemas"
-import { capitalizeFirstLetter, makeAbbveriation, plural, formatDate } from "@/lib/utilities"
+import { capitalizeFirstLetter, makeAbbveriation, plural } from "@/lib/utilities"
+import { paymentTermsLabel } from "@/components/structures/repository/data"
 import { Icons } from "@/components/icons/lucide"
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Contacts } from "@/components/layouts/contacts"
 
 
@@ -22,8 +21,6 @@ interface ClientPageProps {
 }
 
 export function Client({ slug, user }: ClientPageProps) {
-  const [pricingPage, setPricingPage] = useState(1)
-
   const { data, isError, isFetching } = useQuery({
     queryKey: [`result-client-${slug}`, slug],
     queryFn: () => queryClient(slug),
@@ -34,8 +31,8 @@ export function Client({ slug, user }: ClientPageProps) {
 
   // Fetch pricing data separately (only for buyers with pricing)
   const { data: pricingData, isLoading: pricingLoading } = useQuery({
-    queryKey: [`client-pricing-${client?.id}`, client?.id, pricingPage],
-    queryFn: () => queryClientPricing(client?.id || '', { p: pricingPage }),
+    queryKey: [`client-pricing-${client?.id}`, client?.id],
+    queryFn: () => queryClientPricing(client?.id || '', { p: 1 }),
     enabled: !!client?.id && client?.type === 'buyer' && client?.has_prices,
     refetchOnWindowFocus: false
   })
@@ -51,9 +48,7 @@ export function Client({ slug, user }: ClientPageProps) {
     return null
   }
 
-  const pricingRelations = pricingData?.data?.data || []
   const pricingTotal = pricingData?.data?.total || 0
-  const pricingPageCount = Math.ceil(pricingTotal / 20)
 
   return (
     <div className="w-full bg-gradient-to-br from-background via-background to-muted/20 min-h-screen pb-12">
@@ -189,272 +184,112 @@ export function Client({ slug, user }: ClientPageProps) {
         </div>
       </div>
 
-      {/* Main Content with Tabs */}
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mt-8">
-        <Tabs defaultValue="overview" className="w-full">
-          <TabsList className="grid w-full max-w-md grid-cols-3 mb-8">
-            <TabsTrigger value="overview">Overview</TabsTrigger>
-            <TabsTrigger value="activity">
-              {client.type === 'farmer' ? 'Products' : 'Pricing'}
-            </TabsTrigger>
-            <TabsTrigger value="insights">Insights</TabsTrigger>
-          </TabsList>
-
-          {/* Overview Tab */}
-          <TabsContent value="overview" className="space-y-6">
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-              {/* Left Column - Main Details (2/3 width) */}
-              <div className="lg:col-span-2 space-y-6">
-                {/* Business Details Card */}
-                <div className="bg-card border rounded-xl p-6 shadow-sm hover:shadow-md transition-shadow">
-                  <h2 className="text-xl font-semibold mb-6 flex items-center gap-2">
-                    <Icons.info className="h-5 w-5 text-primary" />
-                    Business Details
-                  </h2>
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <div className="space-y-1">
-                      <dt className="text-sm font-medium text-muted-foreground flex items-center gap-1.5">
-                        <Icons.tag className="h-3.5 w-3.5" />
-                        Category
-                      </dt>
-                      <dd className="text-base font-semibold">
-                        {client.primary_category ? capitalizeFirstLetter(client.primary_category.name) : 'N/A'}
-                      </dd>
-                    </div>
-                    <div className="space-y-1">
-                      <dt className="text-sm font-medium text-muted-foreground flex items-center gap-1.5">
-                        <Icons.creditCard className="h-3.5 w-3.5" />
-                        Payment Terms
-                      </dt>
-                      <dd className="text-base font-semibold">
-                        {client.payment_terms ? capitalizeFirstLetter(client.payment_terms) : 'N/A'}
-                      </dd>
-                    </div>
-                    <div className="space-y-1">
-                      <dt className="text-sm font-medium text-muted-foreground flex items-center gap-1.5">
-                        <Icons.package className="h-3.5 w-3.5" />
-                        Main Product
-                      </dt>
-                      <dd className="text-base font-semibold">
-                        {client.main_produce?.name ? capitalizeFirstLetter(client.main_produce.name) : 'N/A'}
-                      </dd>
-                    </div>
-                    <div className="space-y-1">
-                      <dt className="text-sm font-medium text-muted-foreground flex items-center gap-1.5">
-                        <Icons.shoppingBag className="h-3.5 w-3.5" />
-                        {client.type === 'farmer' ? 'Other Products' : 'Other Interests'}
-                      </dt>
-                      <dd className="text-base font-semibold">
-                        {client.other_produce && client.other_produce.length > 0
-                          ? client.other_produce
-                              .filter(p => p.name !== client.main_produce?.name)
-                              .map(p => capitalizeFirstLetter(p.name))
-                              .join(', ') || 'N/A'
-                          : 'N/A'}
-                      </dd>
-                    </div>
-                  </div>
+      {/* Main Content */}
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mt-8 space-y-6">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          {/* Left Column - Main Details (2/3 width) */}
+          <div className="lg:col-span-2 space-y-6">
+            {/* Business Details Card */}
+            <div className="bg-card border rounded-xl p-6 shadow-sm hover:shadow-md transition-shadow">
+              <h2 className="text-xl font-semibold mb-6 flex items-center gap-2">
+                <Icons.info className="h-5 w-5 text-primary" />
+                Business Details
+              </h2>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div className="space-y-1">
+                  <dt className="text-sm font-medium text-muted-foreground flex items-center gap-1.5">
+                    <Icons.tag className="h-3.5 w-3.5" />
+                    Category
+                  </dt>
+                  <dd className="text-base font-semibold">
+                    {client.primary_category ? capitalizeFirstLetter(client.primary_category.name) : 'N/A'}
+                  </dd>
                 </div>
-              </div>
-
-              {/* Right Sidebar - Contact & Quick Info (1/3 width) */}
-              <div className="space-y-6">
-                {/* Contact Card */}
-                <div className="bg-card border rounded-xl p-6 shadow-sm hover:shadow-md transition-shadow">
-                  <h2 className="text-lg font-semibold mb-4 flex items-center gap-2">
-                    <Icons.phone className="h-5 w-5 text-primary" />
-                    Contact
-                  </h2>
-                  <Contacts user={user} client={client} />
+                <div className="space-y-1">
+                  <dt className="text-sm font-medium text-muted-foreground flex items-center gap-1.5">
+                    <Icons.package className="h-3.5 w-3.5" />
+                    Main Product
+                  </dt>
+                  <dd className="text-base font-semibold">
+                    {client.main_produce?.name ? capitalizeFirstLetter(client.main_produce.name) : 'N/A'}
+                  </dd>
                 </div>
               </div>
             </div>
-          </TabsContent>
 
-          {/* Activity Tab - Products or Pricing */}
-          <TabsContent value="activity" className="space-y-6">
-            {client.type === 'farmer' ? (
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div className="bg-card border rounded-xl p-6 shadow-sm">
-                  <h2 className="text-xl font-semibold mb-4">Products & Produce</h2>
-                  {client.main_produce && (
-                    <div className="mb-4">
-                      <h3 className="text-sm text-muted-foreground mb-2">Primary Product</h3>
-                      <Badge className="text-base px-4 py-2">{capitalizeFirstLetter(client.main_produce.name)}</Badge>
-                    </div>
-                  )}
-                  {client.other_produce && client.other_produce.length > 0 && (
-                    <div>
-                      <h3 className="text-sm text-muted-foreground mb-2">Other Products</h3>
-                      <div className="flex flex-wrap gap-2">
-                        {client.other_produce.map((produce, index) => (
-                          <Badge key={index} variant="outline">
-                            {capitalizeFirstLetter(produce.name)}
-                          </Badge>
-                        ))}
-                      </div>
-                    </div>
-                  )}
+            {/* Also Buying/Growing */}
+            <div className="bg-card border rounded-xl p-6 shadow-sm hover:shadow-md transition-shadow">
+              <h2 className="text-xl font-semibold mb-4 flex items-center gap-2">
+                <Icons.shoppingBag className="h-5 w-5 text-primary" />
+                {client.type === 'farmer' ? 'Also Growing' : 'Also Buying'}
+              </h2>
+              {client.other_produce && client.other_produce.length > 0
+                ? (
+                  <ul className="list-disc list-inside space-y-1.5">
+                    {client.other_produce
+                      .filter(p => p.name !== client.main_produce?.name)
+                      .map((p, i) => (
+                        <li key={i} className="text-sm font-medium">{capitalizeFirstLetter(p.name)}</li>
+                      ))}
+                  </ul>
+                )
+                : <p className="text-sm text-muted-foreground">No additional products listed</p>}
+            </div>
+
+            {/* Pricing (buyers only) */}
+            {client.type === 'buyer' && (
+              <div className="bg-card border rounded-xl p-6 shadow-sm hover:shadow-md transition-shadow">
+                <h2 className="text-xl font-semibold mb-4 flex items-center gap-2">
+                  <Icons.lock className="h-5 w-5 text-primary" />
+                  Pricing
+                </h2>
+                <div className="flex items-center gap-2 mb-4">
+                  <Icons.creditCard className="h-3.5 w-3.5 text-muted-foreground" />
+                  <span className="text-sm text-muted-foreground">Payment Terms:</span>
+                  <span className="text-sm font-semibold">{paymentTermsLabel(client.payment_terms)}</span>
                 </div>
-                <div className="bg-card border rounded-xl p-6 shadow-sm">
-                  <h2 className="text-xl font-semibold mb-2">Product Details</h2>
-                  <p className="text-sm text-muted-foreground">Detailed product information coming soon</p>
-                </div>
-              </div>
-            ) : (
-              <div className="space-y-6">
                 {pricingLoading ? (
-                  <div className="bg-card border rounded-xl p-12 shadow-sm">
-                    <div className="flex flex-col items-center justify-center">
-                      <Icons.spinner className="h-8 w-8 animate-spin text-primary mb-4" />
-                      <p className="text-sm text-muted-foreground">Loading pricing data...</p>
-                    </div>
+                  <div className="flex items-center gap-3 py-4 border-t">
+                    <Icons.spinner className="h-5 w-5 animate-spin text-primary" />
+                    <p className="text-sm text-muted-foreground">Loading pricing data...</p>
                   </div>
-                ) : client.has_prices && pricingRelations.length > 0 ? (
-                  <div className="bg-card border rounded-xl overflow-hidden shadow-sm">
-                    <div className="overflow-x-auto">
-                      <table className="w-full">
-                        <thead>
-                          <tr className="border-b bg-muted/20">
-                            <th className="text-left py-3 px-6 text-sm font-semibold text-muted-foreground">Effective Date</th>
-                            <th className="text-left py-3 px-6 text-sm font-semibold text-muted-foreground">Type</th>
-                            <th className="text-left py-3 px-6 text-sm font-semibold text-muted-foreground">Category</th>
-                            <th className="text-right py-3 px-6 text-sm font-semibold text-muted-foreground">Product Tags</th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          {pricingRelations.map((priceList: any, index: number) => {
-                            // Count available products
-                            const productKeys = ['beef', 'lamb', 'mutton', 'goat', 'chicken', 'pork', 'slaughter', 'catering']
-                            const availableProducts = productKeys.filter(key => {
-                              const product = priceList[key]
-                              return product && (product.hasPrice === true || product.HasPrice === true)
-                            })
-                            const tagCount = availableProducts.length
-
-                            const priceDate = new Date(priceList.effectiveDate).toISOString().split('T')[0]
-                            const priceListUrl = `/prices/${slug}-${priceDate}`
-
-                            return (
-                              <tr key={index} className="border-b last:border-b-0 hover:bg-muted/10 transition-colors">
-                                <td className="py-4 px-6">
-                                  <div className="flex items-center gap-2">
-                                    <Icons.calender className="h-4 w-4 text-muted-foreground" />
-                                    <span className="font-medium">{formatDate(priceList.effectiveDate)}</span>
-                                  </div>
-                                </td>
-                                <td className="py-4 px-6">
-                                  <Badge variant="outline" className="font-medium">
-                                    {capitalizeFirstLetter(priceList.pricing_basis || 'Live Weight')}
-                                  </Badge>
-                                </td>
-                                <td className="py-4 px-6 text-sm">
-                                  {capitalizeFirstLetter(priceList.client_specialization || client.primary_category?.name || '-')}
-                                </td>
-                                <td className="py-4 px-6 text-right">
-                                  <div className="flex items-center justify-end gap-3">
-                                    <Badge variant="secondary" className="bg-primary/10 text-primary border-primary/20">
-                                      {tagCount} {tagCount === 1 ? 'Product' : 'Products'}
-                                    </Badge>
-                                    <Button asChild variant="ghost" size="sm">
-                                      <a
-                                        href={priceListUrl}
-                                        className="flex items-center gap-1"
-                                        onClick={() => sendGTMEvent({ event: 'link', value: 'ViewPriceFromDetailPage' })}
-                                      >
-                                        View
-                                        <Icons.chevronRight className="h-4 w-4" />
-                                      </a>
-                                    </Button>
-                                  </div>
-                                </td>
-                              </tr>
-                            )
-                          })}
-                        </tbody>
-                      </table>
-                    </div>
-
-                    {/* Pagination */}
-                    {pricingPageCount > 1 && (
-                      <div className="p-6 border-t bg-muted/10">
-                        <div className="flex items-center justify-between">
-                          <p className="text-sm text-muted-foreground">
-                            Page {pricingPage} of {pricingPageCount} • {pricingTotal} total price {pricingTotal === 1 ? 'list' : 'lists'}
-                          </p>
-                          <div className="flex gap-2">
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={() => setPricingPage(p => Math.max(1, p - 1))}
-                              disabled={pricingPage === 1 || pricingLoading}
-                            >
-                              <Icons.chevronLeft className="h-4 w-4 mr-1" />
-                              Previous
-                            </Button>
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              onClick={() => setPricingPage(p => Math.min(pricingPageCount, p + 1))}
-                              disabled={pricingPage === pricingPageCount || pricingLoading}
-                            >
-                              Next
-                              <Icons.chevronRight className="h-4 w-4 ml-1" />
-                            </Button>
-                          </div>
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                ) : (
-                  <div className="bg-card border rounded-xl p-6 shadow-sm">
-                    <div className="flex flex-col items-center justify-center py-12 text-center">
-                      <Icons.circleDollarSign className="h-16 w-16 text-muted-foreground/30 mb-4" />
-                      <h3 className="text-lg font-semibold mb-2">No Pricing Available</h3>
-                      <p className="text-sm text-muted-foreground max-w-md">
-                        This buyer hasn&apos;t shared pricing information yet. Check back later or contact them directly for pricing details.
+                ) : client.has_prices && pricingTotal > 0 ? (
+                  <div className="flex items-center justify-between py-4 border-t">
+                    <div>
+                      <p className="text-sm text-muted-foreground">
+                        {capitalizeFirstLetter(client.name)} has shared pricing information
+                      </p>
+                      <p className="text-2xl font-bold text-primary mt-1">
+                        {pricingTotal} price {pricingTotal === 1 ? 'list' : 'lists'}
                       </p>
                     </div>
+                    <Button
+                      onClick={() => sendGTMEvent({ event: 'link', value: 'SubscribePricingFromDetailPage' })}
+                    >
+                      <Icons.lock className="h-4 w-4 mr-2" />
+                      Unlock Pricing
+                    </Button>
                   </div>
+                ) : (
+                  <p className="text-sm text-muted-foreground py-4 border-t">
+                    This buyer hasn&apos;t shared pricing information yet. Check back later or contact them directly for pricing details.
+                  </p>
                 )}
               </div>
             )}
-          </TabsContent>
+          </div>
 
-          {/* Insights Tab - Recommendations & Matching */}
-          <TabsContent value="insights" className="space-y-6">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <div className="bg-card border rounded-xl p-6 shadow-sm">
-                <h2 className="text-xl font-semibold mb-4 flex items-center gap-2">
-                  <Icons.sparkles className="h-5 w-5 text-primary" />
-                  {client.type === 'farmer' ? 'Agro Chemical Matches' : 'Supplier Matches'}
-                </h2>
-                <p className="text-sm text-muted-foreground mb-4">
-                  {client.type === 'farmer'
-                    ? 'Based on your products, we recommend these agro chemicals'
-                    : 'Farmers matching your product interests'}
-                </p>
-                <div className="bg-muted/50 rounded-lg p-8 text-center">
-                  <Icons.sparkles className="h-12 w-12 mx-auto text-muted-foreground/50 mb-2" />
-                  <p className="text-sm text-muted-foreground">Coming soon</p>
-                </div>
-              </div>
-              <div className="bg-card border rounded-xl p-6 shadow-sm">
-                <h2 className="text-xl font-semibold mb-4 flex items-center gap-2">
-                  <Icons.barChart className="h-5 w-5 text-primary" />
-                  Market Insights
-                </h2>
-                <p className="text-sm text-muted-foreground mb-4">
-                  Market trends and analytics for your products
-                </p>
-                <div className="bg-muted/50 rounded-lg p-8 text-center">
-                  <Icons.barChart className="h-12 w-12 mx-auto text-muted-foreground/50 mb-2" />
-                  <p className="text-sm text-muted-foreground">Coming soon</p>
-                </div>
-              </div>
+          {/* Right Sidebar - Contact (1/3 width) */}
+          <div className="space-y-6">
+            <div className="bg-card border rounded-xl p-6 shadow-sm hover:shadow-md transition-shadow">
+              <h2 className="text-lg font-semibold mb-4 flex items-center gap-2">
+                <Icons.phone className="h-5 w-5 text-primary" />
+                Contact
+              </h2>
+              <Contacts user={user} client={client} />
             </div>
-          </TabsContent>
-        </Tabs>
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/apps/client-fnp/components/layouts/farmers.tsx
+++ b/apps/client-fnp/components/layouts/farmers.tsx
@@ -10,6 +10,7 @@ import {Pagination} from "@/components/generic/pagination"
 import {Icons} from "@/components/icons/lucide"
 
 import {queryClients, queryClientsByProduct} from "@/lib/query"
+import {AdSenseInFeed} from "@/components/ads/AdSenseInFeed"
 import {ApplicationUser, AuthenticatedUser} from "@/lib/schemas"
 import {slug, capitalizeFirstLetter, plural} from "@/lib/utilities"
 
@@ -46,10 +47,12 @@ export function Farmers({user, queryBy}: FarmersPageProps) {
   const provinceFilters = searchParams?.getAll("province") ?? []
   const produceFilters = searchParams?.getAll("produce") ?? []
   const categoryFilters = searchParams?.getAll("category") ?? []
+  const paymentTermsFilters = searchParams?.getAll("payment_terms") ?? []
+  const pricingFilters = searchParams?.getAll("pricing") ?? []
 
   const {data, isError, isFetching} = useQuery({
-    queryKey: ["results-farmers", {p: page, province: provinceFilters, produce: produceFilters, category: categoryFilters}],
-    queryFn: () => queryBy != undefined ? queryClientsByProduct('farmer', queryBy, {p: page}) : queryClients('farmer', {p: page, province: provinceFilters, produce: produceFilters, category: categoryFilters}),
+    queryKey: ["results-farmers", {p: page, province: provinceFilters, produce: produceFilters, category: categoryFilters, payment_terms: paymentTermsFilters, pricing: pricingFilters, queryBy}],
+    queryFn: () => queryBy != undefined ? queryClientsByProduct('farmer', queryBy, {p: page, province: provinceFilters}) : queryClients('farmer', {p: page, province: provinceFilters, produce: produceFilters, category: categoryFilters, payment_terms: paymentTermsFilters, pricing: pricingFilters}),
     refetchOnWindowFocus: false
   })
 
@@ -102,7 +105,9 @@ export function Farmers({user, queryBy}: FarmersPageProps) {
 
       <div className="space-y-3">
         {farmers.map((farmer, farmerIndex) => (
-          <div key={farmerIndex} className="bg-card border rounded-lg p-6 hover:shadow-md hover:border-primary/40 transition-all group">
+          <div key={farmerIndex}>
+          {farmerIndex > 0 && farmerIndex % 3 === 0 && <AdSenseInFeed />}
+          <div className="bg-card border rounded-lg p-6 hover:shadow-md hover:border-primary/40 transition-all group">
             <div className="flex items-start gap-4">
               <div className="flex-shrink-0 w-12 h-12 rounded-lg bg-muted flex items-center justify-center text-muted-foreground">
                 {/* Placeholder for farmer icon/logo */}
@@ -146,6 +151,7 @@ export function Farmers({user, queryBy}: FarmersPageProps) {
                 )}
               </div>
             </div>
+          </div>
           </div>
         ))}
       </div>

--- a/apps/client-fnp/components/monetization/cross-sell-banner.tsx
+++ b/apps/client-fnp/components/monetization/cross-sell-banner.tsx
@@ -1,0 +1,105 @@
+"use client"
+
+import Link from "next/link"
+import { sendGTMEvent } from "@next/third-parties/google"
+import { capitalizeFirstLetter, plural } from "@/lib/utilities"
+
+interface CrossSellBannerProps {
+    product: string
+    context: "buyer" | "farmer"
+}
+
+export function CrossSellBanner({ product, context }: CrossSellBannerProps) {
+    const name = capitalizeFirstLetter(plural(product))
+
+    const cards = context === "buyer" ? [
+        {
+            title: `${name} Market Prices`,
+            description: "Check current pricing data",
+            href: "/prices",
+            event: "CrossSellPricesFromBuyer",
+            icon: (
+                <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 18.75a60.07 60.07 0 0115.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 013 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 00-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 01-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 003 15h-.75M15 10.5a3 3 0 11-6 0 3 3 0 016 0zm3 0h.008v.008H18V10.5zm-12 0h.008v.008H6V10.5z" />
+                </svg>
+            ),
+        },
+        {
+            title: "Animal Health Guides",
+            description: "Vaccines, antibiotics & nutrition",
+            href: "/agrochemical-guides/all",
+            event: "CrossSellGuidesFromBuyer",
+            icon: (
+                <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0112 15a9.065 9.065 0 00-6.23.693L5 14.5m14.8.8l1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0112 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5" />
+                </svg>
+            ),
+        },
+        {
+            title: `Find ${name} Farmers`,
+            description: "Source directly from producers",
+            href: `/farmers/${product}`,
+            event: "CrossSellFarmersFromBuyer",
+            icon: (
+                <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z" />
+                </svg>
+            ),
+        },
+    ] : [
+        {
+            title: `${name} Market Prices`,
+            description: "Check current pricing data",
+            href: "/prices",
+            event: "CrossSellPricesFromFarmer",
+            icon: (
+                <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 18.75a60.07 60.07 0 0115.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 013 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 00-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 01-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 003 15h-.75M15 10.5a3 3 0 11-6 0 3 3 0 016 0zm3 0h.008v.008H18V10.5zm-12 0h.008v.008H6V10.5z" />
+                </svg>
+            ),
+        },
+        {
+            title: "Chemical & Health Guides",
+            description: "Crop protection & animal health",
+            href: "/agrochemical-guides/all",
+            event: "CrossSellGuidesFromFarmer",
+            icon: (
+                <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0112 15a9.065 9.065 0 00-6.23.693L5 14.5m14.8.8l1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0112 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5" />
+                </svg>
+            ),
+        },
+        {
+            title: `Find ${name} Buyers`,
+            description: "Sell to verified buyers",
+            href: `/buyers/${product}`,
+            event: "CrossSellBuyersFromFarmer",
+            icon: (
+                <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 00-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 00-16.536-1.84M7.5 14.25L5.106 5.272M6 20.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm12.75 0a.75.75 0 11-1.5 0 .75.75 0 011.5 0z" />
+                </svg>
+            ),
+        },
+    ]
+
+    return (
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-6">
+            {cards.map((card) => (
+                <Link
+                    key={card.title}
+                    href={card.href}
+                    className="flex items-center gap-3 rounded-lg border bg-card p-3 transition hover:border-primary/50 hover:shadow-sm group"
+                    onClick={() => sendGTMEvent({ event: "click", value: card.event })}
+                >
+                    <div className="flex h-9 w-9 flex-none items-center justify-center rounded-full bg-muted text-muted-foreground group-hover:bg-primary group-hover:text-white transition-colors">
+                        {card.icon}
+                    </div>
+                    <div className="min-w-0">
+                        <p className="text-sm font-medium truncate">{card.title}</p>
+                        <p className="text-xs text-muted-foreground">{card.description}</p>
+                    </div>
+                </Link>
+            ))}
+        </div>
+    )
+}

--- a/apps/client-fnp/components/monetization/related-markets.tsx
+++ b/apps/client-fnp/components/monetization/related-markets.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import Link from "next/link"
+import Image from "next/image"
+import { sendGTMEvent } from "@next/third-parties/google"
+
+import logoChicken from "@/assets/logos/chicken.svg"
+import logoPig from "@/assets/logos/pig.svg"
+import logoCattle from "@/assets/logos/cattle.svg"
+import logoChilli from "@/assets/logos/chilli.svg"
+import logoTomato from "@/assets/logos/tomato.svg"
+import logoOnion from "@/assets/logos/onion.svg"
+
+const allMarkets = [
+    { name: "Chicken", slug: "chicken", logo: logoChicken },
+    { name: "Pork", slug: "pork", logo: logoPig },
+    { name: "Onions", slug: "onions", logo: logoOnion },
+    { name: "Cattle", slug: "cattle", logo: logoCattle },
+    { name: "Tomatoes", slug: "tomatoes", logo: logoTomato },
+    { name: "Chilli", slug: "chilli", logo: logoChilli },
+]
+
+interface RelatedMarketsProps {
+    currentProduct: string
+    context: "buyer" | "farmer"
+}
+
+export function RelatedMarkets({ currentProduct, context }: RelatedMarketsProps) {
+    const basePath = context === "buyer" ? "/buyers" : "/farmers"
+    const related = allMarkets.filter(m => m.slug !== currentProduct.toLowerCase()).slice(0, 4)
+
+    return (
+        <div className="mt-12 mb-8">
+            <h2 className="text-xl font-bold font-heading mb-4">Explore Other Markets</h2>
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                {related.map((market) => (
+                    <Link
+                        key={market.slug}
+                        href={`${basePath}/${market.slug}`}
+                        className="flex items-center gap-3 rounded-lg border bg-card p-4 transition hover:border-primary/50 hover:shadow-md group"
+                        onClick={() => sendGTMEvent({ event: "click", value: `RelatedMarket${market.name}` })}
+                    >
+                        <div className="flex h-10 w-10 flex-none items-center justify-center rounded-full shadow-sm ring-1 ring-zinc-900/5 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0">
+                            <Image src={market.logo} alt="" className="h-7 w-7" unoptimized />
+                        </div>
+                        <span className="text-sm font-medium group-hover:text-primary transition-colors">{market.name}</span>
+                    </Link>
+                ))}
+            </div>
+        </div>
+    )
+}

--- a/apps/client-fnp/components/structures/price-cards-view.tsx
+++ b/apps/client-fnp/components/structures/price-cards-view.tsx
@@ -1,11 +1,12 @@
 "use client"
 
-import { useState } from "react"
+import { Fragment, useState } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { useQueryStates, parseAsArrayOf, parseAsString } from "nuqs"
 import { queryProducerPriceLists } from "@/lib/query"
 import { Button } from "@/components/ui/button"
 import { PriceSummaryCard } from "@/components/structures/price-summary-card"
+import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
 import { ChevronLeft, ChevronRight } from "lucide-react"
 
 export function PriceCardsView() {
@@ -38,9 +39,9 @@ export function PriceCardsView() {
 
   if (isLoading) {
     return (
-      <div className="space-y-4">
+      <div className="space-y-3">
         {[...Array(6)].map((_, i) => (
-          <div key={i} className="h-40 rounded-xl border bg-card animate-pulse" />
+          <div key={i} className="h-16 rounded-xl border bg-card animate-pulse" />
         ))}
       </div>
     )
@@ -59,13 +60,18 @@ export function PriceCardsView() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <p className="text-sm text-muted-foreground">
-          Showing {producePriceLists.length} of {total} price lists • Page {currentPage} of {totalPages}
+          Showing {producePriceLists.length} of {total} price lists
         </p>
       </div>
 
-      <div className="space-y-10">
-        {producePriceLists.map((priceList: any) => (
-          <PriceSummaryCard key={priceList.id} priceList={priceList} />
+      <div className="space-y-3">
+        {producePriceLists.map((priceList: any, index: number) => (
+          <Fragment key={priceList.id}>
+            <PriceSummaryCard priceList={priceList} />
+            {(index + 1) % 3 === 0 && index < producePriceLists.length - 1 && (
+              <AdSenseInFeed />
+            )}
+          </Fragment>
         ))}
       </div>
 

--- a/apps/client-fnp/components/structures/price-details-grid.tsx
+++ b/apps/client-fnp/components/structures/price-details-grid.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { capitalizeFirstLetter, centsToDollars, cn } from "@/lib/utilities"
+import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
 
 interface PriceListData {
   id: string
@@ -54,20 +55,28 @@ const formatGradeName = (key: string): string => {
 export function PriceDetailsGrid({ priceList }: PriceDetailsGridProps) {
   const categories = pricingTypes[priceList.client_specialization] || []
 
+  // Filter to only renderable categories
+  const renderableCategories = categories.filter((pricingType) => {
+    if (priceList[pricingType] === undefined) return false
+    const categoryData = priceList[pricingType]
+    const gradeEntries = Object.entries(categoryData).filter(
+      ([key]) => !["hasPrice", "hasCollectedPrice", "farm_produce_id"].includes(key)
+    )
+    return gradeEntries.length > 0
+  })
+
   return (
     <div className="space-y-6">
-      {categories.map((pricingType, typeIndex) => {
-        if (priceList[pricingType] === undefined) return null
-
+      {renderableCategories.map((pricingType, renderIndex) => {
         const categoryData = priceList[pricingType]
         const gradeEntries = Object.entries(categoryData).filter(
           ([key]) => !["hasPrice", "hasCollectedPrice", "farm_produce_id"].includes(key)
         )
 
-        if (gradeEntries.length === 0) return null
-
         return (
-          <div key={typeIndex} className="rounded-xl border bg-card overflow-hidden shadow-sm">
+          <div key={renderIndex}>
+          {renderIndex > 0 && renderIndex % 2 === 0 && <AdSenseInFeed />}
+          <div className="rounded-xl border bg-card overflow-hidden shadow-sm">
             <div className="px-6 py-3 bg-gradient-to-r from-muted/30 to-card border-b">
               <h3 className="text-lg font-bold text-card-foreground">
                 {capitalizeFirstLetter(pricingType)}
@@ -138,6 +147,7 @@ export function PriceDetailsGrid({ priceList }: PriceDetailsGridProps) {
                 </tbody>
               </table>
             </div>
+          </div>
           </div>
         )
       })}

--- a/apps/client-fnp/components/structures/price-summary-card.tsx
+++ b/apps/client-fnp/components/structures/price-summary-card.tsx
@@ -2,8 +2,7 @@
 
 import Link from "next/link"
 import { formatDate, capitalizeFirstLetter, slug } from "@/lib/utilities"
-import { Badge } from "@/components/ui/badge"
-import { Calendar, Building2, ArrowRight, CheckCircle2 } from "lucide-react"
+import { ArrowRight } from "lucide-react"
 
 interface PriceListData {
   id: string
@@ -27,15 +26,19 @@ interface PriceSummaryCardProps {
 
 type ProducerPriceListKeys = "beef" | "lamb" | "mutton" | "goat" | "chicken" | "pork" | "slaughter"
 
-const produceEmojis: Record<ProducerPriceListKeys, string> = {
-  beef: "🥩",
-  lamb: "🐑",
-  mutton: "🐏",
-  goat: "🐐",
-  chicken: "🐔",
-  pork: "🐷",
-  slaughter: "🔪"
+const produceKeys: ProducerPriceListKeys[] = ["beef", "lamb", "mutton", "goat", "chicken", "pork", "slaughter"]
+
+const specializationColors: Record<string, { bg: string; accent: string; text: string }> = {
+  livestock: { bg: "bg-amber-50 dark:bg-amber-950/20", accent: "bg-amber-500", text: "text-amber-700 dark:text-amber-400" },
+  poultry: { bg: "bg-orange-50 dark:bg-orange-950/20", accent: "bg-orange-500", text: "text-orange-700 dark:text-orange-400" },
+  dairy: { bg: "bg-blue-50 dark:bg-blue-950/20", accent: "bg-blue-500", text: "text-blue-700 dark:text-blue-400" },
+  horticulture: { bg: "bg-green-50 dark:bg-green-950/20", accent: "bg-green-500", text: "text-green-700 dark:text-green-400" },
+  grain: { bg: "bg-yellow-50 dark:bg-yellow-950/20", accent: "bg-yellow-500", text: "text-yellow-700 dark:text-yellow-400" },
+  aquaculture: { bg: "bg-cyan-50 dark:bg-cyan-950/20", accent: "bg-cyan-500", text: "text-cyan-700 dark:text-cyan-400" },
+  plantation: { bg: "bg-emerald-50 dark:bg-emerald-950/20", accent: "bg-emerald-500", text: "text-emerald-700 dark:text-emerald-400" },
 }
+
+const defaultColors = { bg: "bg-slate-50 dark:bg-slate-950/20", accent: "bg-slate-500", text: "text-slate-700 dark:text-slate-400" }
 
 export function PriceSummaryCard({ priceList }: PriceSummaryCardProps) {
   const formattedDate = formatDate(priceList.effectiveDate.toString())
@@ -43,66 +46,39 @@ export function PriceSummaryCard({ priceList }: PriceSummaryCardProps) {
   const nameSlug = slug(priceList.client_name)
   const priceSlug = `${nameSlug}-${dateSlug}`
 
-  // Get available produce types
-  const availableProduce = (Object.keys(produceEmojis) as ProducerPriceListKeys[]).filter(
+  const availableProduce = produceKeys.filter(
     (key) => priceList[key] !== undefined && priceList[key] !== null
   )
 
+  const colors = specializationColors[priceList.client_specialization?.toLowerCase()] || defaultColors
+
   return (
-    <Link href={`/prices/${priceSlug}`}>
-      <div className="group rounded-xl border bg-card p-4 sm:p-6 shadow-sm transition-all duration-300 hover:shadow-md hover:border-primary/30 cursor-pointer mb-4">
-        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-4">
-            <div className="flex-1">
-              <div className="flex items-center gap-2 mb-3">
-                <h3 className="text-lg sm:text-xl font-bold font-heading text-card-foreground">
-                  {capitalizeFirstLetter(priceList.client_name)}
-                </h3>
-                {priceList.verified && (
-                  <CheckCircle2 className="h-4 w-4 sm:h-5 sm:w-5 text-green-600 flex-shrink-0" />
-                )}
-              </div>
+    <Link href={`/prices/${priceSlug}`} className="block group">
+      <div className={`relative rounded-xl ${colors.bg} border border-transparent hover:border-primary/20 p-4 transition-all duration-200 hover:shadow-md`}>
+        <div className={`absolute left-0 top-4 bottom-4 w-1 rounded-r-full ${colors.accent}`} />
 
-              <div className="space-y-4">
-                <div className="flex items-center gap-2 flex-wrap">
-                  <Building2 className="h-4 w-4 text-muted-foreground flex-shrink-0" />
-                  <span className="text-xs text-muted-foreground uppercase tracking-wide">Farm Produce Category:</span>
-                  <span className="text-sm font-medium text-card-foreground">
-                    {capitalizeFirstLetter(priceList.client_specialization)}
-                  </span>
-                </div>
-
-                <div className="flex items-center gap-2 flex-wrap">
-                  <Calendar className="h-4 w-4 text-muted-foreground flex-shrink-0" />
-                  <span className="text-xs text-muted-foreground uppercase tracking-wide">Effective:</span>
-                  <span className="text-sm font-medium text-card-foreground">{formattedDate}</span>
-                </div>
-
-                <div className="flex flex-wrap items-center gap-1.5 sm:gap-2 mt-3">
-                  {priceList.pricing_basis && (
-                    <Badge variant="outline" className="text-xs font-medium capitalize">
-                      {priceList.pricing_basis}
-                    </Badge>
-                  )}
-
-                  {availableProduce.length > 0 && (
-                    <>
-                      {availableProduce.map((produce) => (
-                        <Badge key={produce} variant="secondary" className="text-xs font-medium whitespace-nowrap">
-                          <span className="mr-1">{produceEmojis[produce]}</span>
-                          {capitalizeFirstLetter(produce)}
-                        </Badge>
-                      ))}
-                    </>
-                  )}
-                </div>
-              </div>
+        <div className="pl-4 flex items-center justify-between">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-3 mb-1">
+              <h3 className="text-base font-semibold text-card-foreground truncate">
+                {capitalizeFirstLetter(priceList.client_name)}
+              </h3>
+              <span className={`text-[11px] font-medium uppercase tracking-wider ${colors.text} shrink-0`}>
+                {capitalizeFirstLetter(priceList.client_specialization)}
+              </span>
             </div>
 
-            <div className="hidden sm:flex items-center gap-2 text-primary opacity-0 group-hover:opacity-100 transition-opacity">
-              <span className="text-sm font-medium">View Details</span>
-              <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+            <div className="flex items-center gap-4 text-sm text-muted-foreground">
+              <span className="text-green-600 dark:text-green-400">{formattedDate}</span>
+              <span className="hidden sm:inline">{availableProduce.map(p => capitalizeFirstLetter(p)).join(", ")}</span>
+              {priceList.pricing_basis && (
+                <span className="hidden md:inline text-xs uppercase tracking-wide">{priceList.pricing_basis}</span>
+              )}
             </div>
           </div>
+
+          <ArrowRight className="h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 group-hover:translate-x-0.5 transition-all shrink-0 ml-4" />
+        </div>
       </div>
     </Link>
   )

--- a/apps/client-fnp/components/structures/related-prices-sidebar.tsx
+++ b/apps/client-fnp/components/structures/related-prices-sidebar.tsx
@@ -36,14 +36,14 @@ export function RelatedPricesSidebar({ currentClientName, currentPriceId, allPri
           <h3 className="text-sm font-semibold text-card-foreground mb-3 uppercase tracking-wide">
             More from {capitalizeFirstLetter(currentClientName)}
           </h3>
-          <div className="space-y-2">
+          <div className="space-y-3">
             {sameClientPrices.map((price) => {
               const dateSlug = new Date(price.effectiveDate).toISOString().split('T')[0]
               const nameSlug = slug(price.client_name)
               const priceSlug = `${nameSlug}-${dateSlug}`
 
               return (
-                <Link key={price.id} href={`/prices/${priceSlug}`}>
+                <Link key={price.id} href={`/prices/${priceSlug}`} className="block">
                   <div className="rounded-lg border bg-card p-3 hover:bg-muted/50 transition-colors cursor-pointer">
                     <div className="flex items-center gap-2 text-xs text-muted-foreground mb-1">
                       <Calendar className="h-3 w-3" />
@@ -67,14 +67,14 @@ export function RelatedPricesSidebar({ currentClientName, currentPriceId, allPri
           <h3 className="text-sm font-semibold text-card-foreground mb-3 uppercase tracking-wide">
             Other Buyers & Producers
           </h3>
-          <div className="space-y-2">
+          <div className="space-y-3">
             {otherClientPrices.map((price) => {
               const dateSlug = new Date(price.effectiveDate).toISOString().split('T')[0]
               const nameSlug = slug(price.client_name)
               const priceSlug = `${nameSlug}-${dateSlug}`
 
               return (
-                <Link key={price.id} href={`/prices/${priceSlug}`}>
+                <Link key={price.id} href={`/prices/${priceSlug}`} className="block">
                   <div className="rounded-lg border bg-card p-3 hover:bg-muted/50 transition-colors cursor-pointer">
                     <p className="text-sm font-medium text-card-foreground mb-1">
                       {capitalizeFirstLetter(price.client_name)}

--- a/apps/client-fnp/components/structures/repository/data.tsx
+++ b/apps/client-fnp/components/structures/repository/data.tsx
@@ -18,4 +18,23 @@ export const scales = ["small", "medium", "large"]
 
 export const units = ["kg"]
 
-export const paymentTerms = ["Next Day", "2 weeks", "30 Days", "60 Days"]
+export const paymentTermsOptions = [
+  { value: "cod", label: "Cash on Delivery" },
+  { value: "cbd", label: "Cash Before Delivery" },
+  { value: "7-days", label: "7 Days" },
+  { value: "14-days", label: "14 Days" },
+  { value: "30-days", label: "30 Days" },
+  { value: "60-days", label: "60 Days" },
+  { value: "90-days", label: "90 Days" },
+  { value: "negotiable", label: "Negotiable" },
+  { value: "not-provided", label: "Not Provided" },
+]
+
+const paymentTermsMap: Record<string, string> = Object.fromEntries(
+  paymentTermsOptions.map((o) => [o.value, o.label])
+)
+
+export function paymentTermsLabel(slug: string): string {
+  if (!slug) return "Not Provided"
+  return paymentTermsMap[slug] || slug
+}

--- a/apps/client-fnp/lib/query.ts
+++ b/apps/client-fnp/lib/query.ts
@@ -51,7 +51,7 @@ export function queryClient(slug: string) {
   return api.get(url)
 }
 
-export function queryClients(slug: string, pagination?: PaginationModel & { province?: string[], produce?: string[], category?: string[] }) {
+export function queryClients(slug: string, pagination?: PaginationModel & { province?: string[], produce?: string[], category?: string[], payment_terms?: string[], pricing?: string[] }) {
     const params = new URLSearchParams()
 
     // Add pagination
@@ -69,6 +69,12 @@ export function queryClients(slug: string, pagination?: PaginationModel & { prov
     if (pagination?.category && pagination.category.length > 0) {
         pagination.category.forEach(c => params.append('category', c))
     }
+    if (pagination?.payment_terms && pagination.payment_terms.length > 0) {
+        pagination.payment_terms.forEach(pt => params.append('payment_terms', pt))
+    }
+    if (pagination?.pricing && pagination.pricing.length > 0) {
+        pagination.pricing.forEach(pr => params.append('pricing', pr))
+    }
 
     const queryString = params.toString()
     const url = queryString ? `${BaseURL}/${slug}/all?${queryString}` : `${BaseURL}/${slug}/all`
@@ -77,18 +83,19 @@ export function queryClients(slug: string, pagination?: PaginationModel & { prov
 }
 
 
-export function queryClientsByProduct(slug: string, product: string, pagination?: PaginationModel) {
-  let url: string
+export function queryClientsByProduct(slug: string, product: string, pagination?: PaginationModel & { province?: string[] }) {
+  const params = new URLSearchParams()
 
   if (pagination?.p !== undefined && pagination.p >= 2) {
-    url = `${BaseURL}/${slug}/${product}?p=${pagination.p}`
-  } else {
-    url = `${BaseURL}/${slug}/${product}`
+    params.set('p', pagination.p.toString())
   }
 
-  // if (pagination?.search !== undefined && pagination.search.length >= 2) {
-  //     url = `${baseUrl}/buyer/all?search=${pagination.search}`
-  // }
+  if (pagination?.province && pagination.province.length > 0) {
+    pagination.province.forEach(p => params.append('province', p))
+  }
+
+  const queryString = params.toString()
+  const url = queryString ? `${BaseURL}/${slug}/${product}?${queryString}` : `${BaseURL}/${slug}/${product}`
 
   return api.get(url)
 }
@@ -142,6 +149,11 @@ export function queryAllFarmProduceUnpaginated() {
 
 export function queryPriceFilterAggregates() {
   const url = `${BaseURL}/prices/aggregates/filters`
+  return api.get(url)
+}
+
+export function queryPricesByProduce(produceSlug: string) {
+  const url = `${BaseURL}/prices/produce/${produceSlug}`
   return api.get(url)
 }
 


### PR DESCRIPTION
## Summary
- Replace free-text payment terms with slug-based options and labels
- Redesign client profile: remove tabs, single-page layout with pricing CTA
- Make pricing and payment_terms single-select filters
- Dynamic mobile filter titles for SEO
- Add in-feed ads to pricing detail page
- Fix filter sidebar to use item._id for correct backend matching
- Pricing page improvements and sidebar enhancements

## Deploy Notes
- Deploy simultaneously with backend