### PR TITLE
Add contact view counts and UI improvements

### DIFF
--- a/apps/admin-fnp/components/ui/select.tsx
+++ b/apps/admin-fnp/components/ui/select.tsx
@@ -52,7 +52,7 @@ const SelectContent = React.forwardRef<
         className={cn(
           "p-1",
           position === "popper" &&
-            "h-[var(-radix-select-trigger-height)] w-full min-w-[var(-radix-select-trigger-width)]",
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
         )}
       >
         {children}

--- a/apps/client-fnp/components/icons/lucide.ts
+++ b/apps/client-fnp/components/icons/lucide.ts
@@ -55,7 +55,8 @@ import {
     ShoppingBag,
     Sparkles,
     BarChart3,
-    Lock
+    Lock,
+    Eye
 } from "lucide-react"
 
 export type Icon = LucideIcon
@@ -118,5 +119,6 @@ export const Icons = {
     shoppingBag: ShoppingBag,
     sparkles: Sparkles,
     barChart: BarChart3,
-    lock: Lock
+    lock: Lock,
+    eye: Eye
 }

--- a/apps/client-fnp/components/layouts/buyers.tsx
+++ b/apps/client-fnp/components/layouts/buyers.tsx
@@ -158,6 +158,12 @@ export function Buyers({user, queryBy}: BuyersPageProps) {
                     {capitalizeFirstLetter(buyer.short_description)}
                   </p>
                 )}
+                {(buyer.contact_views || 0) > 0 && (
+                  <p className="text-orange-600 text-xs font-medium mt-2 flex items-center gap-1">
+                    <Icons.eye className="h-3.5 w-3.5" />
+                    {buyer.contact_views} {buyer.contact_views === 1 ? 'person viewed' : 'people viewed'} this contact recently
+                  </p>
+                )}
               </div>
             </div>
           </div>

--- a/apps/client-fnp/components/layouts/client.tsx
+++ b/apps/client-fnp/components/layouts/client.tsx
@@ -163,6 +163,14 @@ export function Client({ slug, user }: ClientPageProps) {
             </div>
           </div>
 
+          {/* Contact Views */}
+          <div className="bg-card border rounded-xl p-4 shadow-sm hover:shadow-md transition-shadow">
+            <div>
+              <p className="text-xs text-muted-foreground mb-1">Contact Views</p>
+              <p className="text-lg font-bold">{client.contact_views || 0}</p>
+            </div>
+          </div>
+
           {/* Pricing or Category */}
           {client.type === 'buyer' && client.has_prices ? (
             <div className="bg-card border rounded-xl p-4 shadow-sm hover:shadow-md transition-shadow">
@@ -225,7 +233,7 @@ export function Client({ slug, user }: ClientPageProps) {
               </h2>
               {client.other_produce && client.other_produce.length > 0
                 ? (
-                  <ul className="list-disc list-inside space-y-1.5">
+                  <ul className="list-disc list-inside grid grid-cols-2 gap-x-4 gap-y-1.5">
                     {client.other_produce
                       .filter(p => p.name !== client.main_produce?.name)
                       .map((p, i) => (

--- a/apps/client-fnp/components/layouts/farmers.tsx
+++ b/apps/client-fnp/components/layouts/farmers.tsx
@@ -149,6 +149,12 @@ export function Farmers({user, queryBy}: FarmersPageProps) {
                     {capitalizeFirstLetter(farmer.short_description)}
                   </p>
                 )}
+                {(farmer.contact_views || 0) > 0 && (
+                  <p className="text-orange-600 text-xs font-medium mt-2 flex items-center gap-1">
+                    <Icons.eye className="h-3.5 w-3.5" />
+                    {farmer.contact_views} {farmer.contact_views === 1 ? 'person viewed' : 'people viewed'} this contact recently
+                  </p>
+                )}
               </div>
             </div>
           </div>

--- a/apps/client-fnp/lib/schemas.ts
+++ b/apps/client-fnp/lib/schemas.ts
@@ -137,6 +137,7 @@ export const ApplicationUserSchema = z.object({
     verified: z.boolean(),
     payment_terms: z.string(),
     has_prices: z.boolean().optional(),
+    contact_views: z.number().optional(),
 })
 
 export const ProducerPriceListSchema = z.object({


### PR DESCRIPTION
## Summary
- Display social proof contact view counts on buyer/farmer list cards ("X people viewed this contact recently")
- Add Contact Views stat card on detail pages
- Two-column layout for Also Buying/Growing section
- Fix admin select.tsx CSS variable (missing double dash)
- Add Eye icon and contact_views to schema

## Test Plan
- [x] Buyer list shows view counts in orange on own line
- [x] Farmer list shows view counts in orange on own line
- [x] Detail page shows Contact Views in stats bar
- [x] Also Buying section renders in two columns
- [x] Admin CSS parsing error resolved