### PR TITLE
v3.0.0 — CDM prices, pricing pages, guides SSR, agrochemical search

### DIFF
--- a/apps/admin-fnp/app/(dashboard)/dashboard/animal-health-active-ingredients/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/(dashboard)/dashboard/animal-health-active-ingredients/[slug]/edit/page.tsx
@@ -1,0 +1,256 @@
+"use client"
+
+import { use } from "react"
+import Link from "next/link"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useMutation, useQuery } from "@tanstack/react-query"
+import { useForm } from "react-hook-form"
+import { useRouter } from "next/navigation"
+
+import { updateAnimalHealthActiveIngredient, queryAnimalHealthActiveIngredient } from "@/lib/query"
+import { FormAnimalHealthActiveIngredientSchema, FormAnimalHealthActiveIngredientModel, AnimalHealthActiveIngredient } from "@/lib/schemas"
+import { cn } from "@/lib/utilities"
+import { buttonVariants } from "@/components/ui/button"
+import { Icons } from "@/components/icons/lucide"
+import { toast } from "@/components/ui/use-toast"
+import { handleApiError } from "@/lib/error-handler"
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+
+export default function EditAnimalHealthActiveIngredientPage({ params }: { params: Promise<{ slug: string }> }) {
+    const router = useRouter()
+    const { slug } = use(params)
+    const ingredientId = slug
+
+    const { data: ingredientData, isLoading } = useQuery({
+        queryKey: ["animal-health-active-ingredient", ingredientId],
+        queryFn: () => queryAnimalHealthActiveIngredient(ingredientId),
+    })
+
+    const ingredient = ingredientData?.data as AnimalHealthActiveIngredient
+
+    const form = useForm<FormAnimalHealthActiveIngredientModel>({
+        defaultValues: {
+            id: ingredient?.id || "",
+            name: ingredient?.name || "",
+            short_description: ingredient?.short_description || "",
+            description: ingredient?.description || "",
+        },
+        values: ingredient ? {
+            id: ingredient.id,
+            name: ingredient.name,
+            short_description: ingredient.short_description,
+            description: ingredient.description,
+        } : undefined,
+        resolver: zodResolver(FormAnimalHealthActiveIngredientSchema),
+    })
+
+    const { mutate, isPending } = useMutation({
+        mutationFn: updateAnimalHealthActiveIngredient,
+        onSuccess: () => {
+            toast({
+                description: "Active ingredient updated successfully",
+            })
+            router.push("/dashboard/animal-health-active-ingredients")
+        },
+        onError: (error) => {
+            handleApiError(error, {
+                context: "active ingredient update"
+            })
+        },
+    })
+
+    async function onSubmit(data: FormAnimalHealthActiveIngredientModel) {
+        mutate(data)
+    }
+
+    if (isLoading) {
+        return (
+            <div className="flex justify-center py-12">
+                <Icons.spinner className="w-8 h-8 animate-spin text-gray-400" />
+            </div>
+        )
+    }
+
+    if (!ingredient) {
+        return (
+            <div className="text-center py-12">
+                <p className="text-sm text-red-600 dark:text-red-400">
+                    Active ingredient not found.
+                </p>
+            </div>
+        )
+    }
+
+    return (
+        <div className="space-y-10">
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+                        Edit Animal Health Active Ingredient
+                    </h1>
+                    <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                        Update the active ingredient information.
+                    </p>
+                </div>
+                <Link
+                    href="/dashboard/animal-health-active-ingredients"
+                    className={cn(buttonVariants({ variant: "ghost" }))}
+                >
+                    <Icons.close className="w-4 h-4 mr-2" />
+                    Close
+                </Link>
+            </div>
+
+            <Form {...form}>
+                <form onSubmit={form.handleSubmit(onSubmit)}>
+                    <div className="space-y-12">
+                        <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
+                            <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                                Active Ingredient Information
+                            </h2>
+                            <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                                Active ingredients are the compounds that provide the primary therapeutic effect in animal health products.
+                            </p>
+
+                            <div className="mt-10 space-y-8">
+                                <div className="px-1">
+                                    <label
+                                        htmlFor="name"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Ingredient Name
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="name"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Input
+                                                            id="name"
+                                                            placeholder="e.g., Oxytetracycline, Toltrazuril, Ivermectin"
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                    <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                        Enter the name of the active ingredient. The URL-friendly slug will be updated automatically.
+                                    </p>
+                                </div>
+
+                                <div className="px-1">
+                                    <label
+                                        htmlFor="short_description"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Short Description
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="short_description"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Input
+                                                            id="short_description"
+                                                            placeholder="e.g., Broad-spectrum antibiotic"
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                    <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                        Brief description for SEO and metadata (max 100 characters).
+                                    </p>
+                                </div>
+
+                                <div className="px-1">
+                                    <label
+                                        htmlFor="description"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Description
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="description"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Textarea
+                                                            id="description"
+                                                            placeholder="Describe the active ingredient, its mode of action, and common uses in animal health"
+                                                            rows={4}
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                    <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                        Provide a brief description of this active ingredient (max 500 characters).
+                                    </p>
+                                </div>
+
+                                <div className="px-1">
+                                    <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                                        Current Slug
+                                    </label>
+                                    <div className="mt-2">
+                                        <div className="block w-full rounded-md bg-gray-50 px-3 py-1.5 text-base text-gray-500 outline outline-1 outline-gray-300 sm:text-sm/6 dark:bg-gray-900 dark:text-gray-400 dark:outline-white/10">
+                                            {ingredient.slug}
+                                        </div>
+                                    </div>
+                                    <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                        This is the URL-friendly version of the ingredient name.
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="mt-6 flex items-center justify-end gap-x-6">
+                        <button
+                            type="button"
+                            onClick={() => router.push("/dashboard/animal-health-active-ingredients")}
+                            className="text-sm/6 font-semibold text-gray-900 dark:text-white"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={isPending}
+                            className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
+                        >
+                            {isPending && <Icons.spinner className="w-4 h-4 mr-2 animate-spin" />}
+                            Save
+                        </button>
+                    </div>
+                </form>
+            </Form>
+        </div>
+    )
+}

--- a/apps/admin-fnp/app/(dashboard)/dashboard/animal-health-active-ingredients/new/page.tsx
+++ b/apps/admin-fnp/app/(dashboard)/dashboard/animal-health-active-ingredients/new/page.tsx
@@ -1,0 +1,208 @@
+"use client"
+
+import Link from "next/link"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useMutation } from "@tanstack/react-query"
+import { useForm } from "react-hook-form"
+import { useRouter } from "next/navigation"
+
+import { addAnimalHealthActiveIngredient } from "@/lib/query"
+import { FormAnimalHealthActiveIngredientSchema, FormAnimalHealthActiveIngredientModel } from "@/lib/schemas"
+import { cn } from "@/lib/utilities"
+import { buttonVariants } from "@/components/ui/button"
+import { Icons } from "@/components/icons/lucide"
+import { toast } from "@/components/ui/use-toast"
+import { handleApiError } from "@/lib/error-handler"
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+
+export default function NewAnimalHealthActiveIngredientPage() {
+    const router = useRouter()
+
+    const form = useForm<FormAnimalHealthActiveIngredientModel>({
+        defaultValues: {
+            id: "",
+            name: "",
+            short_description: "",
+            description: "",
+        },
+        resolver: zodResolver(FormAnimalHealthActiveIngredientSchema),
+    })
+
+    const { mutate, isPending } = useMutation({
+        mutationFn: addAnimalHealthActiveIngredient,
+        onSuccess: () => {
+            toast({
+                description: "Active ingredient added successfully",
+            })
+            router.push("/dashboard/animal-health-active-ingredients")
+        },
+        onError: (error) => {
+            handleApiError(error, {
+                context: "active ingredient creation"
+            })
+        },
+    })
+
+    async function onSubmit(data: FormAnimalHealthActiveIngredientModel) {
+        mutate(data)
+    }
+
+    return (
+        <div className="space-y-10">
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+                        Add Animal Health Active Ingredient
+                    </h1>
+                    <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                        Create a new active ingredient for animal health products.
+                    </p>
+                </div>
+                <Link
+                    href="/dashboard/animal-health-active-ingredients"
+                    className={cn(buttonVariants({ variant: "ghost" }))}
+                >
+                    <Icons.close className="w-4 h-4 mr-2" />
+                    Close
+                </Link>
+            </div>
+
+            <Form {...form}>
+                <form onSubmit={form.handleSubmit(onSubmit)}>
+                    <div className="space-y-12">
+                        <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
+                            <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                                Active Ingredient Information
+                            </h2>
+                            <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                                Active ingredients are the compounds that provide the primary therapeutic effect in animal health products.
+                            </p>
+
+                            <div className="mt-10 space-y-8">
+                                <div className="px-1">
+                                    <label
+                                        htmlFor="name"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Ingredient Name
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="name"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Input
+                                                            id="name"
+                                                            placeholder="e.g., Oxytetracycline, Toltrazuril, Ivermectin"
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                    <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                        Enter the name of the active ingredient. The URL-friendly slug will be generated automatically.
+                                    </p>
+                                </div>
+
+                                <div className="px-1">
+                                    <label
+                                        htmlFor="short_description"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Short Description
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="short_description"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Input
+                                                            id="short_description"
+                                                            placeholder="e.g., Broad-spectrum antibiotic"
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                    <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                        Brief description for SEO and metadata (max 100 characters).
+                                    </p>
+                                </div>
+
+                                <div className="px-1">
+                                    <label
+                                        htmlFor="description"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Description
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="description"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Textarea
+                                                            id="description"
+                                                            placeholder="Describe the active ingredient, its mode of action, and common uses in animal health"
+                                                            rows={4}
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                    <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                        Provide a brief description of this active ingredient (max 500 characters).
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="mt-6 flex items-center justify-end gap-x-6">
+                        <button
+                            type="button"
+                            onClick={() => router.push("/dashboard/animal-health-active-ingredients")}
+                            className="text-sm/6 font-semibold text-gray-900 dark:text-white"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={isPending}
+                            className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
+                        >
+                            {isPending && <Icons.spinner className="w-4 h-4 mr-2 animate-spin" />}
+                            Save
+                        </button>
+                    </div>
+                </form>
+            </Form>
+        </div>
+    )
+}

--- a/apps/admin-fnp/app/(dashboard)/dashboard/animal-health-active-ingredients/page.tsx
+++ b/apps/admin-fnp/app/(dashboard)/dashboard/animal-health-active-ingredients/page.tsx
@@ -1,0 +1,15 @@
+import { DashboardHeader } from "@/components/state/dashboardHeader"
+import { DashboardShell } from "@/components/state/dashboardShell"
+import { AnimalHealthActiveIngredientsTable } from "@/components/structures/tables/animalHealthActiveIngredients"
+
+export default async function AnimalHealthActiveIngredientsPage() {
+  return (
+    <DashboardShell>
+      <DashboardHeader
+        heading="Animal Health Active Ingredients"
+        text="Manage active ingredients for animal health products."
+      ></DashboardHeader>
+      <AnimalHealthActiveIngredientsTable />
+    </DashboardShell>
+  )
+}

--- a/apps/admin-fnp/app/(dashboard)/dashboard/animal-health-categories/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/(dashboard)/dashboard/animal-health-categories/[slug]/edit/page.tsx
@@ -1,0 +1,256 @@
+"use client"
+
+import { use } from "react"
+import Link from "next/link"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useMutation, useQuery } from "@tanstack/react-query"
+import { useForm } from "react-hook-form"
+import { useRouter } from "next/navigation"
+
+import { updateAnimalHealthCategory, queryAnimalHealthCategory } from "@/lib/query"
+import { FormAnimalHealthCategorySchema, FormAnimalHealthCategoryModel, AnimalHealthCategory } from "@/lib/schemas"
+import { cn } from "@/lib/utilities"
+import { buttonVariants } from "@/components/ui/button"
+import { Icons } from "@/components/icons/lucide"
+import { toast } from "@/components/ui/use-toast"
+import { handleApiError } from "@/lib/error-handler"
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+
+export default function EditAnimalHealthCategoryPage({ params }: { params: Promise<{ slug: string }> }) {
+    const router = useRouter()
+    const { slug } = use(params)
+    const categoryId = slug
+
+    const { data: categoryData, isLoading } = useQuery({
+        queryKey: ["animal-health-category", categoryId],
+        queryFn: () => queryAnimalHealthCategory(categoryId),
+    })
+
+    const category = categoryData?.data as AnimalHealthCategory
+
+    const form = useForm<FormAnimalHealthCategoryModel>({
+        defaultValues: {
+            id: category?.id || "",
+            name: category?.name || "",
+            short_description: category?.short_description || "",
+            description: category?.description || "",
+        },
+        values: category ? {
+            id: category.id,
+            name: category.name,
+            short_description: category.short_description,
+            description: category.description,
+        } : undefined,
+        resolver: zodResolver(FormAnimalHealthCategorySchema),
+    })
+
+    const { mutate, isPending } = useMutation({
+        mutationFn: updateAnimalHealthCategory,
+        onSuccess: () => {
+            toast({
+                description: "Category updated successfully",
+            })
+            router.push("/dashboard/animal-health-categories")
+        },
+        onError: (error) => {
+            handleApiError(error, {
+                context: "category update"
+            })
+        },
+    })
+
+    async function onSubmit(data: FormAnimalHealthCategoryModel) {
+        mutate(data)
+    }
+
+    if (isLoading) {
+        return (
+            <div className="flex justify-center py-12">
+                <Icons.spinner className="w-8 h-8 animate-spin text-gray-400" />
+            </div>
+        )
+    }
+
+    if (!category) {
+        return (
+            <div className="text-center py-12">
+                <p className="text-sm text-red-600 dark:text-red-400">
+                    Category not found.
+                </p>
+            </div>
+        )
+    }
+
+    return (
+        <div className="space-y-10">
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+                        Edit Animal Health Category
+                    </h1>
+                    <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                        Update the category information.
+                    </p>
+                </div>
+                <Link
+                    href="/dashboard/animal-health-categories"
+                    className={cn(buttonVariants({ variant: "ghost" }))}
+                >
+                    <Icons.close className="w-4 h-4 mr-2" />
+                    Close
+                </Link>
+            </div>
+
+            <Form {...form}>
+                <form onSubmit={form.handleSubmit(onSubmit)}>
+                    <div className="space-y-12">
+                        <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
+                            <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                                Category Information
+                            </h2>
+                            <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                                Categories help organize animal health products (e.g., Vaccines, Antibiotics, Nutrition).
+                            </p>
+
+                            <div className="mt-10 space-y-8">
+                                <div className="px-1">
+                                    <label
+                                        htmlFor="name"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Category Name
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="name"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Input
+                                                            id="name"
+                                                            placeholder="e.g., Vaccines, Antibiotics, Nutrition"
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                    <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                        Enter the name of the category. The URL-friendly slug will be updated automatically.
+                                    </p>
+                                </div>
+
+                                <div className="px-1">
+                                    <label
+                                        htmlFor="short_description"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Short Description
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="short_description"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Input
+                                                            id="short_description"
+                                                            placeholder="e.g., Prevent infectious diseases in poultry"
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                    <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                        Brief description for SEO and metadata (max 100 characters).
+                                    </p>
+                                </div>
+
+                                <div className="px-1">
+                                    <label
+                                        htmlFor="description"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Description
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="description"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Textarea
+                                                            id="description"
+                                                            placeholder="Describe the category and what types of animal health products it includes"
+                                                            rows={4}
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                    <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                        Provide a brief description of this category (max 500 characters).
+                                    </p>
+                                </div>
+
+                                <div className="px-1">
+                                    <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                                        Current Slug
+                                    </label>
+                                    <div className="mt-2">
+                                        <div className="block w-full rounded-md bg-gray-50 px-3 py-1.5 text-base text-gray-500 outline outline-1 outline-gray-300 sm:text-sm/6 dark:bg-gray-900 dark:text-gray-400 dark:outline-white/10">
+                                            {category.slug}
+                                        </div>
+                                    </div>
+                                    <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                        This is the URL-friendly version of the category name.
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="mt-6 flex items-center justify-end gap-x-6">
+                        <button
+                            type="button"
+                            onClick={() => router.push("/dashboard/animal-health-categories")}
+                            className="text-sm/6 font-semibold text-gray-900 dark:text-white"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={isPending}
+                            className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
+                        >
+                            {isPending && <Icons.spinner className="w-4 h-4 mr-2 animate-spin" />}
+                            Save
+                        </button>
+                    </div>
+                </form>
+            </Form>
+        </div>
+    )
+}

--- a/apps/admin-fnp/app/(dashboard)/dashboard/animal-health-categories/new/page.tsx
+++ b/apps/admin-fnp/app/(dashboard)/dashboard/animal-health-categories/new/page.tsx
@@ -1,0 +1,208 @@
+"use client"
+
+import Link from "next/link"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useMutation } from "@tanstack/react-query"
+import { useForm } from "react-hook-form"
+import { useRouter } from "next/navigation"
+
+import { addAnimalHealthCategory } from "@/lib/query"
+import { FormAnimalHealthCategorySchema, FormAnimalHealthCategoryModel } from "@/lib/schemas"
+import { cn } from "@/lib/utilities"
+import { buttonVariants } from "@/components/ui/button"
+import { Icons } from "@/components/icons/lucide"
+import { toast } from "@/components/ui/use-toast"
+import { handleApiError } from "@/lib/error-handler"
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+
+export default function NewAnimalHealthCategoryPage() {
+    const router = useRouter()
+
+    const form = useForm<FormAnimalHealthCategoryModel>({
+        defaultValues: {
+            id: "",
+            name: "",
+            short_description: "",
+            description: "",
+        },
+        resolver: zodResolver(FormAnimalHealthCategorySchema),
+    })
+
+    const { mutate, isPending } = useMutation({
+        mutationFn: addAnimalHealthCategory,
+        onSuccess: () => {
+            toast({
+                description: "Category added successfully",
+            })
+            router.push("/dashboard/animal-health-categories")
+        },
+        onError: (error) => {
+            handleApiError(error, {
+                context: "category creation"
+            })
+        },
+    })
+
+    async function onSubmit(data: FormAnimalHealthCategoryModel) {
+        mutate(data)
+    }
+
+    return (
+        <div className="space-y-10">
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+                        Add Animal Health Category
+                    </h1>
+                    <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                        Create a new category for animal health products.
+                    </p>
+                </div>
+                <Link
+                    href="/dashboard/animal-health-categories"
+                    className={cn(buttonVariants({ variant: "ghost" }))}
+                >
+                    <Icons.close className="w-4 h-4 mr-2" />
+                    Close
+                </Link>
+            </div>
+
+            <Form {...form}>
+                <form onSubmit={form.handleSubmit(onSubmit)}>
+                    <div className="space-y-12">
+                        <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
+                            <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                                Category Information
+                            </h2>
+                            <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                                Categories help organize animal health products (e.g., Vaccines, Antibiotics, Nutrition).
+                            </p>
+
+                            <div className="mt-10 space-y-8">
+                                <div className="px-1">
+                                    <label
+                                        htmlFor="name"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Category Name
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="name"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Input
+                                                            id="name"
+                                                            placeholder="e.g., Vaccines, Antibiotics, Nutrition"
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                    <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                        Enter the name of the category. The URL-friendly slug will be generated automatically.
+                                    </p>
+                                </div>
+
+                                <div className="px-1">
+                                    <label
+                                        htmlFor="short_description"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Short Description
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="short_description"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Input
+                                                            id="short_description"
+                                                            placeholder="e.g., Prevent infectious diseases in poultry"
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                    <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                        Brief description for SEO and metadata (max 100 characters).
+                                    </p>
+                                </div>
+
+                                <div className="px-1">
+                                    <label
+                                        htmlFor="description"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Description
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="description"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Textarea
+                                                            id="description"
+                                                            placeholder="Describe the category and what types of animal health products it includes"
+                                                            rows={4}
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                    <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                        Provide a brief description of this category (max 500 characters).
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="mt-6 flex items-center justify-end gap-x-6">
+                        <button
+                            type="button"
+                            onClick={() => router.push("/dashboard/animal-health-categories")}
+                            className="text-sm/6 font-semibold text-gray-900 dark:text-white"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={isPending}
+                            className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
+                        >
+                            {isPending && <Icons.spinner className="w-4 h-4 mr-2 animate-spin" />}
+                            Save
+                        </button>
+                    </div>
+                </form>
+            </Form>
+        </div>
+    )
+}

--- a/apps/admin-fnp/app/(dashboard)/dashboard/animal-health-categories/page.tsx
+++ b/apps/admin-fnp/app/(dashboard)/dashboard/animal-health-categories/page.tsx
@@ -1,0 +1,15 @@
+import { DashboardHeader } from "@/components/state/dashboardHeader"
+import { DashboardShell } from "@/components/state/dashboardShell"
+import { AnimalHealthCategoriesTable } from "@/components/structures/tables/animalHealthCategories"
+
+export default async function AnimalHealthCategoriesPage() {
+  return (
+    <DashboardShell>
+      <DashboardHeader
+        heading="Animal Health Categories"
+        text="Manage product categories for animal health products (Vaccines, Antibiotics, Nutrition, etc.)."
+      ></DashboardHeader>
+      <AnimalHealthCategoriesTable />
+    </DashboardShell>
+  )
+}

--- a/apps/admin-fnp/app/(dashboard)/dashboard/animal-health-products/page.tsx
+++ b/apps/admin-fnp/app/(dashboard)/dashboard/animal-health-products/page.tsx
@@ -1,0 +1,15 @@
+import { DashboardHeader } from "@/components/state/dashboardHeader"
+import { DashboardShell } from "@/components/state/dashboardShell"
+import { AnimalHealthProductsTable } from "@/components/structures/tables/animalHealthProducts"
+
+export default async function AnimalHealthProductsPage() {
+  return (
+    <DashboardShell>
+      <DashboardHeader
+        heading="Animal Health Products"
+        text="Manage animal health products (vaccines, antibiotics, supplements)."
+      ></DashboardHeader>
+      <AnimalHealthProductsTable />
+    </DashboardShell>
+  )
+}

--- a/apps/admin-fnp/app/(dashboard)/dashboard/animal-health-targets/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/(dashboard)/dashboard/animal-health-targets/[slug]/edit/page.tsx
@@ -1,0 +1,324 @@
+"use client"
+
+import { use } from "react"
+import Link from "next/link"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useMutation, useQuery } from "@tanstack/react-query"
+import { useForm } from "react-hook-form"
+import { useRouter } from "next/navigation"
+
+import { updateAnimalHealthTarget, queryAnimalHealthTarget } from "@/lib/query"
+import { FormAnimalHealthTargetSchema, FormAnimalHealthTargetModel, AnimalHealthTarget } from "@/lib/schemas"
+import { cn } from "@/lib/utilities"
+import { buttonVariants } from "@/components/ui/button"
+import { Icons } from "@/components/icons/lucide"
+import { toast } from "@/components/ui/use-toast"
+import { handleApiError } from "@/lib/error-handler"
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+
+export default function EditAnimalHealthTargetPage({ params }: { params: Promise<{ slug: string }> }) {
+    const router = useRouter()
+    const { slug } = use(params)
+    const targetId = slug
+
+    const { data: targetData, isLoading } = useQuery({
+        queryKey: ["animal-health-target", targetId],
+        queryFn: () => queryAnimalHealthTarget(targetId),
+    })
+
+    const target = targetData?.data as AnimalHealthTarget
+
+    const form = useForm<FormAnimalHealthTargetModel>({
+        defaultValues: {
+            id: target?.id || "",
+            name: target?.name || "",
+            scientific_name: target?.scientific_name || "",
+            description: target?.description || "",
+            damage_type: target?.damage_type || "",
+            remark: target?.remark || "",
+        },
+        values: target ? {
+            id: target.id,
+            name: target.name,
+            scientific_name: target.scientific_name,
+            description: target.description,
+            damage_type: target.damage_type,
+            remark: target.remark,
+        } : undefined,
+        resolver: zodResolver(FormAnimalHealthTargetSchema),
+    })
+
+    const { mutate, isPending } = useMutation({
+        mutationFn: updateAnimalHealthTarget,
+        onSuccess: () => {
+            toast({
+                description: "Target updated successfully",
+            })
+            router.push("/dashboard/animal-health-targets")
+        },
+        onError: (error) => {
+            handleApiError(error, {
+                context: "target update"
+            })
+        },
+    })
+
+    async function onSubmit(data: FormAnimalHealthTargetModel) {
+        mutate(data)
+    }
+
+    if (isLoading) {
+        return (
+            <div className="flex justify-center py-12">
+                <Icons.spinner className="w-8 h-8 animate-spin text-gray-400" />
+            </div>
+        )
+    }
+
+    if (!target) {
+        return (
+            <div className="text-center py-12">
+                <p className="text-sm text-red-600 dark:text-red-400">
+                    Target not found.
+                </p>
+            </div>
+        )
+    }
+
+    return (
+        <div className="space-y-10">
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+                        Edit Animal Health Target
+                    </h1>
+                    <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                        Update the target information.
+                    </p>
+                </div>
+                <Link
+                    href="/dashboard/animal-health-targets"
+                    className={cn(buttonVariants({ variant: "ghost" }))}
+                >
+                    <Icons.close className="w-4 h-4 mr-2" />
+                    Close
+                </Link>
+            </div>
+
+            <Form {...form}>
+                <form onSubmit={form.handleSubmit(onSubmit)}>
+                    <div className="space-y-12">
+                        <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
+                            <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                                Target Information
+                            </h2>
+                            <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                                Targets are diseases, conditions, or pathogens that animal health products are designed to treat or prevent.
+                            </p>
+
+                            <div className="mt-10 space-y-8">
+                                <div className="px-1">
+                                    <label
+                                        htmlFor="name"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Target Name
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="name"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Input
+                                                            id="name"
+                                                            placeholder="e.g., Newcastle Disease, Coccidiosis, Gumboro"
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                    <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                        Enter the common name of the disease or condition. The URL-friendly slug will be updated automatically.
+                                    </p>
+                                </div>
+
+                                <div className="px-1">
+                                    <label
+                                        htmlFor="scientific_name"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Scientific Name (Optional)
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="scientific_name"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Input
+                                                            id="scientific_name"
+                                                            placeholder="e.g., Eimeria tenella, Paramyxovirus type 1"
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                    <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                        Scientific name of the pathogen or disease (if applicable).
+                                    </p>
+                                </div>
+
+                                <div className="px-1">
+                                    <label
+                                        htmlFor="description"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Description (Optional)
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="description"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Textarea
+                                                            id="description"
+                                                            placeholder="e.g., A highly contagious viral disease affecting poultry respiratory and nervous systems"
+                                                            rows={3}
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                    <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                        User-friendly explanation of the disease or condition.
+                                    </p>
+                                </div>
+
+                                <div className="px-1">
+                                    <label
+                                        htmlFor="damage_type"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Damage Type (Optional)
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="damage_type"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Textarea
+                                                            id="damage_type"
+                                                            placeholder="e.g., Causes respiratory distress, drop in egg production, high mortality in unvaccinated flocks"
+                                                            rows={3}
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                    <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                        SEO-optimized description of symptoms and effects on animals.
+                                    </p>
+                                </div>
+
+                                <div className="px-1">
+                                    <label
+                                        htmlFor="remark"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Remarks (Optional)
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="remark"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Textarea
+                                                            id="remark"
+                                                            placeholder="e.g., Common in broilers aged 3-6 weeks, notifiable disease"
+                                                            rows={3}
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                    <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                        Additional notes about the target (e.g., age groups affected, regulatory status).
+                                    </p>
+                                </div>
+
+                                <div className="px-1">
+                                    <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                                        Current Slug
+                                    </label>
+                                    <div className="mt-2">
+                                        <div className="block w-full rounded-md bg-gray-50 px-3 py-1.5 text-base text-gray-500 outline outline-1 outline-gray-300 sm:text-sm/6 dark:bg-gray-900 dark:text-gray-400 dark:outline-white/10">
+                                            {target.slug}
+                                        </div>
+                                    </div>
+                                    <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                        This is the URL-friendly version of the target name.
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="mt-6 pb-12 flex items-center justify-end gap-x-6">
+                        <button
+                            type="button"
+                            onClick={() => router.push("/dashboard/animal-health-targets")}
+                            className="text-sm/6 font-semibold text-gray-900 dark:text-white"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={isPending}
+                            className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
+                        >
+                            {isPending && <Icons.spinner className="w-4 h-4 mr-2 animate-spin" />}
+                            Save
+                        </button>
+                    </div>
+                </form>
+            </Form>
+        </div>
+    )
+}

--- a/apps/admin-fnp/app/(dashboard)/dashboard/animal-health-targets/new/page.tsx
+++ b/apps/admin-fnp/app/(dashboard)/dashboard/animal-health-targets/new/page.tsx
@@ -1,0 +1,274 @@
+"use client"
+
+import Link from "next/link"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useMutation } from "@tanstack/react-query"
+import { useForm } from "react-hook-form"
+import { useRouter } from "next/navigation"
+
+import { addAnimalHealthTarget } from "@/lib/query"
+import { FormAnimalHealthTargetSchema, FormAnimalHealthTargetModel } from "@/lib/schemas"
+import { cn } from "@/lib/utilities"
+import { buttonVariants } from "@/components/ui/button"
+import { Icons } from "@/components/icons/lucide"
+import { toast } from "@/components/ui/use-toast"
+import { handleApiError } from "@/lib/error-handler"
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+
+export default function NewAnimalHealthTargetPage() {
+    const router = useRouter()
+
+    const form = useForm<FormAnimalHealthTargetModel>({
+        defaultValues: {
+            id: "",
+            name: "",
+            scientific_name: "",
+            description: "",
+            damage_type: "",
+            remark: "",
+        },
+        resolver: zodResolver(FormAnimalHealthTargetSchema),
+    })
+
+    const { mutate, isPending } = useMutation({
+        mutationFn: addAnimalHealthTarget,
+        onSuccess: () => {
+            toast({
+                description: "Target added successfully",
+            })
+            router.push("/dashboard/animal-health-targets")
+        },
+        onError: (error) => {
+            handleApiError(error, {
+                context: "target creation"
+            })
+        },
+    })
+
+    async function onSubmit(data: FormAnimalHealthTargetModel) {
+        mutate(data)
+    }
+
+    return (
+        <div className="space-y-10">
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+                        Add Animal Health Target
+                    </h1>
+                    <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                        Create a new disease or condition target for animal health products.
+                    </p>
+                </div>
+                <Link
+                    href="/dashboard/animal-health-targets"
+                    className={cn(buttonVariants({ variant: "ghost" }))}
+                >
+                    <Icons.close className="w-4 h-4 mr-2" />
+                    Close
+                </Link>
+            </div>
+
+            <Form {...form}>
+                <form onSubmit={form.handleSubmit(onSubmit)}>
+                    <div className="space-y-12">
+                        <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
+                            <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                                Target Information
+                            </h2>
+                            <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                                Targets are diseases, conditions, or pathogens that animal health products are designed to treat or prevent.
+                            </p>
+
+                            <div className="mt-10 space-y-8">
+                                <div className="px-1">
+                                    <label
+                                        htmlFor="name"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Target Name
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="name"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Input
+                                                            id="name"
+                                                            placeholder="e.g., Newcastle Disease, Coccidiosis, Gumboro"
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                    <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                        Enter the common name of the disease or condition. The URL-friendly slug will be generated automatically.
+                                    </p>
+                                </div>
+
+                                <div className="px-1">
+                                    <label
+                                        htmlFor="scientific_name"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Scientific Name (Optional)
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="scientific_name"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Input
+                                                            id="scientific_name"
+                                                            placeholder="e.g., Eimeria tenella, Paramyxovirus type 1"
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                    <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                        Scientific name of the pathogen or disease (if applicable).
+                                    </p>
+                                </div>
+
+                                <div className="px-1">
+                                    <label
+                                        htmlFor="description"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Description (Optional)
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="description"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Textarea
+                                                            id="description"
+                                                            placeholder="e.g., A highly contagious viral disease affecting poultry respiratory and nervous systems"
+                                                            rows={3}
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                    <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                        User-friendly explanation of the disease or condition.
+                                    </p>
+                                </div>
+
+                                <div className="px-1">
+                                    <label
+                                        htmlFor="damage_type"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Damage Type (Optional)
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="damage_type"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Textarea
+                                                            id="damage_type"
+                                                            placeholder="e.g., Causes respiratory distress, drop in egg production, high mortality in unvaccinated flocks"
+                                                            rows={3}
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                    <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                        SEO-optimized description of symptoms and effects on animals.
+                                    </p>
+                                </div>
+
+                                <div className="px-1">
+                                    <label
+                                        htmlFor="remark"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Remarks (Optional)
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="remark"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Textarea
+                                                            id="remark"
+                                                            placeholder="e.g., Common in broilers aged 3-6 weeks, notifiable disease"
+                                                            rows={3}
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                    <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                        Additional notes about the target (e.g., age groups affected, regulatory status).
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="mt-6 pb-12 flex items-center justify-end gap-x-6">
+                        <button
+                            type="button"
+                            onClick={() => router.push("/dashboard/animal-health-targets")}
+                            className="text-sm/6 font-semibold text-gray-900 dark:text-white"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={isPending}
+                            className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
+                        >
+                            {isPending && <Icons.spinner className="w-4 h-4 mr-2 animate-spin" />}
+                            Save
+                        </button>
+                    </div>
+                </form>
+            </Form>
+        </div>
+    )
+}

--- a/apps/admin-fnp/app/(dashboard)/dashboard/animal-health-targets/page.tsx
+++ b/apps/admin-fnp/app/(dashboard)/dashboard/animal-health-targets/page.tsx
@@ -1,0 +1,15 @@
+import { DashboardHeader } from "@/components/state/dashboardHeader"
+import { DashboardShell } from "@/components/state/dashboardShell"
+import { AnimalHealthTargetsTable } from "@/components/structures/tables/animalHealthTargets"
+
+export default async function AnimalHealthTargetsPage() {
+  return (
+    <DashboardShell>
+      <DashboardHeader
+        heading="Animal Health Targets"
+        text="Manage diseases and conditions that animal health products target."
+      ></DashboardHeader>
+      <AnimalHealthTargetsTable />
+    </DashboardShell>
+  )
+}

--- a/apps/admin-fnp/app/(dashboard)/dashboard/cdm-prices/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/(dashboard)/dashboard/cdm-prices/[slug]/edit/page.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import { use } from "react"
+import { useQuery } from "@tanstack/react-query"
+
+import { queryCdmPrice } from "@/lib/query"
+import { CdmPrice } from "@/lib/schemas"
+import { Placeholder } from "@/components/state/placeholder"
+import { CdmPriceForm } from "@/components/structures/forms/cdmPriceForm"
+
+export default function EditCdmPricePage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = use(params)
+  const priceId = slug
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["cdm-price", priceId],
+    queryFn: () => queryCdmPrice(priceId),
+  })
+
+  const price = data?.data as CdmPrice
+
+  if (isLoading) {
+    return (
+      <Placeholder>
+        <Placeholder.Title>Loading CDM Price...</Placeholder.Title>
+      </Placeholder>
+    )
+  }
+
+  if (isError || !price) {
+    return (
+      <Placeholder>
+        <Placeholder.Icon name="close" />
+        <Placeholder.Title>Error Loading CDM Price</Placeholder.Title>
+        <Placeholder.Description>
+          Could not load the CDM price. It may have been deleted.
+        </Placeholder.Description>
+      </Placeholder>
+    )
+  }
+
+  return <CdmPriceForm price={price} mode="edit" />
+}

--- a/apps/admin-fnp/app/(dashboard)/dashboard/cdm-prices/new/page.tsx
+++ b/apps/admin-fnp/app/(dashboard)/dashboard/cdm-prices/new/page.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { CdmPriceForm } from "@/components/structures/forms/cdmPriceForm"
+
+export default function NewCdmPricePage() {
+  return <CdmPriceForm mode="create" />
+}

--- a/apps/admin-fnp/app/(dashboard)/dashboard/cdm-prices/page.tsx
+++ b/apps/admin-fnp/app/(dashboard)/dashboard/cdm-prices/page.tsx
@@ -1,0 +1,15 @@
+import { DashboardHeader } from "@/components/state/dashboardHeader"
+import { DashboardShell } from "@/components/state/dashboardShell"
+import { CdmPriceLists } from "@/components/structures/tables/cdmPriceLists"
+
+export default async function DashboardCdmPricesPage() {
+  return (
+    <DashboardShell>
+      <DashboardHeader
+        heading="CDM Price Lists"
+        text="Manage Cold Dress Mass cattle pricing."
+      ></DashboardHeader>
+      <CdmPriceLists />
+    </DashboardShell>
+  )
+}

--- a/apps/admin-fnp/app/(dashboard)/dashboard/layout.tsx
+++ b/apps/admin-fnp/app/(dashboard)/dashboard/layout.tsx
@@ -2,6 +2,7 @@ import { dashboardConfig } from "@/config/dashboard"
 import { AccountNavigation } from "@/components/navigation/account"
 import { MainNavigation } from "@/components/navigation/main"
 import { SidebarNavigation } from "@/components/navigation/sidebar"
+import { ScrollArea } from "@/components/ui/scroll-area"
 
 interface DashboardLayoutProps {
   children?: React.ReactNode
@@ -11,20 +12,22 @@ export default async function DashboardLayout({
   children,
 }: DashboardLayoutProps) {
   return (
-    <div className="flex flex-col min-h-screen space-y-6">
+    <div className="flex flex-col min-h-screen">
       <header className="sticky top-0 z-40 border-b shadow-sm bg-background">
         <div className="container flex items-center justify-between h-16 py-4">
           <MainNavigation />
           <AccountNavigation />
         </div>
       </header>
-      <div className="max-w-full flex flex-1 gap-12 px-8">
-        <aside className="fixed hidden h-screen w-[200px] flex-col border-r px-4 md:flex">
-          <SidebarNavigation
-            navigationLinks={dashboardConfig.sidebarNavigation}
-          />
+      <div className="max-w-full flex flex-1 px-8">
+        <aside className="fixed top-16 hidden h-[calc(100vh-4rem)] w-[220px] flex-col border-r md:flex">
+          <ScrollArea className="flex-1 px-4 py-4">
+            <SidebarNavigation
+              navigationGroups={dashboardConfig.sidebarNavigation}
+            />
+          </ScrollArea>
         </aside>
-        <main className="flex flex-col flex-1 overflow-hidden sm:ml-64">
+        <main className="flex flex-col flex-1 overflow-hidden sm:ml-[236px] py-6">
           {children}
         </main>
       </div>

--- a/apps/admin-fnp/app/(dashboard)/dashboard/spray-programs/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/(dashboard)/dashboard/spray-programs/[slug]/edit/page.tsx
@@ -1,0 +1,94 @@
+"use client"
+
+import { use, useEffect, useRef } from "react"
+import Link from "next/link"
+import { useQuery } from "@tanstack/react-query"
+
+import { querySprayProgram } from "@/lib/query"
+import { SprayProgram } from "@/lib/schemas"
+import { cn } from "@/lib/utilities"
+import { buttonVariants } from "@/components/ui/button"
+import { Icons } from "@/components/icons/lucide"
+import { Placeholder } from "@/components/state/placeholder"
+import { SprayProgramForm } from "@/components/structures/forms/sprayProgramForm"
+import { handleFetchError } from "@/lib/error-handler"
+
+interface EditSprayProgramPageProps {
+  params: Promise<{
+    slug: string
+  }>
+}
+
+export default function EditSprayProgramPage({ params }: EditSprayProgramPageProps) {
+  const { slug } = use(params)
+  const id = slug
+  const url = `/dashboard/spray-programs`
+
+  const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
+    queryKey: ["dashboard-spray-program", id],
+    queryFn: () => querySprayProgram(id),
+    refetchOnWindowFocus: false,
+  })
+
+  const sprayProgram = data?.data as SprayProgram
+
+  const hasShownError = useRef(false)
+  useEffect(() => {
+    if (isError && !hasShownError.current) {
+      hasShownError.current = true
+      handleFetchError(error, {
+        onRetry: () => {
+          hasShownError.current = false
+          refetch()
+        },
+        context: "spray program"
+      })
+    }
+    if (!isError) {
+      hasShownError.current = false
+    }
+  }, [isError, error, refetch])
+
+  if (isError) {
+    return (
+      <div className="mt-20">
+        <Placeholder>
+          <Placeholder.Icon name="close" />
+          <Placeholder.Title>Error Fetching Spray Program</Placeholder.Title>
+          <Placeholder.Description>
+            Error fetching spray program from the database
+          </Placeholder.Description>
+        </Placeholder>
+      </div>
+    )
+  }
+
+  if (isLoading || isFetching) {
+    return (
+      <div className="mt-20">
+        <Placeholder>
+          <Placeholder.Icon name="search" />
+          <Placeholder.Title>Fetching Spray Program</Placeholder.Title>
+          <Placeholder.Description>
+            Fetching spray program from the database
+          </Placeholder.Description>
+        </Placeholder>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <div className={"absolute right-10 top-8"}>
+        <Link href={url} className={cn(buttonVariants({ variant: "link" }))}>
+          <>
+            <Icons.close className="w-4 h-4 mr-2" />
+            Close
+          </>
+        </Link>
+      </div>
+
+      {sprayProgram !== undefined ? <SprayProgramForm sprayProgram={sprayProgram} mode="edit" /> : null}
+    </>
+  )
+}

--- a/apps/admin-fnp/app/(dashboard)/dashboard/spray-programs/new/page.tsx
+++ b/apps/admin-fnp/app/(dashboard)/dashboard/spray-programs/new/page.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import Link from "next/link"
+import { useState } from "react"
+
+import { FormSprayProgramModel } from "@/lib/schemas"
+import { cn } from "@/lib/utilities"
+import { buttonVariants } from "@/components/ui/button"
+import { Icons } from "@/components/icons/lucide"
+import { SprayProgramForm } from "@/components/structures/forms/sprayProgramForm"
+
+export default function CreateSprayProgramPage() {
+
+    const url = `/dashboard/spray-programs`
+
+    const [sprayProgram, _] = useState<FormSprayProgramModel>({
+        id: "",
+        name: "",
+        description: "",
+        farm_produce_id: "",
+        cover_image: undefined,
+        stages: [],
+        published: false,
+    })
+
+    return (
+        <>
+            <div className={"absolute right-10 top-8"}>
+                <Link href={url} className={cn(buttonVariants({ variant: "link" }))}>
+                    <>
+                        <Icons.close className="w-4 h-4 mr-2" />
+                        Close
+                    </>
+                </Link>
+            </div>
+
+            <SprayProgramForm sprayProgram={sprayProgram} mode="create" />
+        </>
+    )
+}

--- a/apps/admin-fnp/app/(dashboard)/dashboard/spray-programs/page.tsx
+++ b/apps/admin-fnp/app/(dashboard)/dashboard/spray-programs/page.tsx
@@ -1,0 +1,15 @@
+import { DashboardHeader } from "@/components/state/dashboardHeader"
+import { DashboardShell } from "@/components/state/dashboardShell"
+import { SprayProgramsTable } from "@/components/structures/tables/sprayPrograms"
+
+export default async function SprayProgramsPage() {
+  return (
+    <DashboardShell>
+      <DashboardHeader
+        heading="Spray Programs"
+        text="Manage spray programs."
+      ></DashboardHeader>
+      <SprayProgramsTable />
+    </DashboardShell>
+  )
+}

--- a/apps/admin-fnp/components/icons/lucide.ts
+++ b/apps/admin-fnp/components/icons/lucide.ts
@@ -51,7 +51,8 @@ import {
   ClipboardList,
   Beaker,
   Bug,
-  Layers
+  Layers,
+  Sprout
 } from "lucide-react"
 
 export type Icon = LucideIcon
@@ -110,5 +111,6 @@ export const Icons = {
   clipboardList: ClipboardList,
   beaker: Beaker,
   bug: Bug,
-  layers: Layers
+  layers: Layers,
+  sprout: Sprout
 }

--- a/apps/admin-fnp/components/navigation/sidebar.tsx
+++ b/apps/admin-fnp/components/navigation/sidebar.tsx
@@ -2,39 +2,48 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { SidebarNavigationItem } from "@/types"
+import { SidebarNavigationGroup } from "@/types"
 
 import { cn } from "@/lib/utilities"
 import { Icons } from "@/components/icons/lucide"
 
 interface SidebarNavigationProps {
-  navigationLinks: SidebarNavigationItem[]
+  navigationGroups: SidebarNavigationGroup[]
 }
 
-export function SidebarNavigation({ navigationLinks }: SidebarNavigationProps) {
+export function SidebarNavigation({ navigationGroups }: SidebarNavigationProps) {
   const path = usePathname()
 
   return (
-    <nav className="grid items-start gap-2">
-      {navigationLinks.map((navLink, index) => {
-        const Icon = Icons[navLink.icon ?? "arrowRight"]
-        return (
-          navLink.href && (
-            <Link key={index} href={navLink.disabled ? "/" : navLink.href}>
-              <span
-                className={cn(
-                  "group flex items-center rounded-md px-3 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground",
-                  path === navLink.href ? "bg-accent" : "transparent",
-                  navLink.disabled && "cursor-not-allowed opacity-80"
-                )}
-              >
-                <Icon className="w-4 h-4 mr-2" />
-                <span>{navLink.title}</span>
-              </span>
-            </Link>
-          )
-        )
-      })}
+    <nav className="flex flex-col gap-6 py-2">
+      {navigationGroups.map((group, groupIndex) => (
+        <div key={groupIndex}>
+          <h4 className="mb-2 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            {group.label}
+          </h4>
+          <div className="grid items-start gap-1">
+            {group.items.map((navLink, index) => {
+              const Icon = Icons[navLink.icon ?? "arrowRight"]
+              return (
+                navLink.href && (
+                  <Link key={index} href={navLink.disabled ? "/" : navLink.href}>
+                    <span
+                      className={cn(
+                        "group flex items-center rounded-md px-3 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground",
+                        path === navLink.href ? "bg-accent" : "transparent",
+                        navLink.disabled && "cursor-not-allowed opacity-80"
+                      )}
+                    >
+                      <Icon className="w-4 h-4 mr-2 shrink-0" />
+                      <span>{navLink.title}</span>
+                    </span>
+                  </Link>
+                )
+              )
+            })}
+          </div>
+        </div>
+      ))}
     </nav>
   )
 }

--- a/apps/admin-fnp/components/structures/columns/animalHealthActiveIngredients.tsx
+++ b/apps/admin-fnp/components/structures/columns/animalHealthActiveIngredients.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { ColumnDef } from "@tanstack/react-table"
+import { AnimalHealthActiveIngredient } from "@/lib/schemas"
+import { Checkbox } from "@/components/ui/checkbox"
+import { formatDate } from "@/lib/utilities"
+
+export const animalHealthActiveIngredientColumns: ColumnDef<AnimalHealthActiveIngredient>[] = [
+  {
+    id: "select",
+    header: ({ table }) => (
+      <Checkbox
+        checked={
+          table.getIsAllPageRowsSelected() ||
+          (table.getIsSomePageRowsSelected() && "indeterminate")
+        }
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Select all"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label="Select row"
+      />
+    ),
+    enableSorting: false,
+    enableHiding: false,
+  },
+  {
+    accessorKey: "name",
+    header: "Name",
+  },
+  {
+    accessorKey: "description",
+    header: "Description",
+    cell: ({ row }) => (
+      <span className="max-w-md truncate">
+        {row.original.description || "-"}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "created",
+    header: "Date Created",
+    cell: ({ row }) => (
+      <span>{formatDate(row.original.created)}</span>
+    ),
+  },
+]

--- a/apps/admin-fnp/components/structures/columns/animalHealthCategories.tsx
+++ b/apps/admin-fnp/components/structures/columns/animalHealthCategories.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import { ColumnDef } from "@tanstack/react-table"
+import { AnimalHealthCategory } from "@/lib/schemas"
+import { Checkbox } from "@/components/ui/checkbox"
+import { formatDate } from "@/lib/utilities"
+
+export const animalHealthCategoryColumns: ColumnDef<AnimalHealthCategory>[] = [
+  {
+    id: "select",
+    header: ({ table }) => (
+      <Checkbox
+        checked={table.getIsAllPageRowsSelected()}
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Select all"
+        className="translate-y-[2px]"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label="Select row"
+        className="translate-y-[2px]"
+      />
+    ),
+    enableSorting: false,
+    enableHiding: false,
+  },
+  {
+    accessorKey: "name",
+    header: "Name",
+  },
+  {
+    accessorKey: "description",
+    header: "Description",
+    cell: ({ row }) => {
+      const description = row.original.description
+      return (
+        <span className="max-w-md truncate">
+          {description || "-"}
+        </span>
+      )
+    },
+  },
+  {
+    accessorKey: "created",
+    header: "Date Created",
+    cell: ({ row }) => {
+      const created = row.original.created
+      return <span>{formatDate(created)}</span>
+    },
+  },
+]

--- a/apps/admin-fnp/components/structures/columns/animalHealthProducts.tsx
+++ b/apps/admin-fnp/components/structures/columns/animalHealthProducts.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import { ColumnDef } from "@tanstack/react-table"
+import { AnimalHealthProduct } from "@/lib/schemas"
+import { Checkbox } from "@/components/ui/checkbox"
+import { AnimalHealthProductControlDropDown } from "@/components/structures/dropdowns/animalHealthProduct-dropdown"
+import { formatDate } from "@/lib/utilities"
+
+export const animalHealthProductColumns: ColumnDef<AnimalHealthProduct>[] = [
+  {
+    id: "select",
+    header: ({ table }) => (
+      <Checkbox
+        checked={table.getIsAllPageRowsSelected()}
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Select all"
+        className="translate-y-[2px]"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label="Select row"
+        className="translate-y-[2px]"
+      />
+    ),
+    enableSorting: false,
+    enableHiding: false,
+  },
+  {
+    accessorKey: "name",
+    header: "Name",
+  },
+  {
+    accessorKey: "brand.name",
+    header: "Brand",
+    cell: ({ row }) => {
+      const brand = row.original.brand
+      return <span>{brand?.name || "-"}</span>
+    },
+  },
+  {
+    accessorKey: "created",
+    header: "Date Created",
+    cell: ({ row }) => {
+      const created = row.original.created
+      return <span>{formatDate(created)}</span>
+    },
+  },
+  {
+    id: "actions",
+    cell: ({ row }) => {
+      const product = row?.original
+      return <AnimalHealthProductControlDropDown product={product} />
+    },
+  },
+]

--- a/apps/admin-fnp/components/structures/columns/animalHealthTargets.tsx
+++ b/apps/admin-fnp/components/structures/columns/animalHealthTargets.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import { ColumnDef } from "@tanstack/react-table"
+import { AnimalHealthTarget } from "@/lib/schemas"
+import { Checkbox } from "@/components/ui/checkbox"
+import { formatDate } from "@/lib/utilities"
+import { AnimalHealthTargetControlDropDown } from "@/components/structures/dropdowns/animalHealthTarget-dropdown"
+
+export const animalHealthTargetColumns: ColumnDef<AnimalHealthTarget>[] = [
+  {
+    id: "select",
+    header: ({ table }) => (
+      <Checkbox
+        checked={
+          table.getIsAllPageRowsSelected() ||
+          (table.getIsSomePageRowsSelected() && "indeterminate")
+        }
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Select all"
+        className="translate-y-[2px]"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label="Select row"
+        className="translate-y-[2px]"
+      />
+    ),
+    enableSorting: false,
+    enableHiding: false,
+  },
+  {
+    accessorKey: "name",
+    header: "Name",
+  },
+  {
+    accessorKey: "description",
+    header: "Description",
+    cell: ({ row }) => (
+      <div className="max-w-xs block truncate" title={row.original.description || ""}>
+        {row.original.description || "-"}
+      </div>
+    ),
+  },
+  {
+    accessorKey: "created",
+    header: "Date Created",
+    cell: ({ row }) => (
+      <span>{formatDate(row.original.created)}</span>
+    ),
+  },
+  {
+    id: "actions",
+    cell: ({ row }) => {
+      const target = row?.original
+      return <AnimalHealthTargetControlDropDown target={target} />
+    },
+  },
+]

--- a/apps/admin-fnp/components/structures/columns/cdmPrices.tsx
+++ b/apps/admin-fnp/components/structures/columns/cdmPrices.tsx
@@ -1,0 +1,75 @@
+"use client"
+
+import Link from "next/link"
+import { ColumnDef } from "@tanstack/react-table"
+
+import { CdmPrice } from "@/lib/schemas"
+import { formatDate } from "@/lib/utilities"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { CdmPriceControlDropDown } from "@/components/structures/dropdowns/cdm-price-dropdown"
+
+export const cdmPriceColumns: ColumnDef<CdmPrice>[] = [
+  {
+    id: "select",
+    header: ({ table }) => (
+      <Checkbox
+        checked={table.getIsAllPageRowsSelected()}
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Select all"
+        className="translate-y-[2px]"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label="Select row"
+        className="translate-y-[2px]"
+      />
+    ),
+    enableSorting: false,
+    enableHiding: false,
+  },
+  {
+    accessorKey: "effectiveDate",
+    header: "Effective Date",
+    cell: ({ row }) => {
+      const date = row.getValue("effectiveDate") as string
+      return <p className="text-base tracking-tight">{formatDate(date)}</p>
+    },
+  },
+  {
+    accessorKey: "client_name",
+    header: "Client Name",
+  },
+  {
+    accessorKey: "exchange_rate",
+    header: "Exchange Rate",
+    cell: ({ row }) => {
+      const rate = row.getValue("exchange_rate") as number
+      return <span>{rate ? rate.toFixed(2) : "-"}</span>
+    },
+  },
+  {
+    id: "see_price",
+    header: "View",
+    cell: ({ row }) => {
+      const priceId = row.original.id
+      return (
+        <Link href={`/dashboard/cdm-prices/${priceId}/edit`}>
+          <Button variant="ghost" size="sm">
+            View
+          </Button>
+        </Link>
+      )
+    },
+  },
+  {
+    id: "actions",
+    cell: ({ row }) => {
+      const price = row?.original
+      return <CdmPriceControlDropDown price={price} />
+    },
+  },
+]

--- a/apps/admin-fnp/components/structures/columns/sprayPrograms.tsx
+++ b/apps/admin-fnp/components/structures/columns/sprayPrograms.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import { ColumnDef } from "@tanstack/react-table"
+import { SprayProgram } from "@/lib/schemas"
+import { Checkbox } from "@/components/ui/checkbox"
+import { SprayProgramControlDropDown } from "@/components/structures/dropdowns/sprayProgram-dropdown"
+
+export const sprayProgramColumns: ColumnDef<SprayProgram>[] = [
+  {
+    id: "select",
+    header: ({ table }) => (
+      <Checkbox
+        checked={table.getIsAllPageRowsSelected()}
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Select all"
+        className="translate-y-[2px]"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label="Select row"
+        className="translate-y-[2px]"
+      />
+    ),
+    enableSorting: false,
+    enableHiding: false,
+  },
+  {
+    accessorKey: "name",
+    header: "Name",
+    cell: ({ row }) => (
+      <span className="capitalize">{row.original.name}</span>
+    ),
+  },
+  {
+    accessorKey: "farm_produce_name",
+    header: "Crop",
+    cell: ({ row }) => (
+      <span className="capitalize">{row.original.farm_produce_name || "-"}</span>
+    ),
+  },
+  {
+    id: "stages",
+    header: "Stages",
+    cell: ({ row }) => (
+      <span>{row.original.stages?.length || 0}</span>
+    ),
+  },
+  {
+    accessorKey: "published",
+    header: "Status",
+    cell: ({ row }) => (
+      <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+        row.original.published
+          ? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300"
+          : "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300"
+      }`}>
+        {row.original.published ? "Published" : "Draft"}
+      </span>
+    ),
+  },
+  {
+    id: "actions",
+    cell: ({ row }) => {
+      const program = row?.original
+      return <SprayProgramControlDropDown program={program} />
+    },
+  },
+]

--- a/apps/admin-fnp/components/structures/dropdowns/animalHealthProduct-dropdown.tsx
+++ b/apps/admin-fnp/components/structures/dropdowns/animalHealthProduct-dropdown.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import Link from "next/link"
+import { MoreHorizontal } from "lucide-react"
+
+import { AnimalHealthProduct } from "@/lib/schemas"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+interface AnimalHealthProductControlDropDownProps {
+  product?: AnimalHealthProduct
+}
+
+export function AnimalHealthProductControlDropDown({
+  product,
+}: AnimalHealthProductControlDropDownProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className="w-8 h-8 p-0">
+          <span className="sr-only">Open menu</span>
+          <MoreHorizontal className={`h-4 w-4 `} />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Actions</DropdownMenuLabel>
+        <DropdownMenuItem>
+          <Link
+            className="w-full"
+            href={`/dashboard/animal-health-products/${product?.id}/edit`}
+          >
+            Edit
+          </Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/admin-fnp/components/structures/dropdowns/animalHealthTarget-dropdown.tsx
+++ b/apps/admin-fnp/components/structures/dropdowns/animalHealthTarget-dropdown.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import Link from "next/link"
+import { MoreHorizontal } from "lucide-react"
+
+import { AnimalHealthTarget } from "@/lib/schemas"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+interface AnimalHealthTargetControlDropDownProps {
+  target?: AnimalHealthTarget
+}
+
+export function AnimalHealthTargetControlDropDown({
+  target,
+}: AnimalHealthTargetControlDropDownProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className="w-8 h-8 p-0">
+          <span className="sr-only">Open menu</span>
+          <MoreHorizontal className={`h-4 w-4 `} />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Actions</DropdownMenuLabel>
+        <DropdownMenuItem>
+          <Link
+            className="w-full"
+            href={`/dashboard/animal-health-targets/${target?.id}/edit`}
+          >
+            Edit
+          </Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/admin-fnp/components/structures/dropdowns/cdm-price-dropdown.tsx
+++ b/apps/admin-fnp/components/structures/dropdowns/cdm-price-dropdown.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { MoreHorizontal } from "lucide-react"
+
+import { deleteCdmPrice } from "@/lib/query"
+import { CdmPrice } from "@/lib/schemas"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { toast } from "@/components/ui/use-toast"
+
+interface CdmPriceControlDropDownProps {
+  price?: CdmPrice
+}
+
+export function CdmPriceControlDropDown({ price }: CdmPriceControlDropDownProps) {
+  const router = useRouter()
+  const queryClient = useQueryClient()
+  const [open, setOpen] = useState(false)
+
+  const { mutate: deletePrice, isPending } = useMutation({
+    mutationFn: deleteCdmPrice,
+    onSuccess: () => {
+      toast({
+        description: "CDM price deleted successfully",
+      })
+      queryClient.invalidateQueries({ queryKey: ["dashboard-cdm-prices"] })
+      router.refresh()
+    },
+    onError: () => {
+      toast({
+        title: "Error",
+        description: "Failed to delete CDM price",
+        variant: "destructive",
+      })
+    },
+  })
+
+  const handleDelete = () => {
+    if (price?.id && confirm("Are you sure you want to delete this CDM price?")) {
+      deletePrice(price.id)
+    }
+  }
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className="h-8 w-8 p-0">
+          <span className="sr-only">Open menu</span>
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Actions</DropdownMenuLabel>
+        <DropdownMenuItem>
+          <Link
+            className="w-full"
+            href={`/dashboard/cdm-prices/${price?.id}/edit`}
+          >
+            Edit
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          className="text-destructive focus:text-destructive"
+          onClick={handleDelete}
+          disabled={isPending}
+        >
+          {isPending ? "Deleting..." : "Delete"}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/admin-fnp/components/structures/dropdowns/sprayProgram-dropdown.tsx
+++ b/apps/admin-fnp/components/structures/dropdowns/sprayProgram-dropdown.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import Link from "next/link"
+import { MoreHorizontal } from "lucide-react"
+
+import { SprayProgram } from "@/lib/schemas"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+interface SprayProgramControlDropDownProps {
+  program?: SprayProgram
+}
+
+export function SprayProgramControlDropDown({
+  program,
+}: SprayProgramControlDropDownProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className="w-8 h-8 p-0">
+          <span className="sr-only">Open menu</span>
+          <MoreHorizontal className={`h-4 w-4 `} />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Actions</DropdownMenuLabel>
+        <DropdownMenuItem>
+          <Link
+            className="w-full"
+            href={`/dashboard/spray-programs/${program?.slug || program?.id}/edit`}
+          >
+            Edit
+          </Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/admin-fnp/components/structures/forms/cdmExcelImport.tsx
+++ b/apps/admin-fnp/components/structures/forms/cdmExcelImport.tsx
@@ -142,12 +142,25 @@ export function CdmExcelImport({ setValue, setSelectedClient }: CdmExcelImportPr
               }
 
               if (weightRange && TEETH_CATEGORIES.includes(gradeCode)) {
+                // Some 6T entries have prices in the notes column (e.g. "6 Teeth - 1.5" means $1.50 USD)
+                let finalDeliveredUsd = deliveredUsd
+                let finalDeliveredZig = deliveredZig
+                let finalNote = notes
+
+                if (!finalDeliveredUsd && notes) {
+                  const priceMatch = notes.match(/(\d+(?:\.\d+)?)$/)
+                  if (priceMatch) {
+                    finalDeliveredUsd = parseFloat(priceMatch[1])
+                    finalNote = ""
+                  }
+                }
+
                 result.liveweight.push({
                   weight_range: weightRange,
                   teeth: gradeCode,
-                  delivered_usd: deliveredUsd,
-                  delivered_zig: deliveredZig,
-                  grade_note: notes,
+                  delivered_usd: finalDeliveredUsd,
+                  delivered_zig: finalDeliveredZig,
+                  grade_note: finalNote,
                 })
               }
             }

--- a/apps/admin-fnp/components/structures/forms/cdmExcelImport.tsx
+++ b/apps/admin-fnp/components/structures/forms/cdmExcelImport.tsx
@@ -1,0 +1,506 @@
+"use client"
+
+import { useState, useCallback } from "react"
+import { UseFormSetValue } from "react-hook-form"
+import { useDropzone } from "react-dropzone"
+import { CdmPrice, ApplicationUser } from "@/lib/schemas"
+import { queryUsers } from "@/lib/query"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Icons } from "@/components/icons/lucide"
+import { Badge } from "@/components/ui/badge"
+
+type CdmExcelImportProps = {
+  setValue: UseFormSetValue<CdmPrice>
+  setSelectedClient: (client: string) => void
+}
+
+type ParsedCdmData = {
+  metadata: {
+    effectiveDate: string
+    exchangeRate: number
+    userId: string
+    username: string
+  }
+  carcassGrades: {
+    commercial: { collected_usd: number; delivered_usd: number; collected_zig: number; delivered_zig: number }
+    economy: { collected_usd: number; delivered_usd: number; collected_zig: number; delivered_zig: number }
+    manufacturing: { collected_usd: number; delivered_usd: number; collected_zig: number; delivered_zig: number }
+  }
+  liveweight: {
+    weight_range: string
+    teeth: string
+    delivered_usd: number
+    delivered_zig: number
+    grade_note: string
+  }[]
+  notes: string[]
+  errors: string[]
+  warnings: string[]
+}
+
+const WEIGHT_RANGES = ["300+", "260-299", "180-259", "160-180"]
+const TEETH_CATEGORIES = ["MT", "2T", "4T", "6T"]
+
+export function CdmExcelImport({ setValue, setSelectedClient }: CdmExcelImportProps) {
+  const [open, setOpen] = useState(false)
+  const [parsedData, setParsedData] = useState<ParsedCdmData | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+
+  const parseExcelFile = async (file: File): Promise<ParsedCdmData> => {
+    // @ts-ignore - xlsx will be installed separately
+    const XLSX = await import("xlsx")
+
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader()
+
+      reader.onload = (e) => {
+        try {
+          const data = e.target?.result
+          const workbook = XLSX.read(data, { type: "binary" })
+          const sheetName = workbook.SheetNames[0]
+          const worksheet = workbook.Sheets[sheetName]
+
+          const jsonData = XLSX.utils.sheet_to_json(worksheet, {
+            header: 1,
+            raw: false,
+            defval: ""
+          }) as string[][]
+
+          // Extract metadata from rows 2-5 (indices 2-5)
+          const metadata = {
+            effectiveDate: jsonData[2]?.[1]?.toString().trim() || "",
+            exchangeRate: parseFloat(jsonData[3]?.[1] || "35"),
+            username: jsonData[4]?.[1]?.toString().trim() || "",
+            userId: jsonData[5]?.[1]?.toString().trim() || "",
+          }
+
+          const result: ParsedCdmData = {
+            metadata,
+            carcassGrades: {
+              commercial: { collected_usd: 0, delivered_usd: 0, collected_zig: 0, delivered_zig: 0 },
+              economy: { collected_usd: 0, delivered_usd: 0, collected_zig: 0, delivered_zig: 0 },
+              manufacturing: { collected_usd: 0, delivered_usd: 0, collected_zig: 0, delivered_zig: 0 },
+            },
+            liveweight: [],
+            notes: [],
+            errors: [],
+            warnings: [],
+          }
+
+          // Parse data rows starting from row 9 (index 8)
+          for (let i = 8; i < jsonData.length; i++) {
+            const row = jsonData[i]
+            if (!row || row.every(cell => !cell || cell.toString().trim() === "")) continue
+
+            // Check for note rows
+            if (row[0]?.toString().toLowerCase().trim() === "note:") {
+              const noteText = row[1]?.toString().trim()
+              if (noteText) result.notes.push(noteText)
+              continue
+            }
+
+            const category = row[0]?.toString().trim()
+            const grade = row[1]?.toString().trim()
+            const gradeCode = row[2]?.toString().trim() || ""
+            const collectedUsd = parseFloat(row[3]?.toString().trim() || "0") || 0
+            const deliveredUsd = parseFloat(row[4]?.toString().trim() || "0") || 0
+            const collectedZig = parseFloat(row[5]?.toString().trim() || "0") || 0
+            const deliveredZig = parseFloat(row[6]?.toString().trim() || "0") || 0
+            const notes = row[7]?.toString().trim() || ""
+
+            if (!category || !grade) continue
+
+            if (category === "CATTLE") {
+              // Carcass grades
+              const gradeLower = grade.toLowerCase()
+              if (gradeLower.includes("commercial")) {
+                result.carcassGrades.commercial = { collected_usd: collectedUsd, delivered_usd: deliveredUsd, collected_zig: collectedZig, delivered_zig: deliveredZig }
+              } else if (gradeLower.includes("economy")) {
+                result.carcassGrades.economy = { collected_usd: collectedUsd, delivered_usd: deliveredUsd, collected_zig: collectedZig, delivered_zig: deliveredZig }
+              } else if (gradeLower.includes("manufacturing")) {
+                result.carcassGrades.manufacturing = { collected_usd: collectedUsd, delivered_usd: deliveredUsd, collected_zig: collectedZig, delivered_zig: deliveredZig }
+              }
+            } else if (category === "CATTLE LWT") {
+              // Liveweight entries - extract weight range from grade name
+              let weightRange = ""
+              for (const range of WEIGHT_RANGES) {
+                if (grade.startsWith(range)) {
+                  weightRange = range
+                  break
+                }
+              }
+
+              if (weightRange && TEETH_CATEGORIES.includes(gradeCode)) {
+                result.liveweight.push({
+                  weight_range: weightRange,
+                  teeth: gradeCode,
+                  delivered_usd: deliveredUsd,
+                  delivered_zig: deliveredZig,
+                  grade_note: notes,
+                })
+              }
+            }
+          }
+
+          // Validation
+          const hasAnyCarcassPrice = Object.values(result.carcassGrades).some(
+            g => g.collected_usd > 0 || g.delivered_usd > 0
+          )
+          if (!hasAnyCarcassPrice) {
+            result.warnings.push("No carcass grade prices found")
+          }
+          if (result.liveweight.length === 0) {
+            result.warnings.push("No liveweight entries found")
+          }
+
+          resolve(result)
+        } catch (error) {
+          reject(new Error(`Failed to parse Excel file: ${error}`))
+        }
+      }
+
+      reader.onerror = () => reject(new Error("Failed to read file"))
+      reader.readAsBinaryString(file)
+    })
+  }
+
+  const onDrop = useCallback(async (acceptedFiles: File[]) => {
+    if (acceptedFiles.length === 0) return
+
+    setIsLoading(true)
+    try {
+      const file = acceptedFiles[0]
+      const data = await parseExcelFile(file)
+      setParsedData(data)
+    } catch (error) {
+      setParsedData({
+        metadata: { effectiveDate: "", exchangeRate: 35, userId: "", username: "" },
+        carcassGrades: {
+          commercial: { collected_usd: 0, delivered_usd: 0, collected_zig: 0, delivered_zig: 0 },
+          economy: { collected_usd: 0, delivered_usd: 0, collected_zig: 0, delivered_zig: 0 },
+          manufacturing: { collected_usd: 0, delivered_usd: 0, collected_zig: 0, delivered_zig: 0 },
+        },
+        liveweight: [],
+        errors: [error instanceof Error ? error.message : "Unknown error occurred"],
+        warnings: [],
+        notes: [],
+      })
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop,
+    accept: {
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": [".xlsx"],
+      "application/vnd.ms-excel": [".xls"],
+    },
+    maxFiles: 1,
+  })
+
+  const applyParsedData = async () => {
+    if (!parsedData || parsedData.errors.length > 0) return
+
+    setIsLoading(true)
+
+    try {
+      // Search for client by username
+      if (parsedData.metadata.username) {
+        try {
+          const clientResponse = await queryUsers({ search: parsedData.metadata.username })
+          const users = clientResponse.data.data as ApplicationUser[] | null
+
+          if (users && Array.isArray(users)) {
+            const match = users.find((user: ApplicationUser) =>
+              user.name.toLowerCase().includes(parsedData.metadata.username.toLowerCase())
+            )
+
+            if (match) {
+              setValue("client_id", match.id)
+              setValue("client_name", match.name)
+              setValue("verified", match.verified)
+              setSelectedClient(match.name)
+            }
+          }
+        } catch (error) {
+          console.error("Error searching for client:", error)
+        }
+      }
+
+      // Set effective date
+      if (parsedData.metadata.effectiveDate) {
+        setValue("effectiveDate", new Date(parsedData.metadata.effectiveDate) as any)
+      }
+
+      // Set exchange rate
+      if (parsedData.metadata.exchangeRate) {
+        setValue("exchange_rate", parsedData.metadata.exchangeRate)
+      }
+
+      // Set carcass grades
+      setValue("carcass_grades.commercial", parsedData.carcassGrades.commercial)
+      setValue("carcass_grades.economy", parsedData.carcassGrades.economy)
+      setValue("carcass_grades.manufacturing", parsedData.carcassGrades.manufacturing)
+
+      // Build full 16-entry liveweight array (4 weight ranges × 4 teeth categories)
+      const liveweightArray = WEIGHT_RANGES.flatMap((range) =>
+        TEETH_CATEGORIES.map((teeth) => {
+          const match = parsedData.liveweight.find(
+            (lw) => lw.weight_range === range && lw.teeth === teeth
+          )
+          return {
+            weight_range: range,
+            teeth,
+            delivered_usd: match?.delivered_usd || 0,
+            delivered_zig: match?.delivered_zig || 0,
+            grade_note: match?.grade_note || "",
+          }
+        })
+      )
+      setValue("liveweight", liveweightArray)
+
+      // Set notes
+      if (parsedData.notes.length > 0) {
+        setValue("notes", parsedData.notes)
+      }
+
+      setOpen(false)
+      setParsedData(null)
+    } catch (error) {
+      console.error("Error applying parsed data:", error)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button type="button" variant="outline" size="sm" className="gap-2">
+          <Icons.fileSpreadsheet className="size-4" />
+          Import from Excel
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-3xl max-h-[80vh]">
+        <DialogHeader>
+          <DialogTitle>Import CDM Price List from Excel</DialogTitle>
+          <DialogDescription>
+            Upload an Excel file (.xlsx) containing Cold Dress Mass pricing data
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {!parsedData ? (
+            <div
+              {...getRootProps()}
+              className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors ${
+                isDragActive
+                  ? "border-primary bg-primary/5"
+                  : "border-muted-foreground/25 hover:border-primary/50"
+              }`}
+            >
+              <input {...getInputProps()} />
+              <div className="flex flex-col items-center gap-2">
+                <Icons.upload className="size-12 text-muted-foreground" />
+                {isLoading ? (
+                  <p className="text-sm text-muted-foreground">Parsing Excel file...</p>
+                ) : isDragActive ? (
+                  <p className="text-sm text-muted-foreground">Drop the file here</p>
+                ) : (
+                  <>
+                    <p className="text-sm text-muted-foreground">
+                      Drag & drop a CDM Excel file here, or click to select
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      Supported formats: .xlsx, .xls
+                    </p>
+                  </>
+                )}
+              </div>
+            </div>
+          ) : (
+            <ScrollArea className="h-[400px] w-full rounded-md border p-4">
+              <div className="space-y-4">
+                {/* Errors */}
+                {parsedData.errors.length > 0 && (
+                  <Alert variant="destructive">
+                    <Icons.alertCircle className="size-4" />
+                    <AlertTitle>Errors Found</AlertTitle>
+                    <AlertDescription>
+                      <ul className="list-disc pl-4 space-y-1">
+                        {parsedData.errors.map((error, i) => (
+                          <li key={i}>{error}</li>
+                        ))}
+                      </ul>
+                    </AlertDescription>
+                  </Alert>
+                )}
+
+                {/* Warnings */}
+                {parsedData.warnings.length > 0 && (
+                  <Alert>
+                    <Icons.alertTriangle className="size-4" />
+                    <AlertTitle>Warnings</AlertTitle>
+                    <AlertDescription>
+                      <ul className="list-disc pl-4 space-y-1">
+                        {parsedData.warnings.map((warning, i) => (
+                          <li key={i}>{warning}</li>
+                        ))}
+                      </ul>
+                    </AlertDescription>
+                  </Alert>
+                )}
+
+                {/* Preview */}
+                {parsedData.errors.length === 0 && (
+                  <div className="space-y-4">
+                    {/* Metadata */}
+                    <div className="rounded-lg border p-3 bg-gray-50">
+                      <h4 className="font-medium mb-2 text-sm">Excel Metadata</h4>
+                      <div className="grid grid-cols-2 gap-2 text-xs">
+                        <div>
+                          <span className="text-muted-foreground">Effective Date:</span>{" "}
+                          <span className="font-medium">{parsedData.metadata.effectiveDate || "Not set"}</span>
+                        </div>
+                        <div>
+                          <span className="text-muted-foreground">Exchange Rate:</span>{" "}
+                          <span className="font-medium">{parsedData.metadata.exchangeRate} ZIG</span>
+                        </div>
+                        <div>
+                          <span className="text-muted-foreground">Client:</span>{" "}
+                          <span className="font-medium">{parsedData.metadata.username || "Not set"}</span>
+                        </div>
+                        <div>
+                          <span className="text-muted-foreground">User ID:</span>{" "}
+                          <span className="font-medium">{parsedData.metadata.userId || "Not set"}</span>
+                        </div>
+                      </div>
+                    </div>
+
+                    {/* Carcass Grades Preview */}
+                    <Card>
+                      <CardHeader className="py-3 bg-gray-50">
+                        <CardTitle className="text-sm">Carcass Grades (per kg)</CardTitle>
+                      </CardHeader>
+                      <CardContent className="py-2">
+                        <table className="w-full text-xs">
+                          <thead>
+                            <tr className="border-b">
+                              <th className="py-1 text-left">Grade</th>
+                              <th className="py-1 text-right">Col. USD</th>
+                              <th className="py-1 text-right">Del. USD</th>
+                              <th className="py-1 text-right">Col. ZIG</th>
+                              <th className="py-1 text-right">Del. ZIG</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {(["commercial", "economy", "manufacturing"] as const).map((grade) => {
+                              const data = parsedData.carcassGrades[grade]
+                              return (
+                                <tr key={grade} className="border-b">
+                                  <td className="py-1 font-medium capitalize">{grade}</td>
+                                  <td className="py-1 text-right">${data.collected_usd.toFixed(2)}</td>
+                                  <td className="py-1 text-right">${data.delivered_usd.toFixed(2)}</td>
+                                  <td className="py-1 text-right">{data.collected_zig.toFixed(2)}</td>
+                                  <td className="py-1 text-right">{data.delivered_zig.toFixed(2)}</td>
+                                </tr>
+                              )
+                            })}
+                          </tbody>
+                        </table>
+                      </CardContent>
+                    </Card>
+
+                    {/* Liveweight Preview */}
+                    <Card>
+                      <CardHeader className="py-3 bg-gray-50">
+                        <CardTitle className="text-sm">Liveweight Entries ({parsedData.liveweight.length})</CardTitle>
+                      </CardHeader>
+                      <CardContent className="py-2">
+                        <table className="w-full text-xs">
+                          <thead>
+                            <tr className="border-b">
+                              <th className="py-1 text-left">Weight</th>
+                              <th className="py-1 text-left">Teeth</th>
+                              <th className="py-1 text-right">Del. USD</th>
+                              <th className="py-1 text-right">Del. ZIG</th>
+                              <th className="py-1 text-left">Note</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {parsedData.liveweight.map((lw, i) => (
+                              <tr key={i} className="border-b">
+                                <td className="py-1">{lw.weight_range}</td>
+                                <td className="py-1">
+                                  <Badge variant="secondary" className="text-[10px] px-1 py-0">{lw.teeth}</Badge>
+                                </td>
+                                <td className="py-1 text-right">{lw.delivered_usd ? `$${lw.delivered_usd.toFixed(2)}` : "-"}</td>
+                                <td className="py-1 text-right">{lw.delivered_zig ? lw.delivered_zig.toFixed(2) : "-"}</td>
+                                <td className="py-1 text-muted-foreground truncate max-w-[150px]">{lw.grade_note || "-"}</td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </CardContent>
+                    </Card>
+
+                    {/* Notes Preview */}
+                    {parsedData.notes.length > 0 && (
+                      <div>
+                        <h4 className="font-medium mb-2 text-sm">Notes ({parsedData.notes.length})</h4>
+                        <div className="space-y-1">
+                          {parsedData.notes.map((note, i) => (
+                            <Alert key={i}>
+                              <Icons.info className="size-4" />
+                              <AlertDescription className="text-xs">{note}</AlertDescription>
+                            </Alert>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            </ScrollArea>
+          )}
+
+          {/* Actions */}
+          <div className="flex gap-2 justify-end">
+            {parsedData && (
+              <Button type="button" variant="outline" onClick={() => setParsedData(null)}>
+                Upload Different File
+              </Button>
+            )}
+            {parsedData && parsedData.errors.length === 0 && (
+              <Button type="button" onClick={applyParsedData} disabled={isLoading}>
+                {isLoading ? (
+                  <>
+                    <Icons.loader className="size-4 mr-2 animate-spin" />
+                    Applying...
+                  </>
+                ) : (
+                  <>
+                    <Icons.check className="size-4 mr-2" />
+                    Apply to Form
+                  </>
+                )}
+              </Button>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/admin-fnp/components/structures/forms/cdmPriceForm.tsx
+++ b/apps/admin-fnp/components/structures/forms/cdmPriceForm.tsx
@@ -1,0 +1,557 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { useMutation, useQuery } from "@tanstack/react-query"
+import { isAxiosError } from "axios"
+import { format } from "date-fns"
+import { useForm, useFieldArray } from "react-hook-form"
+import { useDebounce } from "use-debounce"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { CalendarIcon, Plus, Trash2 } from "lucide-react"
+
+import { addCdmPrice, updateCdmPrice, queryUsers } from "@/lib/query"
+import {
+  ApplicationUser,
+  CdmPrice,
+  CdmPriceSchema,
+} from "@/lib/schemas"
+import { cn } from "@/lib/utilities"
+import { handleApiError, handleFormErrors } from "@/lib/error-handler"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Calendar } from "@/components/ui/calendar"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Command,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { toast } from "@/components/ui/use-toast"
+import { Icons } from "@/components/icons/lucide"
+import { CdmExcelImport } from "@/components/structures/forms/cdmExcelImport"
+
+const WEIGHT_RANGES = ["300+", "260-299", "180-259", "160-180"]
+const TEETH_CATEGORIES = ["MT", "2T", "4T", "6T"]
+
+const defaultLiveweightEntries = WEIGHT_RANGES.flatMap((range) =>
+  TEETH_CATEGORIES.map((teeth) => ({
+    weight_range: range,
+    teeth,
+    delivered_usd: 0,
+    delivered_zig: 0,
+    grade_note: "",
+  }))
+)
+
+const defaultCarcassGrade = {
+  collected_usd: 0,
+  delivered_usd: 0,
+  collected_zig: 0,
+  delivered_zig: 0,
+}
+
+interface CdmPriceFormProps {
+  price?: CdmPrice
+  mode: "create" | "edit"
+}
+
+export function CdmPriceForm({ price, mode }: CdmPriceFormProps) {
+  const router = useRouter()
+  const [searchClient, setSearchClient] = useState(price?.client_name || "")
+  const [selectedClient, setSelectedClient] = useState(price?.client_name || "")
+  const [openClient, setOpenClient] = useState(false)
+  const [openCalendar, setOpenCalendar] = useState(false)
+  const [noteInput, setNoteInput] = useState("")
+
+  const form = useForm<CdmPrice>({
+    defaultValues: price
+      ? {
+          ...price,
+          effectiveDate: new Date(price.effectiveDate),
+        }
+      : {
+          id: "",
+          client_id: "",
+          client_name: "",
+          effectiveDate: new Date(),
+          exchange_rate: 0,
+          carcass_grades: {
+            commercial: { ...defaultCarcassGrade },
+            economy: { ...defaultCarcassGrade },
+            manufacturing: { ...defaultCarcassGrade },
+          },
+          liveweight: defaultLiveweightEntries,
+          notes: [],
+        },
+    resolver: zodResolver(CdmPriceSchema),
+  })
+
+  const { fields: liveweightFields } = useFieldArray({
+    control: form.control,
+    name: "liveweight" as any,
+  })
+
+  const notes = form.watch("notes")
+
+  // Client search
+  const [debouncedSearchQuery] = useDebounce(searchClient, 1000)
+  const enabled = !!debouncedSearchQuery
+
+  const { data } = useQuery({
+    queryKey: ["dashboard-client", { search: debouncedSearchQuery }],
+    queryFn: () => queryUsers({ search: debouncedSearchQuery }),
+    enabled,
+  })
+
+  const clients = data?.data?.data as ApplicationUser[]
+
+  // Mutations
+  const { mutate: createMutate, isPending: isCreating } = useMutation({
+    mutationFn: addCdmPrice,
+    onSuccess: () => {
+      toast({ description: "CDM price created successfully" })
+      router.push("/dashboard/cdm-prices")
+    },
+    onError: (error) => {
+      handleApiError(error, { context: "CDM price creation" })
+    },
+  })
+
+  const { mutate: updateMutate, isPending: isUpdating } = useMutation({
+    mutationFn: updateCdmPrice,
+    onSuccess: () => {
+      toast({ description: "CDM price updated successfully" })
+      router.push("/dashboard/cdm-prices")
+    },
+    onError: (error) => {
+      handleApiError(error, { context: "CDM price update" })
+    },
+  })
+
+  const isPending = isCreating || isUpdating
+
+  function onSubmit(data: CdmPrice) {
+    // Set client_name from selected
+    data.client_name = selectedClient
+    if (mode === "create") {
+      createMutate(data)
+    } else {
+      updateMutate(data)
+    }
+  }
+
+  function addNote() {
+    if (noteInput.trim()) {
+      const current = form.getValues("notes") || []
+      form.setValue("notes", [...current, noteInput.trim()])
+      setNoteInput("")
+    }
+  }
+
+  function removeNote(index: number) {
+    const current = form.getValues("notes") || []
+    form.setValue(
+      "notes",
+      current.filter((_, i) => i !== index)
+    )
+  }
+
+  return (
+    <div className="space-y-10">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">
+            {mode === "create" ? "Add CDM Price" : "Edit CDM Price"}
+          </h1>
+          <p className="mt-2 text-sm text-gray-600">
+            {mode === "create"
+              ? "Create a new Cold Dress Mass price list"
+              : "Update CDM price list"}
+          </p>
+        </div>
+        <CdmExcelImport
+          setValue={form.setValue}
+          setSelectedClient={setSelectedClient}
+        />
+      </div>
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit, handleFormErrors)} className="space-y-8">
+          {/* Client & Date Section */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Price Details</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="grid grid-cols-1 gap-6 sm:grid-cols-3">
+                {/* Client selector */}
+                <FormField
+                  control={form.control}
+                  name="client_id"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Client</FormLabel>
+                      <FormControl>
+                        <Popover open={openClient} onOpenChange={setOpenClient}>
+                          <PopoverTrigger asChild className="w-full">
+                            <div className="group min-h-10 rounded-md border border-input px-3 py-2 text-sm ring-offset-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-0 cursor-pointer" tabIndex={0} role="button">
+                              <div className="flex flex-wrap gap-1">
+                                {selectedClient.length > 1 ? (
+                                  <Badge
+                                    variant="outline"
+                                    className="flex justify-between text-green-800 bg-green-100 border-green-400"
+                                  >
+                                    {selectedClient}
+                                  </Badge>
+                                ) : (
+                                  "Select Client..."
+                                )}
+                              </div>
+                            </div>
+                          </PopoverTrigger>
+                          <PopoverContent className="w-[320px] p-0">
+                            <Command shouldFilter={false}>
+                              <CommandInput
+                                value={searchClient}
+                                onValueChange={setSearchClient}
+                                placeholder="Search clients..."
+                              />
+                              {clients?.length > 0 ? (
+                                <CommandList className="mb-8 max-h-[150px]">
+                                  {clients.map((client) => (
+                                    <CommandItem
+                                      key={client.id}
+                                      value={client.id}
+                                      onSelect={(value) => {
+                                        field.onChange(value)
+                                        setSelectedClient(client.name)
+                                        form.setValue("client_name", client.name)
+                                        form.setValue("verified", client.verified)
+                                        setOpenClient(false)
+                                        setSearchClient("")
+                                      }}
+                                    >
+                                      <span>{client.name}</span>
+                                    </CommandItem>
+                                  ))}
+                                </CommandList>
+                              ) : null}
+                            </Command>
+                          </PopoverContent>
+                        </Popover>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                {/* Effective Date */}
+                <FormField
+                  control={form.control}
+                  name="effectiveDate"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Effective Date</FormLabel>
+                      <Popover open={openCalendar} onOpenChange={setOpenCalendar}>
+                        <PopoverTrigger asChild>
+                          <FormControl>
+                            <Button
+                              variant="outline"
+                              className={cn(
+                                "w-full pl-3 text-left font-normal",
+                                !field.value && "text-muted-foreground"
+                              )}
+                            >
+                              {field.value ? format(field.value, "dd MMMM yyyy") : "Pick a date"}
+                              <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                            </Button>
+                          </FormControl>
+                        </PopoverTrigger>
+                        <PopoverContent className="w-auto p-0" align="start">
+                          <Calendar
+                            mode="single"
+                            selected={field.value ? new Date(field.value) : undefined}
+                            onSelect={(date) => {
+                              field.onChange(date)
+                              setOpenCalendar(false)
+                            }}
+                            initialFocus
+                          />
+                        </PopoverContent>
+                      </Popover>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                {/* Exchange Rate */}
+                <FormField
+                  control={form.control}
+                  name="exchange_rate"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Exchange Rate (USD to ZIG)</FormLabel>
+                      <FormControl>
+                        <Input
+                          type="number"
+                          step="0.01"
+                          placeholder="e.g. 27.50"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Carcass Grades Section */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Carcass Grades (per kg)</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b">
+                      <th className="py-2 text-left font-medium">Grade</th>
+                      <th className="py-2 text-left font-medium">Collected USD</th>
+                      <th className="py-2 text-left font-medium">Delivered USD</th>
+                      <th className="py-2 text-left font-medium">Collected ZIG</th>
+                      <th className="py-2 text-left font-medium">Delivered ZIG</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {(["commercial", "economy", "manufacturing"] as const).map((grade) => (
+                      <tr key={grade} className="border-b">
+                        <td className="py-3 font-medium capitalize">{grade} ({grade === "commercial" ? "C" : grade === "economy" ? "X" : "J"})</td>
+                        {(["collected_usd", "delivered_usd", "collected_zig", "delivered_zig"] as const).map((priceField) => (
+                          <td key={priceField} className="py-3 pr-2">
+                            <FormField
+                              control={form.control}
+                              name={`carcass_grades.${grade}.${priceField}`}
+                              render={({ field }) => (
+                                <FormItem>
+                                  <FormControl>
+                                    <Input
+                                      type="number"
+                                      step="0.01"
+                                      className="w-28"
+                                      {...field}
+                                    />
+                                  </FormControl>
+                                </FormItem>
+                              )}
+                            />
+                          </td>
+                        ))}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Liveweight Section */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Liveweight Prices (per kg delivered)</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b">
+                      <th className="py-2 text-left font-medium">Weight Range (kg)</th>
+                      <th className="py-2 text-left font-medium">Teeth</th>
+                      <th className="py-2 text-left font-medium">Delivered USD</th>
+                      <th className="py-2 text-left font-medium">Delivered ZIG</th>
+                      <th className="py-2 text-left font-medium">Grade Note</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {liveweightFields.map((field, index) => (
+                      <tr key={field.id} className="border-b">
+                        <td className="py-3">
+                          <FormField
+                            control={form.control}
+                            name={`liveweight.${index}.weight_range`}
+                            render={({ field }) => (
+                              <FormItem>
+                                <FormControl>
+                                  <Select onValueChange={field.onChange} value={field.value}>
+                                    <SelectTrigger className="w-28">
+                                      <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                      {WEIGHT_RANGES.map((range) => (
+                                        <SelectItem key={range} value={range}>
+                                          {range}
+                                        </SelectItem>
+                                      ))}
+                                    </SelectContent>
+                                  </Select>
+                                </FormControl>
+                              </FormItem>
+                            )}
+                          />
+                        </td>
+                        <td className="py-3">
+                          <FormField
+                            control={form.control}
+                            name={`liveweight.${index}.teeth`}
+                            render={({ field }) => (
+                              <FormItem>
+                                <FormControl>
+                                  <Select onValueChange={field.onChange} value={field.value}>
+                                    <SelectTrigger className="w-20">
+                                      <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                      {TEETH_CATEGORIES.map((teeth) => (
+                                        <SelectItem key={teeth} value={teeth}>
+                                          {teeth}
+                                        </SelectItem>
+                                      ))}
+                                    </SelectContent>
+                                  </Select>
+                                </FormControl>
+                              </FormItem>
+                            )}
+                          />
+                        </td>
+                        <td className="py-3 pr-2">
+                          <FormField
+                            control={form.control}
+                            name={`liveweight.${index}.delivered_usd`}
+                            render={({ field }) => (
+                              <FormItem>
+                                <FormControl>
+                                  <Input type="number" step="0.01" className="w-28" {...field} />
+                                </FormControl>
+                              </FormItem>
+                            )}
+                          />
+                        </td>
+                        <td className="py-3 pr-2">
+                          <FormField
+                            control={form.control}
+                            name={`liveweight.${index}.delivered_zig`}
+                            render={({ field }) => (
+                              <FormItem>
+                                <FormControl>
+                                  <Input type="number" step="0.01" className="w-28" {...field} />
+                                </FormControl>
+                              </FormItem>
+                            )}
+                          />
+                        </td>
+                        <td className="py-3">
+                          <FormField
+                            control={form.control}
+                            name={`liveweight.${index}.grade_note`}
+                            render={({ field }) => (
+                              <FormItem>
+                                <FormControl>
+                                  <Input placeholder="e.g. Kill / Low Grade" className="w-40" {...field} />
+                                </FormControl>
+                              </FormItem>
+                            )}
+                          />
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Notes Section */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Notes</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex gap-2">
+                <Input
+                  value={noteInput}
+                  onChange={(e) => setNoteInput(e.target.value)}
+                  placeholder="Add a note..."
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault()
+                      addNote()
+                    }
+                  }}
+                />
+                <Button type="button" variant="outline" onClick={addNote}>
+                  <Plus className="h-4 w-4" />
+                </Button>
+              </div>
+              {notes && notes.length > 0 && (
+                <ul className="space-y-2">
+                  {notes.map((note, index) => (
+                    <li key={index} className="flex items-center justify-between rounded-md border px-3 py-2 text-sm">
+                      <span>{note}</span>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => removeNote(index)}
+                      >
+                        <Trash2 className="h-4 w-4 text-destructive" />
+                      </Button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Submit */}
+          <div className="flex items-center justify-end gap-x-6">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => router.push("/dashboard/cdm-prices")}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isPending}>
+              {isPending && <Icons.spinner className="mr-2 h-4 w-4 animate-spin" />}
+              {mode === "create" ? "Create" : "Update"}
+            </Button>
+          </div>
+        </form>
+      </Form>
+    </div>
+  )
+}

--- a/apps/admin-fnp/components/structures/forms/sprayProgramForm.tsx
+++ b/apps/admin-fnp/components/structures/forms/sprayProgramForm.tsx
@@ -1,0 +1,632 @@
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useMutation, useQuery } from "@tanstack/react-query"
+import { useForm } from "react-hook-form"
+import { useRouter } from "next/navigation"
+import { useState, useEffect } from "react"
+import { useDebounce } from "use-debounce"
+import { Check, ChevronsUpDown, Plus, Trash2, ChevronUp, ChevronDown } from "lucide-react"
+
+import { addSprayProgram, updateSprayProgram, queryAllFarmProduce, queryAgroChemicals } from "@/lib/query"
+import {
+    FormSprayProgramModel,
+    FormSprayProgramSchema,
+    FarmProduce,
+    AgroChemicalItem,
+} from "@/lib/schemas"
+import { cn, logFormPayload } from "@/lib/utilities"
+import { handleApiError, handleFormErrors } from "@/lib/error-handler"
+
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
+} from "@/components/ui/form"
+
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { toast } from "@/components/ui/use-toast"
+import { Icons } from "@/components/icons/lucide"
+import {
+    Command,
+    CommandInput,
+    CommandItem,
+    CommandList,
+    CommandEmpty,
+} from "@/components/ui/command"
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from "@/components/ui/popover"
+import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
+import { FileInput } from "@/components/structures/controls/file-input"
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select"
+
+interface SprayProgramFormProps extends React.HTMLAttributes<HTMLDivElement> {
+    sprayProgram: FormSprayProgramModel
+    mode?: "create" | "edit"
+}
+
+const PURPOSE_OPTIONS = [
+    "Weed Control",
+    "Insect Control",
+    "Disease Prevention",
+    "Disease Control",
+    "Growth Regulation",
+    "Nutrient Management",
+    "Soil Treatment",
+    "Seed Treatment",
+]
+
+const APPLICATION_METHODS = [
+    "Foliar spray",
+    "Soil drench",
+    "Seed treatment",
+    "Band application",
+    "Broadcasting",
+    "Spot treatment",
+    "Dipping",
+]
+
+
+export function SprayProgramForm({ sprayProgram, mode = "create" }: SprayProgramFormProps) {
+    const isEditMode = mode === "edit" || !!sprayProgram?.id
+
+    const form = useForm({
+        defaultValues: {
+            id: sprayProgram?.id || "",
+            name: sprayProgram?.name || "",
+            description: sprayProgram?.description || "",
+            farm_produce_id: sprayProgram?.farm_produce_id || "",
+            cover_image: sprayProgram?.cover_image || null,
+            stages: sprayProgram?.stages || [],
+            published: sprayProgram?.published || false,
+        },
+        resolver: zodResolver(FormSprayProgramSchema),
+    })
+
+    const router = useRouter()
+
+    // Crop selection state
+    const [selectedCropName, setSelectedCropName] = useState("")
+    const [openCrop, setOpenCrop] = useState(false)
+
+    // Fetch all crops
+    const { data: cropData } = useQuery({
+        queryKey: ["all-farm-produce"],
+        queryFn: () => queryAllFarmProduce(),
+        refetchOnWindowFocus: false,
+    })
+
+    const crops = (cropData?.data?.data || cropData?.data || []) as FarmProduce[]
+
+    // Set crop name in edit mode
+    useEffect(() => {
+        if (isEditMode && sprayProgram?.farm_produce_id && crops.length > 0) {
+            const crop = crops.find((c: FarmProduce) => c.id === sprayProgram.farm_produce_id)
+            if (crop) setSelectedCropName(crop.name)
+        }
+    }, [isEditMode, sprayProgram?.farm_produce_id, crops])
+
+    // Agrochemical search for recommendations
+    const [searchAgroChemical, setSearchAgroChemical] = useState("")
+    const [debouncedAgroSearch] = useDebounce(searchAgroChemical, 500)
+    const [openAgroChemical, setOpenAgroChemical] = useState(false)
+    const [activeStageIdx, setActiveStageIdx] = useState<number | null>(null)
+
+    const { data: agroChemicalData } = useQuery({
+        queryKey: ["search-agrochemicals", { search: debouncedAgroSearch }],
+        queryFn: () => queryAgroChemicals({ search: debouncedAgroSearch }),
+        enabled: !!debouncedAgroSearch && debouncedAgroSearch.length >= 2,
+        refetchOnWindowFocus: false,
+    })
+
+    const agroChemicals = (agroChemicalData?.data?.data || []) as AgroChemicalItem[]
+
+    // Mutation
+    const { mutate, isPending } = useMutation({
+        mutationFn: isEditMode ? updateSprayProgram : addSprayProgram,
+        onSuccess: () => {
+            toast({ description: isEditMode ? "Spray program updated!" : "Spray program created!" })
+            router.push("/dashboard/spray-programs")
+        },
+        onError: (error) => handleApiError(error, { context: "spray program" }),
+    })
+
+    function onSubmit(payload: any) {
+        logFormPayload(payload, "spray-program")
+        mutate(payload)
+    }
+
+    function onError(errors: any) {
+        handleFormErrors(errors, { context: "spray program" })
+    }
+
+    // Stage management
+    const stages = form.watch("stages") || []
+
+    function addStage() {
+        const current = form.getValues("stages") || []
+        form.setValue("stages", [
+            ...current,
+            {
+                name: "",
+                order: current.length + 1,
+                description: "",
+                timing_description: "",
+                recommendations: [],
+            },
+        ])
+    }
+
+    function removeStage(idx: number) {
+        const current = form.getValues("stages") || []
+        const updated = current.filter((_: any, i: number) => i !== idx)
+            .map((s: any, i: number) => ({ ...s, order: i + 1 }))
+        form.setValue("stages", updated)
+    }
+
+    function moveStage(idx: number, direction: "up" | "down") {
+        const current = [...(form.getValues("stages") || [])]
+        const newIdx = direction === "up" ? idx - 1 : idx + 1
+        if (newIdx < 0 || newIdx >= current.length) return
+        ;[current[idx], current[newIdx]] = [current[newIdx], current[idx]]
+        const updated = current.map((s: any, i: number) => ({ ...s, order: i + 1 }))
+        form.setValue("stages", updated)
+    }
+
+    // Recommendation management
+    function addRecommendation(stageIdx: number, agroChemical: AgroChemicalItem) {
+        const current = form.getValues("stages") || []
+        const stage = { ...current[stageIdx] }
+        const existing = stage.recommendations || []
+
+        // Prevent duplicates
+        if (existing.some((r: any) => r.agrochemical_id === agroChemical.id)) return
+
+        stage.recommendations = [
+            ...existing,
+            {
+                agrochemical_id: agroChemical.id,
+                agrochemical_name: agroChemical.name,
+                agrochemical_slug: agroChemical.slug || "",
+                purpose: "",
+                dosage: { value: "", unit: "", per: "" },
+                application_method: "",
+                notes: "",
+            },
+        ]
+        const updated = [...current]
+        updated[stageIdx] = stage
+        form.setValue("stages", updated)
+        setOpenAgroChemical(false)
+        setSearchAgroChemical("")
+    }
+
+    function removeRecommendation(stageIdx: number, recIdx: number) {
+        const current = form.getValues("stages") || []
+        const stage = { ...current[stageIdx] }
+        stage.recommendations = stage.recommendations.filter((_: any, i: number) => i !== recIdx)
+        const updated = [...current]
+        updated[stageIdx] = stage
+        form.setValue("stages", updated)
+    }
+
+    function updateRecommendation(stageIdx: number, recIdx: number, field: string, value: any) {
+        const current = form.getValues("stages") || []
+        const stage = { ...current[stageIdx] }
+        const recs = [...stage.recommendations]
+        if (field.startsWith("dosage.")) {
+            const dosageField = field.split(".")[1]
+            recs[recIdx] = { ...recs[recIdx], dosage: { ...recs[recIdx].dosage, [dosageField]: value } }
+        } else {
+            recs[recIdx] = { ...recs[recIdx], [field]: value }
+        }
+        stage.recommendations = recs
+        const updated = [...current]
+        updated[stageIdx] = stage
+        form.setValue("stages", updated)
+    }
+
+    return (
+        <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit, onError)} className="space-y-8">
+                {/* Basic Information */}
+                <div className="space-y-4">
+                    <h3 className="text-lg font-semibold">Basic Information</h3>
+
+                    <FormField
+                        control={form.control}
+                        name="name"
+                        render={({ field }) => (
+                            <FormItem>
+                                <FormLabel>Name</FormLabel>
+                                <FormControl>
+                                    <Input {...field} placeholder="e.g., Tomato Spray Program" />
+                                </FormControl>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+
+                    <FormField
+                        control={form.control}
+                        name="description"
+                        render={({ field }) => (
+                            <FormItem>
+                                <FormLabel>Description</FormLabel>
+                                <FormControl>
+                                    <Textarea {...field} placeholder="Describe the spray program..." rows={3} />
+                                </FormControl>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+
+                    {/* Crop Select */}
+                    <FormField
+                        control={form.control}
+                        name="farm_produce_id"
+                        render={({ field }) => (
+                            <FormItem className="flex flex-col">
+                                <FormLabel>Crop</FormLabel>
+                                <Popover open={openCrop} onOpenChange={setOpenCrop}>
+                                    <PopoverTrigger asChild>
+                                        <FormControl>
+                                            <Button
+                                                variant="outline"
+                                                role="combobox"
+                                                className={cn(
+                                                    "w-full justify-between",
+                                                    !field.value && "text-muted-foreground"
+                                                )}
+                                            >
+                                                {field.value ? selectedCropName : "Select crop"}
+                                                <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                                            </Button>
+                                        </FormControl>
+                                    </PopoverTrigger>
+                                    <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
+                                        <Command>
+                                            <CommandInput placeholder="Search crop..." />
+                                            <CommandList>
+                                                <CommandEmpty>No crop found</CommandEmpty>
+                                                {crops.map((crop: FarmProduce) => (
+                                                    <CommandItem
+                                                        value={crop.name}
+                                                        key={crop.id}
+                                                        onSelect={() => {
+                                                            form.setValue("farm_produce_id", crop.id)
+                                                            setSelectedCropName(crop.name)
+                                                            setOpenCrop(false)
+                                                        }}
+                                                    >
+                                                        <Check
+                                                            className={cn(
+                                                                "mr-2 h-4 w-4",
+                                                                crop.id === field.value ? "opacity-100" : "opacity-0"
+                                                            )}
+                                                        />
+                                                        <span className="capitalize">{crop.name}</span>
+                                                    </CommandItem>
+                                                ))}
+                                            </CommandList>
+                                        </Command>
+                                    </PopoverContent>
+                                </Popover>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+
+                    {/* Published */}
+                    <FormField
+                        control={form.control}
+                        name="published"
+                        render={({ field }) => (
+                            <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                                <FormControl>
+                                    <Checkbox
+                                        checked={field.value}
+                                        onCheckedChange={field.onChange}
+                                    />
+                                </FormControl>
+                                <div className="space-y-1 leading-none">
+                                    <FormLabel>Published</FormLabel>
+                                    <p className="text-sm text-muted-foreground">
+                                        Make this spray program visible to the public
+                                    </p>
+                                </div>
+                            </FormItem>
+                        )}
+                    />
+                </div>
+
+                {/* Cover Image */}
+                <div className="space-y-4">
+                    <h3 className="text-lg font-semibold">Cover Image</h3>
+                    <FormField
+                        control={form.control}
+                        name="cover_image"
+                        render={({ field }) => (
+                            <FormItem>
+                                <FormControl>
+                                    <FileInput
+                                        value={field.value ? [field.value] : []}
+                                        fieldName="cover_image"
+                                        onChange={(images: any) => {
+                                            field.onChange(images && images.length > 0 ? images[0] : null)
+                                        }}
+                                        maxImages={1}
+                                    />
+                                </FormControl>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+                </div>
+
+                {/* Stages */}
+                <div className="space-y-4">
+                    <div className="flex items-center justify-between">
+                        <h3 className="text-lg font-semibold">Growth Stages</h3>
+                        <Button type="button" variant="outline" size="sm" onClick={addStage}>
+                            <Plus className="mr-2 h-4 w-4" />
+                            Add Stage
+                        </Button>
+                    </div>
+
+                    {stages.length === 0 && (
+                        <p className="text-sm text-muted-foreground p-4 bg-muted/30 rounded-lg border text-center">
+                            No stages added yet. Click &quot;Add Stage&quot; to begin building the spray program.
+                        </p>
+                    )}
+
+                    {stages.map((stage: any, stageIdx: number) => (
+                        <div key={stageIdx} className={`border rounded-lg p-4 space-y-4 ${stageIdx % 2 === 0 ? "bg-background" : "bg-green-50 dark:bg-green-950/20"}`}>
+                            <div className="flex items-center justify-between">
+                                <h4 className="font-semibold text-sm">
+                                    Stage {stageIdx + 1}
+                                    {stage.name && `: ${stage.name}`}
+                                </h4>
+                                <div className="flex items-center gap-1">
+                                    <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-8 w-8"
+                                        onClick={() => moveStage(stageIdx, "up")}
+                                        disabled={stageIdx === 0}
+                                    >
+                                        <ChevronUp className="h-4 w-4" />
+                                    </Button>
+                                    <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-8 w-8"
+                                        onClick={() => moveStage(stageIdx, "down")}
+                                        disabled={stageIdx === stages.length - 1}
+                                    >
+                                        <ChevronDown className="h-4 w-4" />
+                                    </Button>
+                                    <Button
+                                        type="button"
+                                        variant="ghost"
+                                        size="icon"
+                                        className="h-8 w-8 text-destructive"
+                                        onClick={() => removeStage(stageIdx)}
+                                    >
+                                        <Trash2 className="h-4 w-4" />
+                                    </Button>
+                                </div>
+                            </div>
+
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                                <div>
+                                    <label className="text-sm font-medium">Stage Name</label>
+                                    <Input
+                                        value={stage.name || ""}
+                                        onChange={(e) => {
+                                            const current = [...(form.getValues("stages") || [])]
+                                            current[stageIdx] = { ...current[stageIdx], name: e.target.value }
+                                            form.setValue("stages", current)
+                                        }}
+                                        placeholder="e.g., Pre-planting"
+                                    />
+                                </div>
+                                <div>
+                                    <label className="text-sm font-medium">Timing</label>
+                                    <Input
+                                        value={stage.timing_description || ""}
+                                        onChange={(e) => {
+                                            const current = [...(form.getValues("stages") || [])]
+                                            current[stageIdx] = { ...current[stageIdx], timing_description: e.target.value }
+                                            form.setValue("stages", current)
+                                        }}
+                                        placeholder="e.g., 0-7 days after planting"
+                                    />
+                                </div>
+                            </div>
+
+                            <div>
+                                <label className="text-sm font-medium">Description</label>
+                                <Textarea
+                                    value={stage.description || ""}
+                                    onChange={(e) => {
+                                        const current = [...(form.getValues("stages") || [])]
+                                        current[stageIdx] = { ...current[stageIdx], description: e.target.value }
+                                        form.setValue("stages", current)
+                                    }}
+                                    placeholder="Describe what happens at this stage..."
+                                    rows={2}
+                                />
+                            </div>
+
+                            {/* Recommendations */}
+                            <div className="space-y-3">
+                                <div className="flex items-center justify-between">
+                                    <label className="text-sm font-medium">Products / Recommendations</label>
+                                    <Popover
+                                        open={openAgroChemical && activeStageIdx === stageIdx}
+                                        onOpenChange={(o) => {
+                                            setOpenAgroChemical(o)
+                                            setActiveStageIdx(o ? stageIdx : null)
+                                        }}
+                                    >
+                                        <PopoverTrigger asChild>
+                                            <Button type="button" variant="outline" size="sm">
+                                                <Plus className="mr-1 h-3 w-3" />
+                                                Add Product
+                                            </Button>
+                                        </PopoverTrigger>
+                                        <PopoverContent className="w-80 p-0" align="end">
+                                            <Command>
+                                                <CommandInput
+                                                    placeholder="Search agrochemical..."
+                                                    onValueChange={setSearchAgroChemical}
+                                                />
+                                                <CommandList>
+                                                    <CommandEmpty>
+                                                        {debouncedAgroSearch.length < 2
+                                                            ? "Type at least 2 characters"
+                                                            : "No agrochemical found"}
+                                                    </CommandEmpty>
+                                                    {agroChemicals.map((ac: AgroChemicalItem) => (
+                                                        <CommandItem
+                                                            value={ac.name}
+                                                            key={ac.id}
+                                                            onSelect={() => addRecommendation(stageIdx, ac)}
+                                                        >
+                                                            <span className="capitalize">{ac.name}</span>
+                                                        </CommandItem>
+                                                    ))}
+                                                </CommandList>
+                                            </Command>
+                                        </PopoverContent>
+                                    </Popover>
+                                </div>
+
+                                {(!stage.recommendations || stage.recommendations.length === 0) && (
+                                    <p className="text-xs text-muted-foreground p-3 bg-muted/20 rounded border border-dashed text-center">
+                                        No products added. Search and add agrochemicals for this stage.
+                                    </p>
+                                )}
+
+                                {stage.recommendations?.map((rec: any, recIdx: number) => (
+                                    <div key={recIdx} className="border rounded-lg p-3 space-y-3 bg-background">
+                                        <div className="flex items-center justify-between">
+                                            <span className="font-medium text-sm capitalize">{rec.agrochemical_name}</span>
+                                            <Button
+                                                type="button"
+                                                variant="ghost"
+                                                size="icon"
+                                                className="h-7 w-7 text-destructive"
+                                                onClick={() => removeRecommendation(stageIdx, recIdx)}
+                                            >
+                                                <Trash2 className="h-3.5 w-3.5" />
+                                            </Button>
+                                        </div>
+
+                                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                                            <div>
+                                                <label className="text-xs font-medium">Purpose</label>
+                                                <Select
+                                                    value={rec.purpose}
+                                                    onValueChange={(v) => updateRecommendation(stageIdx, recIdx, "purpose", v)}
+                                                >
+                                                    <SelectTrigger className="h-8 text-xs">
+                                                        <SelectValue placeholder="Select purpose" />
+                                                    </SelectTrigger>
+                                                    <SelectContent>
+                                                        {PURPOSE_OPTIONS.map((p) => (
+                                                            <SelectItem key={p} value={p}>{p}</SelectItem>
+                                                        ))}
+                                                    </SelectContent>
+                                                </Select>
+                                            </div>
+                                            <div>
+                                                <label className="text-xs font-medium">Application Method</label>
+                                                <Select
+                                                    value={rec.application_method}
+                                                    onValueChange={(v) => updateRecommendation(stageIdx, recIdx, "application_method", v)}
+                                                >
+                                                    <SelectTrigger className="h-8 text-xs">
+                                                        <SelectValue placeholder="Select method" />
+                                                    </SelectTrigger>
+                                                    <SelectContent>
+                                                        {APPLICATION_METHODS.map((m) => (
+                                                            <SelectItem key={m} value={m}>{m}</SelectItem>
+                                                        ))}
+                                                    </SelectContent>
+                                                </Select>
+                                            </div>
+                                        </div>
+
+                                        <div className="grid grid-cols-3 gap-3">
+                                            <div>
+                                                <label className="text-xs font-medium">Dosage</label>
+                                                <Input
+                                                    value={rec.dosage?.value || ""}
+                                                    onChange={(e) => updateRecommendation(stageIdx, recIdx, "dosage.value", e.target.value)}
+                                                    placeholder="e.g., 2"
+                                                    className="h-8 text-xs"
+                                                />
+                                            </div>
+                                            <div>
+                                                <label className="text-xs font-medium">Unit</label>
+                                                <Input
+                                                    value={rec.dosage?.unit || ""}
+                                                    onChange={(e) => updateRecommendation(stageIdx, recIdx, "dosage.unit", e.target.value)}
+                                                    placeholder="e.g., ml"
+                                                    className="h-8 text-xs"
+                                                />
+                                            </div>
+                                            <div>
+                                                <label className="text-xs font-medium">Per</label>
+                                                <Input
+                                                    value={rec.dosage?.per || ""}
+                                                    onChange={(e) => updateRecommendation(stageIdx, recIdx, "dosage.per", e.target.value)}
+                                                    placeholder="e.g., liter"
+                                                    className="h-8 text-xs"
+                                                />
+                                            </div>
+                                        </div>
+
+                                        <div>
+                                            <label className="text-xs font-medium">Notes</label>
+                                            <Input
+                                                value={rec.notes || ""}
+                                                onChange={(e) => updateRecommendation(stageIdx, recIdx, "notes", e.target.value)}
+                                                placeholder="Additional notes..."
+                                                className="h-8 text-xs"
+                                            />
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    ))}
+                </div>
+
+                {/* Submit */}
+                <Button type="submit" disabled={isPending}>
+                    {isPending && <Icons.spinner className="mr-2 h-4 w-4 animate-spin" />}
+                    {isEditMode ? "Update Spray Program" : "Create Spray Program"}
+                </Button>
+            </form>
+        </Form>
+    )
+}

--- a/apps/admin-fnp/components/structures/tables/animalHealthActiveIngredients.tsx
+++ b/apps/admin-fnp/components/structures/tables/animalHealthActiveIngredients.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import { useState, useEffect, useRef } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { PaginationState } from "@tanstack/react-table"
+
+import { queryAnimalHealthActiveIngredients } from "@/lib/query"
+import { AnimalHealthActiveIngredient } from "@/lib/schemas"
+import { handleFetchError } from "@/lib/error-handler"
+import { Placeholder } from "@/components/state/placeholder"
+import { DataTable } from "@/components/structures/data-table"
+import { animalHealthActiveIngredientColumns } from "@/components/structures/columns/animalHealthActiveIngredients"
+
+export function AnimalHealthActiveIngredientsTable() {
+  const [search, setSearch] = useState("")
+
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 1,
+    pageSize: 20,
+  })
+
+  const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
+    queryKey: ["dashboard-animal-health-active-ingredients", { p: pagination.pageIndex, search }],
+    queryFn: () =>
+      queryAnimalHealthActiveIngredients({
+        p: pagination.pageIndex,
+        search: search,
+      }),
+    refetchOnWindowFocus: false
+  })
+
+  const ingredients = data?.data?.data as AnimalHealthActiveIngredient[]
+  const total = data?.data?.total as number
+
+  // Show error toast only once when error occurs
+  const hasShownError = useRef(false)
+  useEffect(() => {
+    if (isError && !hasShownError.current) {
+      hasShownError.current = true
+      handleFetchError(error, {
+        onRetry: () => {
+          hasShownError.current = false
+          refetch()
+        },
+        context: "animal health active ingredients"
+      })
+    }
+    if (!isError) {
+      hasShownError.current = false
+    }
+  }, [isError, error, refetch])
+
+  if (isError) {
+    return (
+      <Placeholder>
+        <Placeholder.Icon name="close" />
+        <Placeholder.Title>Error Fetching Active Ingredients</Placeholder.Title>
+        <Placeholder.Description>
+          Error fetching animal health active ingredients from the database
+        </Placeholder.Description>
+      </Placeholder>
+    )
+  }
+
+  if (isLoading || isFetching) {
+    return (
+      <Placeholder>
+        <Placeholder.Title>Fetching Active Ingredients</Placeholder.Title>
+      </Placeholder>
+    )
+  }
+
+  return (
+    <DataTable
+      columns={animalHealthActiveIngredientColumns}
+      data={ingredients}
+      newUrl="/dashboard/animal-health-active-ingredients/new"
+      tableName="Animal Health Active Ingredient"
+      total={total}
+      pagination={pagination}
+      setPagination={setPagination}
+      search={search}
+      setSearch={setSearch}
+    />
+  )
+}

--- a/apps/admin-fnp/components/structures/tables/animalHealthCategories.tsx
+++ b/apps/admin-fnp/components/structures/tables/animalHealthCategories.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import { useState, useEffect, useRef } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { PaginationState } from "@tanstack/react-table"
+
+import { queryAnimalHealthCategories } from "@/lib/query"
+import { AnimalHealthCategory } from "@/lib/schemas"
+import { handleFetchError } from "@/lib/error-handler"
+import { Placeholder } from "@/components/state/placeholder"
+import { DataTable } from "@/components/structures/data-table"
+import { animalHealthCategoryColumns } from "@/components/structures/columns/animalHealthCategories"
+
+export function AnimalHealthCategoriesTable() {
+  const [search, setSearch] = useState("")
+
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 1,
+    pageSize: 20,
+  })
+
+  const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
+    queryKey: ["dashboard-animal-health-categories", { p: pagination.pageIndex, search }],
+    queryFn: () =>
+      queryAnimalHealthCategories({
+        p: pagination.pageIndex,
+        search: search,
+      }),
+    refetchOnWindowFocus: false
+  })
+
+  const categories = data?.data?.data as AnimalHealthCategory[]
+  const total = data?.data?.total as number
+
+  // Show error toast only once when error occurs
+  const hasShownError = useRef(false)
+  useEffect(() => {
+    if (isError && !hasShownError.current) {
+      hasShownError.current = true
+      handleFetchError(error, {
+        onRetry: () => {
+          hasShownError.current = false
+          refetch()
+        },
+        context: "animal health categories"
+      })
+    }
+    if (!isError) {
+      hasShownError.current = false
+    }
+  }, [isError, error, refetch])
+
+  if (isError) {
+    return (
+      <Placeholder>
+        <Placeholder.Icon name="close" />
+        <Placeholder.Title>Error Fetching Categories</Placeholder.Title>
+        <Placeholder.Description>
+          Error fetching animal health categories from the database
+        </Placeholder.Description>
+      </Placeholder>
+    )
+  }
+
+  if (isLoading || isFetching) {
+    return (
+      <Placeholder>
+        <Placeholder.Title>Fetching Categories</Placeholder.Title>
+      </Placeholder>
+    )
+  }
+
+  return (
+    <DataTable
+      columns={animalHealthCategoryColumns}
+      data={categories}
+      newUrl="/dashboard/animal-health-categories/new"
+      tableName="Animal Health Category"
+      total={total}
+      pagination={pagination}
+      setPagination={setPagination}
+      search={search}
+      setSearch={setSearch}
+    />
+  )
+}

--- a/apps/admin-fnp/components/structures/tables/animalHealthProducts.tsx
+++ b/apps/admin-fnp/components/structures/tables/animalHealthProducts.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import { useState, useEffect, useRef } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { PaginationState } from "@tanstack/react-table"
+
+import { queryAnimalHealthProducts } from "@/lib/query"
+import { AnimalHealthProduct } from "@/lib/schemas"
+import { handleFetchError } from "@/lib/error-handler"
+import { Placeholder } from "@/components/state/placeholder"
+import { DataTable } from "@/components/structures/data-table"
+import { animalHealthProductColumns } from "@/components/structures/columns/animalHealthProducts"
+
+export function AnimalHealthProductsTable() {
+  const [search, setSearch] = useState("")
+
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 1,
+    pageSize: 20,
+  })
+
+  const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
+    queryKey: ["dashboard-animal-health-products", { p: pagination.pageIndex, search }],
+    queryFn: () =>
+      queryAnimalHealthProducts({
+        p: pagination.pageIndex,
+        search: search,
+      }),
+    refetchOnWindowFocus: false
+  })
+
+  const products = data?.data?.data as AnimalHealthProduct[]
+  const total = data?.data?.total as number
+
+  // Show error toast only once when error occurs
+  const hasShownError = useRef(false)
+  useEffect(() => {
+    if (isError && !hasShownError.current) {
+      hasShownError.current = true
+      handleFetchError(error, {
+        onRetry: () => {
+          hasShownError.current = false
+          refetch()
+        },
+        context: "animal health products"
+      })
+    }
+    if (!isError) {
+      hasShownError.current = false
+    }
+  }, [isError, error, refetch])
+
+  if (isError) {
+    return (
+      <Placeholder>
+        <Placeholder.Icon name="close" />
+        <Placeholder.Title>Error Fetching Products</Placeholder.Title>
+        <Placeholder.Description>
+          Error fetching animal health products from the database
+        </Placeholder.Description>
+      </Placeholder>
+    )
+  }
+
+  if (isLoading || isFetching) {
+    return (
+      <Placeholder>
+        <Placeholder.Title>Fetching Animal Health Products</Placeholder.Title>
+      </Placeholder>
+    )
+  }
+
+  return (
+    <DataTable
+      columns={animalHealthProductColumns}
+      data={products}
+      newUrl="/dashboard/animal-health-products/new"
+      tableName="Animal Health Product"
+      total={total}
+      pagination={pagination}
+      setPagination={setPagination}
+      search={search}
+      setSearch={setSearch}
+    />
+  )
+}

--- a/apps/admin-fnp/components/structures/tables/animalHealthTargets.tsx
+++ b/apps/admin-fnp/components/structures/tables/animalHealthTargets.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import { useState, useEffect, useRef } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { PaginationState } from "@tanstack/react-table"
+
+import { queryAnimalHealthTargets } from "@/lib/query"
+import { AnimalHealthTarget } from "@/lib/schemas"
+import { handleFetchError } from "@/lib/error-handler"
+import { Placeholder } from "@/components/state/placeholder"
+import { DataTable } from "@/components/structures/data-table"
+import { animalHealthTargetColumns } from "@/components/structures/columns/animalHealthTargets"
+
+export function AnimalHealthTargetsTable() {
+  const [search, setSearch] = useState("")
+
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 1,
+    pageSize: 20,
+  })
+
+  const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
+    queryKey: ["dashboard-animal-health-targets", { p: pagination.pageIndex, search }],
+    queryFn: () =>
+      queryAnimalHealthTargets({
+        p: pagination.pageIndex,
+        search: search,
+      }),
+    refetchOnWindowFocus: false
+  })
+
+  const targets = data?.data?.data as AnimalHealthTarget[]
+  const total = data?.data?.total as number
+
+  // Show error toast only once when error occurs
+  const hasShownError = useRef(false)
+  useEffect(() => {
+    if (isError && !hasShownError.current) {
+      hasShownError.current = true
+      handleFetchError(error, {
+        onRetry: () => {
+          hasShownError.current = false
+          refetch()
+        },
+        context: "animal health targets"
+      })
+    }
+    if (!isError) {
+      hasShownError.current = false
+    }
+  }, [isError, error, refetch])
+
+  if (isError) {
+    return (
+      <Placeholder>
+        <Placeholder.Icon name="close" />
+        <Placeholder.Title>Error Fetching Targets</Placeholder.Title>
+        <Placeholder.Description>
+          Error fetching animal health targets from the database
+        </Placeholder.Description>
+      </Placeholder>
+    )
+  }
+
+  if (isLoading || isFetching) {
+    return (
+      <Placeholder>
+        <Placeholder.Title>Fetching Targets</Placeholder.Title>
+      </Placeholder>
+    )
+  }
+
+  return (
+    <DataTable
+      columns={animalHealthTargetColumns}
+      data={targets}
+      newUrl="/dashboard/animal-health-targets/new"
+      tableName="Animal Health Target"
+      total={total}
+      pagination={pagination}
+      setPagination={setPagination}
+      search={search}
+      setSearch={setSearch}
+    />
+  )
+}

--- a/apps/admin-fnp/components/structures/tables/cdmPriceLists.tsx
+++ b/apps/admin-fnp/components/structures/tables/cdmPriceLists.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import { useState, useEffect, useRef } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { PaginationState } from "@tanstack/react-table"
+
+import { queryCdmPrices } from "@/lib/query"
+import { CdmPrice } from "@/lib/schemas"
+import { handleFetchError } from "@/lib/error-handler"
+import { Placeholder } from "@/components/state/placeholder"
+import { DataTable } from "@/components/structures/data-table"
+import { cdmPriceColumns } from "@/components/structures/columns/cdmPrices"
+
+export function CdmPriceLists() {
+  const [search, setSearch] = useState("")
+
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 1,
+    pageSize: 20,
+  })
+
+  const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
+    queryKey: ["dashboard-cdm-prices", { p: pagination.pageIndex }],
+    queryFn: () =>
+      queryCdmPrices({
+        p: pagination.pageIndex,
+      }),
+    refetchOnWindowFocus: false
+  })
+
+  const cdmPrices: CdmPrice[] = data?.data?.data || []
+  const total = data?.data?.total as number
+
+  const hasShownError = useRef(false)
+  useEffect(() => {
+    if (isError && !hasShownError.current) {
+      hasShownError.current = true
+      handleFetchError(error, {
+        onRetry: () => {
+          hasShownError.current = false
+          refetch()
+        },
+        context: "CDM price lists"
+      })
+    }
+    if (!isError) {
+      hasShownError.current = false
+    }
+  }, [isError, error, refetch])
+
+  if (isError) {
+    return (
+      <Placeholder>
+        <Placeholder.Icon name="close" />
+        <Placeholder.Title>Error Fetching CDM Price Lists</Placeholder.Title>
+        <Placeholder.Description>
+          Error fetching CDM price lists from the database
+        </Placeholder.Description>
+      </Placeholder>
+    )
+  }
+
+  if (isLoading || isFetching) {
+    return (
+      <Placeholder>
+        <Placeholder.Title>Fetching CDM Price Lists</Placeholder.Title>
+      </Placeholder>
+    )
+  }
+
+  return (
+    <DataTable
+      columns={cdmPriceColumns}
+      data={cdmPrices}
+      newUrl="/dashboard/cdm-prices/new"
+      tableName="CDM Price"
+      total={total}
+      pagination={pagination}
+      setPagination={setPagination}
+      search={search}
+      setSearch={setSearch}
+    />
+  )
+}

--- a/apps/admin-fnp/components/structures/tables/producerPriceLists.tsx
+++ b/apps/admin-fnp/components/structures/tables/producerPriceLists.tsx
@@ -1,66 +1,61 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect, useRef } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { PaginationState } from "@tanstack/react-table"
-import { isAxiosError } from "axios"
 
 import { queryProducerPriceLists } from "@/lib/query"
 import { ProducerPriceList } from "@/lib/schemas"
-import { ToastAction } from "@/components/ui/toast"
-import { toast } from "@/components/ui/use-toast"
+import { handleFetchError } from "@/lib/error-handler"
 import { Placeholder } from "@/components/state/placeholder"
 import { DataTable } from "@/components/structures/data-table"
 import { producerPriceListColumns } from "@/components/structures/columns/producerLists"
 
 export function ProducePriceLists() {
-  const [searchClient, setSearchClient] = useState("")
+  const [search, setSearch] = useState("")
 
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 1,
     pageSize: 20,
   })
 
-  const { isError, isLoading, isFetching, refetch, data } = useQuery({
-    queryKey: ["dashboard-producer-price-lists", { p: pagination.pageIndex }],
+  const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
+    queryKey: ["dashboard-producer-price-lists", { p: pagination.pageIndex, search }],
     queryFn: () =>
       queryProducerPriceLists({
         p: pagination.pageIndex,
+        search: search,
       }),
+    refetchOnWindowFocus: false
   })
 
   const producePriceLists: ProducerPriceList[] = data?.data?.data || []
   const total = data?.data?.total as number
 
-  if (isError) {
-    if (isAxiosError(data)) {
-      switch (data.code) {
-        case "ERR_NETWORK":
-          toast({
-            description: "There seems to be a network error.",
-            action: <ToastAction altText="Try again">Try again</ToastAction>,
-          })
-          break
-
-        default:
-          toast({
-            title: "Uh oh! Failed to fetch clients.",
-            description: "There was a problem with your request.",
-            action: (
-              <ToastAction altText="Try again" onClick={() => refetch()}>
-                Try again
-              </ToastAction>
-            ),
-          })
-          break
-      }
+  const hasShownError = useRef(false)
+  useEffect(() => {
+    if (isError && !hasShownError.current) {
+      hasShownError.current = true
+      handleFetchError(error, {
+        onRetry: () => {
+          hasShownError.current = false
+          refetch()
+        },
+        context: "producer price lists"
+      })
     }
+    if (!isError) {
+      hasShownError.current = false
+    }
+  }, [isError, error, refetch])
+
+  if (isError) {
     return (
       <Placeholder>
         <Placeholder.Icon name="close" />
-        <Placeholder.Title>Error Fetching Users</Placeholder.Title>
+        <Placeholder.Title>Error Fetching Producer Price Lists</Placeholder.Title>
         <Placeholder.Description>
-          Error Fetching users from the database
+          Error fetching producer price lists from the database
         </Placeholder.Description>
       </Placeholder>
     )
@@ -76,7 +71,6 @@ export function ProducePriceLists() {
 
   return (
     <DataTable
-      /* @ts-ignore */ // working on all other table besides this one jeez
       columns={producerPriceListColumns}
       data={producePriceLists}
       newUrl="/dashboard/prices/new"
@@ -84,8 +78,8 @@ export function ProducePriceLists() {
       total={total}
       pagination={pagination}
       setPagination={setPagination}
-      searchClient={searchClient}
-      setSearchClient={setSearchClient}
+      search={search}
+      setSearch={setSearch}
     />
   )
 }

--- a/apps/admin-fnp/components/structures/tables/products.tsx
+++ b/apps/admin-fnp/components/structures/tables/products.tsx
@@ -1,31 +1,30 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useEffect, useRef } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { PaginationState } from "@tanstack/react-table"
-import { isAxiosError } from "axios"
 
 import { queryAgroChemicals } from "@/lib/query"
 import { AgroChemicalItem } from "@/lib/schemas"
-import { ToastAction } from "@/components/ui/toast"
-import { toast } from "@/components/ui/use-toast"
+import { handleFetchError } from "@/lib/error-handler"
 import { Placeholder } from "@/components/state/placeholder"
 import { DataTable } from "@/components/structures/data-table"
 import { agroChemicalColumns } from "@/components/structures/columns/products"
 
 export function AgroChemicalsTable() {
-  const [searchClient, setSearchClient] = useState("")
+  const [search, setSearch] = useState("")
 
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 1,
     pageSize: 20,
   })
 
-  const { isError, isLoading, isFetching, refetch, data } = useQuery({
-    queryKey: ["dashboard-products", { p: pagination.pageIndex }],
+  const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
+    queryKey: ["dashboard-products", { p: pagination.pageIndex, search }],
     queryFn: () =>
       queryAgroChemicals({
         p: pagination.pageIndex,
+        search: search,
       }),
     refetchOnWindowFocus: false
   })
@@ -33,35 +32,30 @@ export function AgroChemicalsTable() {
   const products = data?.data?.data as AgroChemicalItem[]
   const total = data?.data?.total as number
 
-  if (isError) {
-    if (isAxiosError(data)) {
-      switch (data.code) {
-        case "ERR_NETWORK":
-          toast({
-            description: "There seems to be a network error.",
-            action: <ToastAction altText="Try again">Try again</ToastAction>,
-          })
-          break
-
-        default:
-          toast({
-            title: "Uh oh! Failed to fetch clients.",
-            description: "There was a problem with your request.",
-            action: (
-              <ToastAction altText="Try again" onClick={() => refetch()}>
-                Try again
-              </ToastAction>
-            ),
-          })
-          break
-      }
+  const hasShownError = useRef(false)
+  useEffect(() => {
+    if (isError && !hasShownError.current) {
+      hasShownError.current = true
+      handleFetchError(error, {
+        onRetry: () => {
+          hasShownError.current = false
+          refetch()
+        },
+        context: "agrochemicals"
+      })
     }
+    if (!isError) {
+      hasShownError.current = false
+    }
+  }, [isError, error, refetch])
+
+  if (isError) {
     return (
       <Placeholder>
         <Placeholder.Icon name="close" />
         <Placeholder.Title>Error Fetching AgroChemicals</Placeholder.Title>
         <Placeholder.Description>
-          Error Fetching agrochemicals from the database
+          Error fetching agrochemicals from the database
         </Placeholder.Description>
       </Placeholder>
     )
@@ -70,14 +64,13 @@ export function AgroChemicalsTable() {
   if (isLoading || isFetching) {
     return (
       <Placeholder>
-        <Placeholder.Title>Fetching Producer Price Lists</Placeholder.Title>
+        <Placeholder.Title>Fetching AgroChemicals</Placeholder.Title>
       </Placeholder>
     )
   }
 
   return (
     <DataTable
-      /* @ts-ignore */ // working on all other table besides this one jeez
       columns={agroChemicalColumns}
       data={products}
       newUrl="/dashboard/agrochemicals/new"
@@ -85,8 +78,8 @@ export function AgroChemicalsTable() {
       total={total}
       pagination={pagination}
       setPagination={setPagination}
-      searchClient={searchClient}
-      setSearchClient={setSearchClient}
+      search={search}
+      setSearch={setSearch}
     />
   )
 }

--- a/apps/admin-fnp/components/structures/tables/sprayPrograms.tsx
+++ b/apps/admin-fnp/components/structures/tables/sprayPrograms.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import { useState, useEffect, useRef } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { PaginationState } from "@tanstack/react-table"
+
+import { querySprayPrograms } from "@/lib/query"
+import { SprayProgram } from "@/lib/schemas"
+import { handleFetchError } from "@/lib/error-handler"
+import { Placeholder } from "@/components/state/placeholder"
+import { DataTable } from "@/components/structures/data-table"
+import { sprayProgramColumns } from "@/components/structures/columns/sprayPrograms"
+
+export function SprayProgramsTable() {
+  const [search, setSearch] = useState("")
+
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 1,
+    pageSize: 20,
+  })
+
+  const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
+    queryKey: ["dashboard-spray-programs", { p: pagination.pageIndex, search }],
+    queryFn: () =>
+      querySprayPrograms({
+        p: pagination.pageIndex,
+        search: search,
+      }),
+    refetchOnWindowFocus: false
+  })
+
+  const programs = data?.data?.data as SprayProgram[]
+  const total = data?.data?.total as number
+
+  const hasShownError = useRef(false)
+  useEffect(() => {
+    if (isError && !hasShownError.current) {
+      hasShownError.current = true
+      handleFetchError(error, {
+        onRetry: () => {
+          hasShownError.current = false
+          refetch()
+        },
+        context: "spray programs"
+      })
+    }
+    if (!isError) {
+      hasShownError.current = false
+    }
+  }, [isError, error, refetch])
+
+  if (isError) {
+    return (
+      <Placeholder>
+        <Placeholder.Icon name="close" />
+        <Placeholder.Title>Error Fetching Spray Programs</Placeholder.Title>
+        <Placeholder.Description>
+          Error fetching spray programs from the database
+        </Placeholder.Description>
+      </Placeholder>
+    )
+  }
+
+  if (isLoading || isFetching) {
+    return (
+      <Placeholder>
+        <Placeholder.Title>Fetching Spray Programs</Placeholder.Title>
+      </Placeholder>
+    )
+  }
+
+  return (
+    <DataTable
+      columns={sprayProgramColumns}
+      data={programs}
+      newUrl="/dashboard/spray-programs/new"
+      tableName="Spray Program"
+      total={total}
+      pagination={pagination}
+      setPagination={setPagination}
+      search={search}
+      setSearch={setSearch}
+    />
+  )
+}

--- a/apps/admin-fnp/config/dashboard.ts
+++ b/apps/admin-fnp/config/dashboard.ts
@@ -9,69 +9,124 @@ export const dashboardConfig: DashboardConfig = {
   ],
   sidebarNavigation: [
     {
-      title: "Users",
-      href: "/dashboard/users",
-      icon: "user",
+      label: "Management",
+      items: [
+        {
+          title: "Users",
+          href: "/dashboard/users",
+          icon: "user",
+        },
+        {
+          title: "Administrators",
+          href: "/dashboard/admins",
+          icon: "construction",
+        },
+        {
+          title: "Buyer Contacts",
+          href: "/dashboard/buyer-contacts",
+          icon: "badgeCheck",
+        },
+      ],
     },
     {
-      title: "AgroChemicals",
-      href: "/dashboard/agrochemicals",
-      icon: "productSearch",
+      label: "AgroChemicals",
+      items: [
+        {
+          title: "Products",
+          href: "/dashboard/agrochemicals",
+          icon: "productSearch",
+        },
+        {
+          title: "Categories",
+          href: "/dashboard/agrochemical-categories",
+          icon: "clipboardList",
+        },
+        {
+          title: "Active Ingredients",
+          href: "/dashboard/agrochemical-active-ingredients",
+          icon: "beaker",
+        },
+        {
+          title: "Targets",
+          href: "/dashboard/agrochemical-targets",
+          icon: "bug",
+        },
+      ],
     },
     {
-      title: "AgroChemical Categories",
-      href: "/dashboard/agrochemical-categories",
-      icon: "clipboardList",
+      label: "Animal Health",
+      items: [
+        {
+          title: "Products",
+          href: "/dashboard/animal-health-products",
+          icon: "productSearch",
+        },
+        {
+          title: "Categories",
+          href: "/dashboard/animal-health-categories",
+          icon: "clipboardList",
+        },
+        {
+          title: "Ingredients",
+          href: "/dashboard/animal-health-active-ingredients",
+          icon: "beaker",
+        },
+        {
+          title: "Targets",
+          href: "/dashboard/animal-health-targets",
+          icon: "bug",
+        },
+      ],
     },
     {
-      title: "AgroChemical Active Ingredients",
-      href: "/dashboard/agrochemical-active-ingredients",
-      icon: "beaker",
+      label: "Farm Produce",
+      items: [
+        {
+          title: "Categories",
+          href: "/dashboard/farmproducecategories",
+          icon: "tractor",
+        },
+        {
+          title: "Products",
+          href: "/dashboard/farmproduce",
+          icon: "package",
+        },
+        {
+          title: "Crop Groups",
+          href: "/dashboard/crop-groups",
+          icon: "layers",
+        },
+        {
+          title: "Weed Groups",
+          href: "/dashboard/weed-groups",
+          icon: "layers",
+        },
+        {
+          title: "Brands",
+          href: "/dashboard/brands",
+          icon: "tag",
+        },
+      ],
     },
     {
-      title: "AgroChemical Targets",
-      href: "/dashboard/agrochemical-targets",
-      icon: "bug",
-    },
-    {
-      title: "Crop Groups",
-      href: "/dashboard/crop-groups",
-      icon: "layers",
-    },
-    {
-      title: "Weed Groups",
-      href: "/dashboard/weed-groups",
-      icon: "layers",
-    },
-    {
-      title: "Brands",
-      href: "/dashboard/brands",
-      icon: "tag",
-    },
-    {
-      title: "Farm Produce Categories",
-      href: "/dashboard/farmproducecategories",
-      icon: "tractor",
-    },
-    {
-      title: "Farm Produce",
-      href: "/dashboard/farmproduce",
-      icon: "package",
-    },
-    {
-      title: "Producer Prices",
-      href: "/dashboard/prices",
-      icon: "billing",
-    },
-    {
-      title: "Administrators",
-      href: "/dashboard/admins",
-      icon: "construction",
-    },
-    {
-      title: "Buyer Contacts",
-      href: "/dashboard/buyer-contacts",
-      icon: "badgeCheck",
+      label: "Programs & Pricing",
+      items: [
+        {
+          title: "Spray Programs",
+          href: "/dashboard/spray-programs",
+          icon: "sprout",
+        },
+        {
+          title: "Producer Prices",
+          href: "/dashboard/prices",
+          icon: "billing",
+        },
+        {
+          title: "CDM Prices",
+          href: "/dashboard/cdm-prices",
+          icon: "billing",
+        },
+      ],
     },
   ],
 }

--- a/apps/admin-fnp/lib/query.ts
+++ b/apps/admin-fnp/lib/query.ts
@@ -513,3 +513,200 @@ export function deleteBuyerContact(id: string) {
   const url = `${baseUrl}/buyercontacts/delete/${id}`
   return api.delete(url)
 }
+
+// Animal Health Product functions
+export function queryAnimalHealthProducts(pagination?: pagination) {
+  let url: string
+  if (pagination?.p !== undefined && pagination.p >= 2) {
+    url = `${baseUrl}/user/animal-health-products?p=${pagination.p}`
+  } else {
+    url = `${baseUrl}/user/animal-health-products`
+  }
+  if (pagination?.search !== undefined && pagination.search.length >= 2) {
+    url = `${baseUrl}/user/animal-health-products?search=${pagination.search}`
+  }
+  return api.get(url)
+}
+
+export function queryAnimalHealthProduct(id: string) {
+  const url = `${baseUrl}/user/animal-health-products/${id}`
+  return api.get(url)
+}
+
+export function addAnimalHealthProduct(data: any) {
+  let url = `${baseUrl}/user/animal-health-products/add`
+  return api.post(url, data)
+}
+
+export function updateAnimalHealthProduct(data: any) {
+  let url = `${baseUrl}/user/animal-health-products/update`
+  return api.post(url, data)
+}
+
+// Animal Health Category functions
+export function queryAnimalHealthCategories(pagination?: pagination) {
+  let url: string
+  if (pagination?.p !== undefined && pagination.p >= 2) {
+    url = `${baseUrl}/user/animal-health-categories?p=${pagination.p}`
+  } else {
+    url = `${baseUrl}/user/animal-health-categories`
+  }
+  if (pagination?.search !== undefined && pagination.search.length >= 2) {
+    url = `${baseUrl}/user/animal-health-categories?search=${pagination.search}`
+  }
+  return api.get(url)
+}
+
+export function queryAnimalHealthCategory(id: string) {
+  const url = `${baseUrl}/user/animal-health-categories/${id}`
+  return api.get(url)
+}
+
+export function addAnimalHealthCategory(data: { name: string; short_description: string; description: string }) {
+  let url = `${baseUrl}/user/animal-health-categories/add`
+  return api.post(url, data)
+}
+
+export function updateAnimalHealthCategory(data: { id: string; name: string; short_description: string; description: string }) {
+  let url = `${baseUrl}/user/animal-health-categories/update`
+  return api.post(url, data)
+}
+
+export function deleteAnimalHealthCategories(categoryIds: string[]) {
+  let url = `${baseUrl}/user/animal-health-categories/delete`
+  return api.post(url, { category_ids: categoryIds })
+}
+
+// Animal Health Active Ingredient functions
+export function queryAnimalHealthActiveIngredients(pagination?: pagination) {
+  let url: string
+  if (pagination?.p !== undefined && pagination.p >= 2) {
+    url = `${baseUrl}/user/animal-health-active-ingredients?p=${pagination.p}`
+  } else {
+    url = `${baseUrl}/user/animal-health-active-ingredients`
+  }
+  if (pagination?.search !== undefined && pagination.search.length >= 2) {
+    url = `${baseUrl}/user/animal-health-active-ingredients?search=${pagination.search}`
+  }
+  return api.get(url)
+}
+
+export function queryAnimalHealthActiveIngredient(id: string) {
+  const url = `${baseUrl}/user/animal-health-active-ingredients/${id}`
+  return api.get(url)
+}
+
+export function addAnimalHealthActiveIngredient(data: { name: string; short_description: string; description: string }) {
+  let url = `${baseUrl}/user/animal-health-active-ingredients/add`
+  return api.post(url, data)
+}
+
+export function updateAnimalHealthActiveIngredient(data: { id: string; name: string; short_description: string; description: string }) {
+  let url = `${baseUrl}/user/animal-health-active-ingredients/update`
+  return api.post(url, data)
+}
+
+export function deleteAnimalHealthActiveIngredients(ingredientIds: string[]) {
+  let url = `${baseUrl}/user/animal-health-active-ingredients/delete`
+  return api.post(url, { ingredient_ids: ingredientIds })
+}
+
+// Animal Health Target functions
+export function queryAnimalHealthTargets(pagination?: pagination) {
+  let url: string
+  if (pagination?.p !== undefined && pagination.p >= 2) {
+    url = `${baseUrl}/user/animal-health-targets?p=${pagination.p}`
+  } else {
+    url = `${baseUrl}/user/animal-health-targets`
+  }
+  if (pagination?.search !== undefined && pagination.search.length >= 2) {
+    url = `${baseUrl}/user/animal-health-targets?search=${pagination.search}`
+  }
+  return api.get(url)
+}
+
+export function queryAnimalHealthTarget(id: string) {
+  const url = `${baseUrl}/user/animal-health-targets/${id}`
+  return api.get(url)
+}
+
+export function addAnimalHealthTarget(data: { name: string; scientific_name?: string; description?: string; damage_type?: string; remark?: string }) {
+  let url = `${baseUrl}/user/animal-health-targets/add`
+  return api.post(url, data)
+}
+
+export function updateAnimalHealthTarget(data: { id: string; name: string; scientific_name?: string; description?: string; damage_type?: string; remark?: string }) {
+  let url = `${baseUrl}/user/animal-health-targets/update`
+  return api.post(url, data)
+}
+
+export function deleteAnimalHealthTargets(targetIds: string[]) {
+  let url = `${baseUrl}/user/animal-health-targets/delete`
+  return api.post(url, { target_ids: targetIds })
+}
+
+// Spray Program functions
+
+export function querySprayPrograms(pagination?: pagination) {
+  let url: string
+  if (pagination?.p !== undefined && pagination.p >= 2) {
+    url = `${baseUrl}/user/spray-programs?p=${pagination.p}`
+  } else {
+    url = `${baseUrl}/user/spray-programs`
+  }
+  if (pagination?.search !== undefined && pagination.search.length >= 2) {
+    url = `${baseUrl}/user/spray-programs?search=${pagination.search}`
+  }
+  return api.get(url)
+}
+
+export function querySprayProgram(id: string) {
+  const url = `${baseUrl}/user/spray-programs/${id}`
+  return api.get(url)
+}
+
+export function addSprayProgram(data: any) {
+  let url = `${baseUrl}/user/spray-programs/add`
+  return api.post(url, data)
+}
+
+export function updateSprayProgram(data: any) {
+  let url = `${baseUrl}/user/spray-programs/update`
+  return api.post(url, data)
+}
+
+export function deleteSprayPrograms(programIds: string[]) {
+  let url = `${baseUrl}/user/spray-programs/delete`
+  return api.post(url, { program_ids: programIds })
+}
+
+// CDM Price functions
+export function queryCdmPrices(pagination?: pagination) {
+  let url: string
+  if (pagination?.p !== undefined && pagination.p >= 2) {
+    url = `${baseUrl}/cdmprices/get?p=${pagination.p}`
+  } else {
+    url = `${baseUrl}/cdmprices/get`
+  }
+  return api.get(url)
+}
+
+export function queryCdmPrice(id: string) {
+  const url = `${baseUrl}/cdmprices/get/${id}`
+  return api.get(url)
+}
+
+export function addCdmPrice(data: any) {
+  let url = `${baseUrl}/cdmprices/add`
+  return api.post(url, data)
+}
+
+export function updateCdmPrice(data: any) {
+  let url = `${baseUrl}/cdmprices/update`
+  return api.post(url, data)
+}
+
+export function deleteCdmPrice(priceId: string) {
+  let url = `${baseUrl}/cdmprices/delete/${priceId}`
+  return api.delete(url)
+}

--- a/apps/admin-fnp/lib/schemas.ts
+++ b/apps/admin-fnp/lib/schemas.ts
@@ -640,3 +640,213 @@ export type FarmProduceResponse = {
   total: number
   data: FarmProduce[]
 }
+
+// Animal Health Schemas
+
+export const AnimalHealthCategorySchema = z.object({
+  id: z.string(),
+  name: z.string().min(1, "Name is required"),
+  slug: z.string().optional(),
+  short_description: z.string().max(100, "Short description cannot exceed 100 characters"),
+  description: z.string().max(500, "Description cannot exceed 500 characters"),
+  created: z.string().optional(),
+  updated: z.string().optional(),
+})
+
+export const FormAnimalHealthCategorySchema = AnimalHealthCategorySchema.pick({
+  id: true,
+  name: true,
+  short_description: true,
+  description: true,
+})
+
+export const AnimalHealthActiveIngredientSchema = z.object({
+  id: z.string(),
+  name: z.string().min(1, "Name is required"),
+  slug: z.string().optional(),
+  short_description: z.string().max(100, "Short description cannot exceed 100 characters"),
+  description: z.string().max(500, "Description cannot exceed 500 characters"),
+  created: z.string().optional(),
+  updated: z.string().optional(),
+})
+
+export const FormAnimalHealthActiveIngredientSchema = AnimalHealthActiveIngredientSchema.pick({
+  id: true,
+  name: true,
+  short_description: true,
+  description: true,
+})
+
+export const AnimalHealthTargetSchema = z.object({
+  id: z.string(),
+  name: z.string().min(1, "Name is required"),
+  scientific_name: z.string().optional(),
+  description: z.string().optional(),
+  damage_type: z.string().optional(),
+  remark: z.string().optional(),
+  slug: z.string().optional(),
+  created: z.string().optional(),
+  updated: z.string().optional(),
+})
+
+export const FormAnimalHealthTargetSchema = AnimalHealthTargetSchema.pick({
+  id: true,
+  name: true,
+  scientific_name: true,
+  description: true,
+  damage_type: true,
+  remark: true,
+})
+
+export const AnimalHealthProductSchema = z.object({
+  id: z.string(),
+  name: z.string().min(1, "Name is required"),
+  slug: z.string().optional(),
+  brand_id: z.string().min(1, "Brand is required"),
+  brand: z.object({
+    id: z.string(),
+    name: z.string(),
+  }).optional(),
+  animal_health_category_id: z.string().min(1, "Animal health category is required"),
+  animal_health_category: z.object({
+    id: z.string(),
+    name: z.string(),
+    slug: z.string(),
+  }).optional(),
+  front_label: z.custom<ImageModel>().optional(),
+  back_label: z.custom<ImageModel>().optional(),
+  images: z.array(z.custom<ImageModel>()).min(1, "At least one product image is required").max(5, "Maximum 5 images allowed"),
+  active_ingredients: z.array(z.object({
+    id: z.string(),
+    name: z.string(),
+    dosage_value: z.number(),
+    dosage_unit: z.string(),
+  })),
+  dosage_rates: z.array(z.object({
+    id: z.string(),
+    animal: z.string(),
+    animal_id: z.string(),
+    animal_group: z.string().optional(),
+    animal_group_id: z.string().optional(),
+    targets: z.array(z.string()),
+    target_ids: z.array(z.string()),
+    entries: z.array(z.object({
+      dosage: z.object({
+        value: z.string(),
+        unit: z.string(),
+        per: z.string(),
+      }),
+      max_applications: z.object({
+        max: z.number(),
+        note: z.string(),
+      }),
+      application_interval: z.string(),
+      withdrawal_period: z.string(),
+      remarks: z.array(z.string()),
+    })),
+  })),
+  created: z.string().optional(),
+  updated: z.string().optional(),
+})
+
+export const FormAnimalHealthProductSchema = AnimalHealthProductSchema
+
+export type AnimalHealthCategory = z.infer<typeof AnimalHealthCategorySchema>
+export type FormAnimalHealthCategoryModel = z.infer<typeof FormAnimalHealthCategorySchema>
+export type AnimalHealthActiveIngredient = z.infer<typeof AnimalHealthActiveIngredientSchema>
+export type FormAnimalHealthActiveIngredientModel = z.infer<typeof FormAnimalHealthActiveIngredientSchema>
+export type AnimalHealthTarget = z.infer<typeof AnimalHealthTargetSchema>
+export type FormAnimalHealthTargetModel = z.infer<typeof FormAnimalHealthTargetSchema>
+export type AnimalHealthProduct = z.infer<typeof AnimalHealthProductSchema>
+export type FormAnimalHealthProductModel = z.infer<typeof FormAnimalHealthProductSchema>
+
+// Spray Program Schemas
+
+export const SprayProgramRecommendationSchema = z.object({
+  agrochemical_id: z.string().min(1, "Agrochemical is required"),
+  agrochemical_name: z.string(),
+  agrochemical_slug: z.string(),
+  purpose: z.string().min(1, "Purpose is required"),
+  dosage: z.object({
+    value: z.string(),
+    unit: z.string(),
+    per: z.string(),
+  }),
+  application_method: z.string(),
+  notes: z.string().optional().default(""),
+})
+
+export const SprayProgramStageSchema = z.object({
+  name: z.string().min(1, "Stage name is required"),
+  order: z.number(),
+  description: z.string().optional().default(""),
+  timing_description: z.string().optional().default(""),
+  recommendations: z.array(SprayProgramRecommendationSchema),
+})
+
+export const SprayProgramSchema = z.object({
+  id: z.string(),
+  name: z.string().min(1, "Name is required").max(100, "Name cannot exceed 100 characters"),
+  slug: z.string().optional(),
+  description: z.string().optional().default(""),
+  farm_produce_id: z.string().min(1, "Crop is required"),
+  farm_produce_name: z.string().optional(),
+  cover_image: z.custom<ImageModel>().optional().nullable(),
+  stages: z.array(SprayProgramStageSchema).min(1, "At least one stage is required"),
+  published: z.boolean().default(false),
+  created: z.string().optional(),
+  updated: z.string().optional(),
+})
+
+export const FormSprayProgramSchema = SprayProgramSchema
+
+export type SprayProgram = z.infer<typeof SprayProgramSchema>
+export type FormSprayProgramModel = z.infer<typeof FormSprayProgramSchema>
+export type SprayProgramStage = z.infer<typeof SprayProgramStageSchema>
+export type SprayProgramRecommendation = z.infer<typeof SprayProgramRecommendationSchema>
+
+// CDM (Cold Dress Mass) Schemas
+
+const CarcassGradePriceSchema = z.object({
+  collected_usd: z.coerce.number().nonnegative(),
+  delivered_usd: z.coerce.number().nonnegative(),
+  collected_zig: z.coerce.number().nonnegative(),
+  delivered_zig: z.coerce.number().nonnegative(),
+})
+
+const CarcassGradesSchema = z.object({
+  commercial: CarcassGradePriceSchema,
+  economy: CarcassGradePriceSchema,
+  manufacturing: CarcassGradePriceSchema,
+})
+
+const LiveweightEntrySchema = z.object({
+  weight_range: z.string().min(1, "Weight range is required"),
+  teeth: z.string().min(1, "Teeth category is required"),
+  delivered_usd: z.coerce.number().nonnegative(),
+  delivered_zig: z.coerce.number().nonnegative(),
+  grade_note: z.string().optional().default(""),
+})
+
+export const CdmPriceSchema = z.object({
+  id: z.string(),
+  created: z.string().optional(),
+  updated: z.string().optional(),
+  client_id: z.string().min(1, "Client is required"),
+  client_name: z.string(),
+  verified: z.boolean().optional(),
+  effectiveDate: z.coerce.date(),
+  exchange_rate: z.coerce.number().positive("Exchange rate must be positive"),
+  carcass_grades: CarcassGradesSchema,
+  liveweight: z.array(LiveweightEntrySchema),
+  notes: z.array(z.string()).default([]),
+})
+
+export type CdmPrice = z.infer<typeof CdmPriceSchema>
+export type CarcassGradePrice = z.infer<typeof CarcassGradePriceSchema>
+export type LiveweightEntry = z.infer<typeof LiveweightEntrySchema>
+
+export type CdmPriceResponse = {
+  total: number
+  data: CdmPrice[]
+}

--- a/apps/admin-fnp/types/index.d.ts
+++ b/apps/admin-fnp/types/index.d.ts
@@ -16,6 +16,11 @@ export type SidebarNavigationItem = {
     }
 )
 
+export type SidebarNavigationGroup = {
+  label: string
+  items: SidebarNavigationItem[]
+}
+
 export type NavigationItem = {
   title: string
   href: string
@@ -24,5 +29,5 @@ export type NavigationItem = {
 
 export type DashboardConfig = {
   mainNavigation: NavigationItem[]
-  sidebarNavigation: SidebarNavigationItem[]
+  sidebarNavigation: SidebarNavigationGroup[]
 }

--- a/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/[slug]/page.tsx
@@ -2,9 +2,10 @@
 
 import { use } from "react"
 import { useQuery } from "@tanstack/react-query"
+import { useSearchParams } from "next/navigation"
 import { queryAgroChemical } from "@/lib/query"
 import Image from "next/image"
-import { Beaker, AlertTriangle } from "lucide-react"
+import { Beaker, AlertTriangle, ArrowLeft } from "lucide-react"
 import Link from "next/link"
 import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
 import { capitalizeFirstLetter, formatUnit } from "@/lib/utilities"
@@ -18,6 +19,8 @@ interface GuidePageProps {
 
 export default function AgroChemicalGuidePage({ params }: GuidePageProps) {
     const { category, slug } = use(params)
+    const searchParams = useSearchParams()
+    const fromSprayProgram = searchParams.get("from")
 
     const { data, isLoading } = useQuery({
         queryKey: ["agrochemical-guide", slug],
@@ -151,6 +154,21 @@ export default function AgroChemicalGuidePage({ params }: GuidePageProps) {
                     type="application/ld+json"
                     dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
                 />
+            )}
+
+            {/* Back to Spray Program */}
+            {fromSprayProgram && (
+                <div className="border-b bg-primary/5">
+                    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2.5">
+                        <Link
+                            href={`/spray-programs/${fromSprayProgram}`}
+                            className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:text-primary/80 transition-colors"
+                        >
+                            <ArrowLeft className="h-3.5 w-3.5" />
+                            Back to Spray Program
+                        </Link>
+                    </div>
+                </div>
             )}
 
             {/* Breadcrumb */}

--- a/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/page.tsx
+++ b/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/page.tsx
@@ -81,8 +81,8 @@ export default function AgroChemicalCategoryPage({ params }: CategoryPageProps) 
                     {/* Main Content */}
                     <main className="flex-1">
                         {chemicalsLoading ? (
-                            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
-                                {[...Array(6)].map((_, i) => (
+                            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-5">
+                                {[...Array(8)].map((_, i) => (
                                     <div key={i} className="animate-pulse">
                                         <div className="bg-card border border-border rounded-lg overflow-hidden">
                                             <div className="aspect-square bg-muted" />

--- a/apps/client-fnp/app/(landing)/agrochemical-guides/all/page.tsx
+++ b/apps/client-fnp/app/(landing)/agrochemical-guides/all/page.tsx
@@ -58,8 +58,8 @@ export default function AllAgroChemicalsPage() {
                     {/* Main Content */}
                     <main className="flex-1">
                         {chemicalsLoading ? (
-                            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
-                                {[...Array(6)].map((_, i) => (
+                            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-5">
+                                {[...Array(8)].map((_, i) => (
                                     <div key={i} className="animate-pulse">
                                         <div className="bg-card border border-border rounded-lg overflow-hidden">
                                             <div className="aspect-square bg-muted" />
@@ -83,7 +83,7 @@ export default function AllAgroChemicalsPage() {
                             </div>
                         ) : (
                             <>
-                                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+                                <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-5">
                                     {chemicals.map((chemical: any) => (
                                         <AgroChemicalCard
                                             key={chemical.id}

--- a/apps/client-fnp/app/(landing)/agrochemical-guides/all/page.tsx
+++ b/apps/client-fnp/app/(landing)/agrochemical-guides/all/page.tsx
@@ -3,13 +3,15 @@
 import { useQuery } from "@tanstack/react-query"
 import { queryAllAgroChemicals } from "@/lib/query"
 import { Button } from "@/components/ui/button"
-import { Beaker } from "lucide-react"
+import { Input } from "@/components/ui/input"
+import { Beaker, Search, X } from "lucide-react"
 import { AgroChemicalFilterSidebar } from "@/components/generic/agroChemicalFilterSidebar"
 import { AgroChemicalCard } from "@/components/agrochemical/AgroChemicalCard"
 import { useQueryStates, parseAsArrayOf, parseAsString, parseAsInteger } from "nuqs"
 
 export default function AllAgroChemicalsPage() {
     const [queryState, setQueryState] = useQueryStates({
+        search: parseAsString.withDefault(""),
         brand: parseAsArrayOf(parseAsString),
         target: parseAsArrayOf(parseAsString),
         active_ingredient: parseAsArrayOf(parseAsString),
@@ -18,9 +20,10 @@ export default function AllAgroChemicalsPage() {
     })
 
     const { data: chemicalsData, isLoading: chemicalsLoading } = useQuery({
-        queryKey: ["agrochemicals-all", queryState.p, queryState.brand, queryState.target, queryState.active_ingredient, queryState.used_on],
+        queryKey: ["agrochemicals-all", queryState.p, queryState.search, queryState.brand, queryState.target, queryState.active_ingredient, queryState.used_on],
         queryFn: () => queryAllAgroChemicals({
             p: queryState.p,
+            search: queryState.search,
             brand: queryState.brand || [],
             target: queryState.target || [],
             active_ingredient: queryState.active_ingredient || [],
@@ -42,11 +45,31 @@ export default function AllAgroChemicalsPage() {
                 {/* Header */}
                 <div className="mb-8">
                     <h1 className="text-4xl font-bold tracking-tight font-heading mb-4">
-                        All Agrochemicals
+                        {queryState.search ? `Results for "${queryState.search}"` : "All Agrochemicals"}
                     </h1>
                     <p className="text-lg text-muted-foreground">
                         Browse our complete collection of agrochemical products
                     </p>
+                    <div className="mt-4 flex items-center gap-2 max-w-md">
+                        <div className="relative flex-1">
+                            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                            <Input
+                                placeholder="Search products, active ingredients..."
+                                value={queryState.search}
+                                onChange={(e) => setQueryState({ search: e.target.value, p: 1 })}
+                                className="pl-10"
+                            />
+                        </div>
+                        {queryState.search && (
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                onClick={() => setQueryState({ search: "", p: 1 })}
+                            >
+                                <X className="h-4 w-4" />
+                            </Button>
+                        )}
+                    </div>
                 </div>
 
                 <div className="flex flex-col lg:flex-row gap-8">

--- a/apps/client-fnp/app/(landing)/agrochemical-guides/page.tsx
+++ b/apps/client-fnp/app/(landing)/agrochemical-guides/page.tsx
@@ -2,10 +2,15 @@
 
 import { sendGTMEvent } from "@next/third-parties/google"
 import Link from "next/link"
-import { Pill, Leaf, Bug, Droplet, Rat, TrendingUp, Beaker, Shell, Shield, ArrowRight } from "lucide-react"
+import Image from "next/image"
+import {
+    Pill, Leaf, Bug, Droplet, Rat, TrendingUp, Beaker, Shell, Shield,
+    ArrowRight, Sprout, Layers, ChevronRight, Search, BookOpen, FlaskConical
+} from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useQuery } from "@tanstack/react-query"
-import { queryAgroChemicalCategories } from "@/lib/query"
+import { queryAgroChemicalCategories, queryPublishedSprayPrograms } from "@/lib/query"
+import { capitalizeFirstLetter } from "@/lib/utilities"
 
 const categoryIcons: Record<string, any> = {
     "insecticides": Bug,
@@ -27,46 +32,223 @@ export default function AgrochemicalGuidesPage() {
         refetchOnWindowFocus: false,
     })
 
+    const { data: sprayData, isLoading: sprayLoading } = useQuery({
+        queryKey: ["spray-programs-landing"],
+        queryFn: () => queryPublishedSprayPrograms(),
+        refetchOnWindowFocus: false,
+    })
+
     const categories = data?.data?.data || []
+    const sprayPrograms = sprayData?.data?.data || []
 
     return (
         <main className="bg-gradient-to-b from-background to-muted/20">
             {/* Hero Section */}
-            <section className="py-12 lg:py-16 relative overflow-hidden">
-                <div className="mx-auto max-w-7xl px-6 lg:px-8">
-                    {/* Hero Content */}
-                    <div className="text-center max-w-3xl mx-auto mb-12">
-                        <h1 className="text-4xl font-bold tracking-tight sm:text-5xl font-heading mb-4">
-                            Your Complete Agrochemical Guide
+            <section className="py-16 lg:py-24 relative overflow-hidden">
+                <div className="absolute inset-0 bg-gradient-to-br from-green-50/60 via-transparent to-emerald-50/40 dark:from-green-950/20 dark:to-emerald-950/10" />
+                <div className="absolute top-20 left-10 w-72 h-72 bg-green-200/20 dark:bg-green-800/10 rounded-full blur-3xl" />
+                <div className="absolute bottom-10 right-10 w-96 h-96 bg-emerald-200/20 dark:bg-emerald-800/10 rounded-full blur-3xl" />
+
+                <div className="mx-auto max-w-7xl px-6 lg:px-8 relative">
+                    <div className="text-center max-w-3xl mx-auto">
+                        <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300 text-sm font-medium mb-6">
+                            <FlaskConical className="h-4 w-4" />
+                            Your Crop Protection Hub
+                        </div>
+                        <h1 className="text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl font-heading mb-5">
+                            Agrochemical Guides &{" "}
+                            <span className="text-primary">Spray Programs</span>
                         </h1>
-                        <p className="text-lg text-muted-foreground leading-7 mb-6">
-                            Search active ingredients, discover how pesticides and herbicides work, find what targets specific pests and diseases.
+                        <p className="text-lg text-muted-foreground leading-7 mb-8 max-w-2xl mx-auto">
+                            Search active ingredients, discover how pesticides and herbicides work,
+                            and follow step-by-step spray programs for every growth stage.
                         </p>
-                        <Button
-                            size="lg"
-                            asChild
-                            onClick={() => sendGTMEvent({ event: "click", value: "ReadGuides" })}
-                            className="text-base px-6 py-5 h-auto font-semibold shadow-lg hover:shadow-xl transition-all group"
-                        >
-                            <Link href="/agrochemical-guides/all" className="flex items-center gap-2">
-                                Browse All Guides
-                                <ArrowRight className="h-5 w-5 transition-transform group-hover:translate-x-1" />
+                        <div className="flex flex-wrap items-center justify-center gap-3">
+                            <Button
+                                size="lg"
+                                asChild
+                                onClick={() => sendGTMEvent({ event: "click", value: "ReadGuides" })}
+                                className="text-base px-6 py-5 h-auto font-semibold shadow-lg hover:shadow-xl transition-all group"
+                            >
+                                <Link href="/agrochemical-guides/all" className="flex items-center gap-2">
+                                    <Search className="h-5 w-5" />
+                                    Browse All Products
+                                </Link>
+                            </Button>
+                            <Button
+                                size="lg"
+                                variant="outline"
+                                asChild
+                                className="text-base px-6 py-5 h-auto font-semibold transition-all group"
+                            >
+                                <Link href="/spray-programs" className="flex items-center gap-2">
+                                    <Sprout className="h-5 w-5" />
+                                    All Spray Programs
+                                    <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+                                </Link>
+                            </Button>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            {/* Quick Stats */}
+            <section className="border-y bg-card/50">
+                <div className="mx-auto max-w-7xl px-6 lg:px-8">
+                    <div className="grid grid-cols-3 divide-x">
+                        <div className="py-6 text-center">
+                            <div className="text-2xl sm:text-3xl font-bold text-primary">{categories.length || "10"}+</div>
+                            <div className="text-xs sm:text-sm text-muted-foreground mt-1">Product Categories</div>
+                        </div>
+                        <div className="py-6 text-center">
+                            <div className="text-2xl sm:text-3xl font-bold text-primary">{sprayPrograms.length || "0"}</div>
+                            <div className="text-xs sm:text-sm text-muted-foreground mt-1">Spray Programs</div>
+                        </div>
+                        <div className="py-6 text-center">
+                            <div className="text-2xl sm:text-3xl font-bold text-primary">Free</div>
+                            <div className="text-xs sm:text-sm text-muted-foreground mt-1">Always Free Access</div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            {/* Spray Programs Section */}
+            {(sprayLoading || sprayPrograms.length > 0) && (
+                <section className="py-14 lg:py-20">
+                    <div className="mx-auto max-w-7xl px-6 lg:px-8">
+                        <div className="flex items-end justify-between mb-8">
+                            <div>
+                                <div className="flex items-center gap-2 text-sm font-medium text-green-600 dark:text-green-400 mb-2">
+                                    <Sprout className="h-4 w-4" />
+                                    STEP-BY-STEP GUIDES
+                                </div>
+                                <h2 className="text-3xl font-bold tracking-tight font-heading">
+                                    Crop Spray Programs
+                                </h2>
+                                <p className="text-muted-foreground mt-2 max-w-lg">
+                                    Know exactly what to spray, when to spray, and how much to use at every growth stage.
+                                </p>
+                            </div>
+                            <Link
+                                href="/spray-programs"
+                                className="hidden sm:flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+                            >
+                                View all
+                                <ArrowRight className="h-4 w-4" />
                             </Link>
-                        </Button>
+                        </div>
+
+                        {sprayLoading ? (
+                            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5">
+                                {[1, 2, 3, 4].map((i) => (
+                                    <div key={i} className="animate-pulse rounded-xl border bg-card overflow-hidden">
+                                        <div className="aspect-[16/9] bg-muted" />
+                                        <div className="p-4 space-y-3">
+                                            <div className="h-5 bg-muted rounded w-3/4" />
+                                            <div className="h-4 bg-muted rounded w-full" />
+                                            <div className="h-4 bg-muted rounded w-1/2" />
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        ) : (
+                            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5">
+                                {sprayPrograms.map((program: any) => (
+                                    <Link
+                                        key={program.id}
+                                        href={`/spray-programs/${program.slug}`}
+                                        className="group rounded-xl border bg-card overflow-hidden hover:border-primary hover:shadow-lg transition-all duration-300"
+                                    >
+                                        <div className="relative aspect-[16/9] bg-gradient-to-br from-green-50 to-emerald-50 dark:from-green-950/30 dark:to-emerald-950/30 overflow-hidden">
+                                            {program.cover_image?.img?.src ? (
+                                                <Image
+                                                    src={program.cover_image.img.src}
+                                                    alt={program.name}
+                                                    fill
+                                                    sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
+                                                    className="object-cover group-hover:scale-105 transition-transform duration-500"
+                                                />
+                                            ) : (
+                                                <div className="absolute inset-0 flex items-center justify-center">
+                                                    <Sprout className="w-12 h-12 text-green-300 dark:text-green-800" />
+                                                </div>
+                                            )}
+                                        </div>
+                                        <div className="p-4">
+                                            <h3 className="font-semibold text-sm mb-1.5 group-hover:text-primary transition-colors line-clamp-1">
+                                                {capitalizeFirstLetter(program.name)}
+                                            </h3>
+                                            {program.farm_produce_name && (
+                                                <div className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300 mb-2">
+                                                    <Sprout className="h-2.5 w-2.5" />
+                                                    {capitalizeFirstLetter(program.farm_produce_name)}
+                                                </div>
+                                            )}
+                                            {program.description && (
+                                                <p className="text-xs text-muted-foreground line-clamp-2 mb-3">
+                                                    {program.description}
+                                                </p>
+                                            )}
+                                            <div className="flex items-center justify-between">
+                                                <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                                                    <Layers className="h-3 w-3" />
+                                                    <span>{program.stages?.length || 0} stages</span>
+                                                </div>
+                                                <ChevronRight className="h-4 w-4 text-primary opacity-0 group-hover:opacity-100 transition-opacity" />
+                                            </div>
+                                        </div>
+                                    </Link>
+                                ))}
+                            </div>
+                        )}
+
+                        <Link
+                            href="/spray-programs"
+                            className="sm:hidden flex items-center justify-center gap-1 text-sm font-medium text-primary hover:underline mt-6"
+                        >
+                            View all spray programs
+                            <ArrowRight className="h-4 w-4" />
+                        </Link>
+                    </div>
+                </section>
+            )}
+
+            {/* Categories Section */}
+            <section className="py-14 lg:py-20 bg-muted/30">
+                <div className="mx-auto max-w-7xl px-6 lg:px-8">
+                    <div className="flex items-end justify-between mb-8">
+                        <div>
+                            <div className="flex items-center gap-2 text-sm font-medium text-primary mb-2">
+                                <BookOpen className="h-4 w-4" />
+                                PRODUCT DATABASE
+                            </div>
+                            <h2 className="text-3xl font-bold tracking-tight font-heading">
+                                Browse by Category
+                            </h2>
+                            <p className="text-muted-foreground mt-2 max-w-lg">
+                                Explore agrochemical products by type. Each guide includes active ingredients, targets, and usage information.
+                            </p>
+                        </div>
+                        <Link
+                            href="/agrochemical-guides/all"
+                            className="hidden sm:flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+                        >
+                            View all products
+                            <ArrowRight className="h-4 w-4" />
+                        </Link>
                     </div>
 
-                    {/* Categories Grid */}
-                    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+                    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
                         {categories.map((category: any) => {
                             const Icon = categoryIcons[category.slug] || Pill
                             return (
                                 <Link
                                     key={category.slug}
                                     href={`/agrochemical-guides/${category.slug}`}
-                                    className="flex flex-col items-center gap-3 p-5 rounded-xl bg-card border border-border hover:border-primary hover:bg-accent transition-all group"
+                                    className="flex flex-col items-center gap-3 p-6 rounded-xl bg-card border border-border hover:border-primary hover:shadow-md transition-all group"
                                 >
-                                    <div className="flex items-center justify-center w-12 h-12 rounded-lg bg-primary/10 group-hover:bg-primary/20 transition-colors">
-                                        <Icon className="w-5 h-5 text-primary" strokeWidth={2} />
+                                    <div className="flex items-center justify-center w-14 h-14 rounded-xl bg-primary/10 group-hover:bg-primary/20 transition-colors">
+                                        <Icon className="w-6 h-6 text-primary" strokeWidth={2} />
                                     </div>
                                     <span className="text-sm font-medium text-center text-foreground group-hover:text-primary transition-colors">
                                         {category.name}
@@ -75,6 +257,14 @@ export default function AgrochemicalGuidesPage() {
                             )
                         })}
                     </div>
+
+                    <Link
+                        href="/agrochemical-guides/all"
+                        className="sm:hidden flex items-center justify-center gap-1 text-sm font-medium text-primary hover:underline mt-6"
+                    >
+                        View all products
+                        <ArrowRight className="h-4 w-4" />
+                    </Link>
                 </div>
             </section>
         </main>

--- a/apps/client-fnp/app/(landing)/agrochemical-guides/page.tsx
+++ b/apps/client-fnp/app/(landing)/agrochemical-guides/page.tsx
@@ -1,16 +1,13 @@
-"use client"
-
-import { sendGTMEvent } from "@next/third-parties/google"
 import Link from "next/link"
 import Image from "next/image"
 import {
     Pill, Leaf, Bug, Droplet, Rat, TrendingUp, Beaker, Shell, Shield,
-    ArrowRight, Sprout, Layers, ChevronRight, Search, BookOpen, FlaskConical
+    ArrowRight, Sprout, Layers, ChevronRight, BookOpen, FlaskConical
 } from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { useQuery } from "@tanstack/react-query"
-import { queryAgroChemicalCategories, queryPublishedSprayPrograms } from "@/lib/query"
+import { BaseURL } from "@/lib/schemas"
 import { capitalizeFirstLetter } from "@/lib/utilities"
+import { GuidesSearch } from "@/components/agrochemical/GuidesSearch"
+import { GuidesHeroActions } from "@/components/agrochemical/GuidesHeroActions"
 
 const categoryIcons: Record<string, any> = {
     "insecticides": Bug,
@@ -25,21 +22,33 @@ const categoryIcons: Record<string, any> = {
     "bactericides": Pill,
 }
 
-export default function AgrochemicalGuidesPage() {
-    const { data } = useQuery({
-        queryKey: ["agrochemical-categories"],
-        queryFn: () => queryAgroChemicalCategories(),
-        refetchOnWindowFocus: false,
-    })
+async function getCategories() {
+    try {
+        const res = await fetch(`${BaseURL}/agrochemicalcategories/`, { next: { revalidate: 3600 } })
+        if (!res.ok) return []
+        const data = await res.json()
+        return data?.data || []
+    } catch {
+        return []
+    }
+}
 
-    const { data: sprayData, isLoading: sprayLoading } = useQuery({
-        queryKey: ["spray-programs-landing"],
-        queryFn: () => queryPublishedSprayPrograms(),
-        refetchOnWindowFocus: false,
-    })
+async function getSprayPrograms() {
+    try {
+        const res = await fetch(`${BaseURL}/sprayprograms/`, { next: { revalidate: 3600 } })
+        if (!res.ok) return []
+        const data = await res.json()
+        return data?.data || []
+    } catch {
+        return []
+    }
+}
 
-    const categories = data?.data?.data || []
-    const sprayPrograms = sprayData?.data?.data || []
+export default async function AgrochemicalGuidesPage() {
+    const [categories, sprayPrograms] = await Promise.all([
+        getCategories(),
+        getSprayPrograms(),
+    ])
 
     return (
         <main className="bg-gradient-to-b from-background to-muted/20">
@@ -63,31 +72,13 @@ export default function AgrochemicalGuidesPage() {
                             Search active ingredients, discover how pesticides and herbicides work,
                             and follow step-by-step spray programs for every growth stage.
                         </p>
-                        <div className="flex flex-wrap items-center justify-center gap-3">
-                            <Button
-                                size="lg"
-                                asChild
-                                onClick={() => sendGTMEvent({ event: "click", value: "ReadGuides" })}
-                                className="text-base px-6 py-5 h-auto font-semibold shadow-lg hover:shadow-xl transition-all group"
-                            >
-                                <Link href="/agrochemical-guides/all" className="flex items-center gap-2">
-                                    <Search className="h-5 w-5" />
-                                    Browse All Products
-                                </Link>
-                            </Button>
-                            <Button
-                                size="lg"
-                                variant="outline"
-                                asChild
-                                className="text-base px-6 py-5 h-auto font-semibold transition-all group"
-                            >
-                                <Link href="/spray-programs" className="flex items-center gap-2">
-                                    <Sprout className="h-5 w-5" />
-                                    All Spray Programs
-                                    <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
-                                </Link>
-                            </Button>
+
+                        {/* Quick Search */}
+                        <div className="mb-8">
+                            <GuidesSearch />
                         </div>
+
+                        <GuidesHeroActions />
                     </div>
                 </div>
             </section>
@@ -113,7 +104,7 @@ export default function AgrochemicalGuidesPage() {
             </section>
 
             {/* Spray Programs Section */}
-            {(sprayLoading || sprayPrograms.length > 0) && (
+            {sprayPrograms.length > 0 && (
                 <section className="py-14 lg:py-20">
                     <div className="mx-auto max-w-7xl px-6 lg:px-8">
                         <div className="flex items-end justify-between mb-8">
@@ -138,69 +129,54 @@ export default function AgrochemicalGuidesPage() {
                             </Link>
                         </div>
 
-                        {sprayLoading ? (
-                            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5">
-                                {[1, 2, 3, 4].map((i) => (
-                                    <div key={i} className="animate-pulse rounded-xl border bg-card overflow-hidden">
-                                        <div className="aspect-[16/9] bg-muted" />
-                                        <div className="p-4 space-y-3">
-                                            <div className="h-5 bg-muted rounded w-3/4" />
-                                            <div className="h-4 bg-muted rounded w-full" />
-                                            <div className="h-4 bg-muted rounded w-1/2" />
+                        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5">
+                            {sprayPrograms.map((program: any) => (
+                                <Link
+                                    key={program.id}
+                                    href={`/spray-programs/${program.slug}`}
+                                    className="group rounded-xl border bg-card overflow-hidden hover:border-primary hover:shadow-lg transition-all duration-300"
+                                >
+                                    <div className="relative aspect-[16/9] bg-gradient-to-br from-green-50 to-emerald-50 dark:from-green-950/30 dark:to-emerald-950/30 overflow-hidden">
+                                        {program.cover_image?.img?.src ? (
+                                            <Image
+                                                src={program.cover_image.img.src}
+                                                alt={program.name}
+                                                fill
+                                                sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
+                                                className="object-cover group-hover:scale-105 transition-transform duration-500"
+                                            />
+                                        ) : (
+                                            <div className="absolute inset-0 flex items-center justify-center">
+                                                <Sprout className="w-12 h-12 text-green-300 dark:text-green-800" />
+                                            </div>
+                                        )}
+                                    </div>
+                                    <div className="p-4">
+                                        <h3 className="font-semibold text-sm mb-1.5 group-hover:text-primary transition-colors line-clamp-1">
+                                            {capitalizeFirstLetter(program.name)}
+                                        </h3>
+                                        {program.farm_produce_name && (
+                                            <div className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300 mb-2">
+                                                <Sprout className="h-2.5 w-2.5" />
+                                                {capitalizeFirstLetter(program.farm_produce_name)}
+                                            </div>
+                                        )}
+                                        {program.description && (
+                                            <p className="text-xs text-muted-foreground line-clamp-2 mb-3">
+                                                {program.description}
+                                            </p>
+                                        )}
+                                        <div className="flex items-center justify-between">
+                                            <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                                                <Layers className="h-3 w-3" />
+                                                <span>{program.stages?.length || 0} stages</span>
+                                            </div>
+                                            <ChevronRight className="h-4 w-4 text-primary opacity-0 group-hover:opacity-100 transition-opacity" />
                                         </div>
                                     </div>
-                                ))}
-                            </div>
-                        ) : (
-                            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5">
-                                {sprayPrograms.map((program: any) => (
-                                    <Link
-                                        key={program.id}
-                                        href={`/spray-programs/${program.slug}`}
-                                        className="group rounded-xl border bg-card overflow-hidden hover:border-primary hover:shadow-lg transition-all duration-300"
-                                    >
-                                        <div className="relative aspect-[16/9] bg-gradient-to-br from-green-50 to-emerald-50 dark:from-green-950/30 dark:to-emerald-950/30 overflow-hidden">
-                                            {program.cover_image?.img?.src ? (
-                                                <Image
-                                                    src={program.cover_image.img.src}
-                                                    alt={program.name}
-                                                    fill
-                                                    sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
-                                                    className="object-cover group-hover:scale-105 transition-transform duration-500"
-                                                />
-                                            ) : (
-                                                <div className="absolute inset-0 flex items-center justify-center">
-                                                    <Sprout className="w-12 h-12 text-green-300 dark:text-green-800" />
-                                                </div>
-                                            )}
-                                        </div>
-                                        <div className="p-4">
-                                            <h3 className="font-semibold text-sm mb-1.5 group-hover:text-primary transition-colors line-clamp-1">
-                                                {capitalizeFirstLetter(program.name)}
-                                            </h3>
-                                            {program.farm_produce_name && (
-                                                <div className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300 mb-2">
-                                                    <Sprout className="h-2.5 w-2.5" />
-                                                    {capitalizeFirstLetter(program.farm_produce_name)}
-                                                </div>
-                                            )}
-                                            {program.description && (
-                                                <p className="text-xs text-muted-foreground line-clamp-2 mb-3">
-                                                    {program.description}
-                                                </p>
-                                            )}
-                                            <div className="flex items-center justify-between">
-                                                <div className="flex items-center gap-1 text-xs text-muted-foreground">
-                                                    <Layers className="h-3 w-3" />
-                                                    <span>{program.stages?.length || 0} stages</span>
-                                                </div>
-                                                <ChevronRight className="h-4 w-4 text-primary opacity-0 group-hover:opacity-100 transition-opacity" />
-                                            </div>
-                                        </div>
-                                    </Link>
-                                ))}
-                            </div>
-                        )}
+                                </Link>
+                            ))}
+                        </div>
 
                         <Link
                             href="/spray-programs"

--- a/apps/client-fnp/app/(landing)/animal-health-guides/[category]/[slug]/layout.tsx
+++ b/apps/client-fnp/app/(landing)/animal-health-guides/[category]/[slug]/layout.tsx
@@ -1,0 +1,100 @@
+import { Metadata } from 'next'
+import { queryAnimalHealthProduct } from '@/lib/query'
+
+interface LayoutProps {
+  children: React.ReactNode
+  params: Promise<{
+    category: string
+    slug: string
+  }>
+}
+
+export async function generateMetadata({ params }: LayoutProps): Promise<Metadata> {
+  const { category, slug } = await params
+
+  try {
+    const response = await queryAnimalHealthProduct(slug)
+    const product = response?.data
+
+    if (!product) {
+      return {
+        title: 'Product Not Found | farmnport',
+        description: 'The animal health product you are looking for could not be found.',
+      }
+    }
+
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://farmnport.com'
+    const url = `${baseUrl}/animal-health-guides/${category}/${slug}`
+    const imageUrl = product.images?.[0]?.img?.src || `${baseUrl}/default-chemical.png`
+
+    const description = product.animal_health_category?.name
+      ? `${product.name} is a ${product.animal_health_category.name} for poultry and livestock health. View active ingredients, dosage rates, withdrawal periods, and application guidelines.`
+      : `Professional animal health product guide for ${product.name}. Complete information on active ingredients, dosage rates, and withdrawal periods.`
+
+    const keywords = [
+      product.name,
+      product.animal_health_category?.name || 'animal health',
+      'veterinary product',
+      'dosage rates',
+      'withdrawal period',
+      'active ingredients',
+      'poultry',
+      'livestock',
+      ...(product.targets?.map((t: any) => t.name) || []),
+      ...(product.active_ingredients?.map((ai: any) => ai.name) || [])
+    ].filter(Boolean).join(', ')
+
+    return {
+      title: `${product.name} - Animal Health Guide | farmnport`,
+      description,
+      keywords,
+      authors: [{ name: 'farmnport' }],
+      openGraph: {
+        title: `${product.name} - Animal Health Guide`,
+        description,
+        url,
+        siteName: 'farmnport',
+        images: [
+          {
+            url: imageUrl,
+            width: 1200,
+            height: 630,
+            alt: product.name,
+          },
+        ],
+        locale: 'en_US',
+        type: 'website',
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title: `${product.name} - Animal Health Guide`,
+        description,
+        images: [imageUrl],
+      },
+      alternates: {
+        canonical: url,
+      },
+      robots: {
+        index: true,
+        follow: true,
+        googleBot: {
+          index: true,
+          follow: true,
+          'max-video-preview': -1,
+          'max-image-preview': 'large',
+          'max-snippet': -1,
+        },
+      },
+    }
+  } catch (error) {
+    console.error('Error generating metadata:', error)
+    return {
+      title: 'Animal Health Guide | farmnport',
+      description: 'Professional animal health product guides and dosage information.',
+    }
+  }
+}
+
+export default function AnimalHealthDetailLayout({ children }: LayoutProps) {
+  return <>{children}</>
+}

--- a/apps/client-fnp/app/(landing)/animal-health-guides/[category]/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/animal-health-guides/[category]/[slug]/page.tsx
@@ -1,0 +1,520 @@
+"use client"
+
+import { use } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { queryAnimalHealthProduct } from "@/lib/query"
+import Image from "next/image"
+import { Beaker, AlertTriangle } from "lucide-react"
+import Link from "next/link"
+import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
+import { capitalizeFirstLetter, formatUnit } from "@/lib/utilities"
+
+interface GuidePageProps {
+    params: Promise<{
+        category: string
+        slug: string
+    }>
+}
+
+export default function AnimalHealthGuidePage({ params }: GuidePageProps) {
+    const { category, slug } = use(params)
+
+    const { data, isLoading } = useQuery({
+        queryKey: ["animal-health-guide", slug],
+        queryFn: () => queryAnimalHealthProduct(slug),
+        refetchOnWindowFocus: false,
+    })
+
+    const product = data?.data
+
+    const categorySlug = product?.animal_health_category?.slug || ""
+    const overviewDesc: Record<string, string> = {
+        vaccines: "a vaccine designed to protect poultry and livestock against infectious diseases. It stimulates the immune system to build resistance when administered according to the recommended schedule.",
+        antibiotics: "an antibiotic formulated for the treatment and prevention of bacterial infections in poultry and livestock. It targets harmful bacteria while supporting animal recovery when used as directed.",
+        "nutrition-supplements": "a nutritional supplement formulated to support optimal health and productivity in poultry and livestock. It provides essential vitamins, minerals, and nutrients for growth and well-being.",
+        "anti-protozoa": "an anti-protozoal product developed for the treatment and prevention of protozoal infections such as coccidiosis. It effectively manages parasitic protozoa in poultry and livestock.",
+        "biosecurity-disinfectants": "a biosecurity disinfectant designed for cleaning and sanitizing poultry and livestock housing. It helps eliminate pathogens and maintain a healthy environment.",
+    }
+
+    if (isLoading) {
+        return (
+            <div className="min-h-screen bg-background">
+                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                    <div className="animate-pulse grid md:grid-cols-2 gap-8">
+                        <div className="aspect-square bg-muted rounded-lg" />
+                        <div className="space-y-4">
+                            <div className="h-8 bg-muted rounded w-3/4" />
+                            <div className="h-4 bg-muted rounded w-1/2" />
+                            <div className="h-12 bg-muted rounded w-1/3" />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        )
+    }
+
+    if (!product) {
+        return (
+            <div className="min-h-screen bg-background flex items-center justify-center px-4 pb-4">
+                <div className="text-center max-w-md">
+                    <div className="mb-6">
+                        <div className="mx-auto w-20 h-20 bg-muted rounded-full flex items-center justify-center">
+                            <Beaker className="w-10 h-10 text-muted-foreground" />
+                        </div>
+                    </div>
+                    <h2 className="text-2xl font-semibold mb-2">Guide Not Found</h2>
+                    <p className="text-muted-foreground mb-6">
+                        We couldn&apos;t find the animal health product guide you&apos;re looking for. It may have been removed or the link might be incorrect.
+                    </p>
+                    <div className="flex flex-col sm:flex-row gap-3 justify-center">
+                        <Link href="/animal-health-guides/all">
+                            <button className="inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">
+                                Browse All Guides
+                            </button>
+                        </Link>
+                        <Link href="/animal-health-guides">
+                            <button className="inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">
+                                Go to Categories
+                            </button>
+                        </Link>
+                    </div>
+                </div>
+            </div>
+        )
+    }
+
+    // Generate JSON-LD structured data
+    const generateStructuredData = () => {
+        if (!product) return null
+
+        const baseUrl = typeof window !== 'undefined' ? window.location.origin : 'https://farmnport.com'
+        const url = `${baseUrl}/animal-health-guides/${category}/${slug}`
+        const imageUrl = product.images?.[0]?.img?.src || `${baseUrl}/default-chemical.png`
+
+        const description = product.animal_health_category?.name
+            ? `${product.name} is a ${product.animal_health_category.name} for poultry and livestock health. View active ingredients, dosage rates, and withdrawal periods.`
+            : `Professional animal health product guide for ${product.name}. Complete information on active ingredients, dosage rates, and withdrawal periods.`
+
+        const usageInfo = product.dosage_rates?.length > 0
+            ? `Dosage rates available for ${product.dosage_rates.map((r: any) => r.animal).join(', ')}`
+            : undefined
+
+        return {
+            "@context": "https://schema.org",
+            "@type": "Product",
+            "name": product.name,
+            "description": description,
+            "image": imageUrl,
+            "category": product.animal_health_category?.name || "Animal Health Product",
+            "url": url,
+            "additionalProperty": [
+                ...(product.active_ingredients?.map((ai: any) => ({
+                    "@type": "PropertyValue",
+                    "name": "Active Ingredient",
+                    "value": `${ai.name} (${ai.dosage_value} ${ai.dosage_unit})`
+                })) || []),
+                ...(product.targets?.map((target: any) => ({
+                    "@type": "PropertyValue",
+                    "name": "Target Disease/Condition",
+                    "value": target.scientific_name ? `${target.name} (${target.scientific_name})` : target.name
+                })) || [])
+            ],
+            "applicationCategory": "Veterinary Product",
+            "usageInfo": usageInfo
+        }
+    }
+
+    const structuredData = generateStructuredData()
+
+    return (
+        <div className="min-h-screen bg-background">
+            {/* JSON-LD Structured Data */}
+            {structuredData && (
+                <script
+                    type="application/ld+json"
+                    dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+                />
+            )}
+
+            {/* Breadcrumb */}
+            <div className="border-b bg-muted/30">
+                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+                    <nav className="flex text-sm text-muted-foreground">
+                        <Link href="/" className="hover:text-foreground">Home</Link>
+                        <span className="mx-2">/</span>
+                        <Link href="/animal-health-guides/all" className="hover:text-foreground">Guides</Link>
+                        <span className="mx-2">/</span>
+                        <Link href={`/animal-health-guides/${category}`} className="hover:text-foreground capitalize">{product.animal_health_category?.name || category}</Link>
+                        <span className="mx-2">/</span>
+                        <span className="text-foreground capitalize">{product.name}</span>
+                    </nav>
+                </div>
+            </div>
+
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                {/* Header Section */}
+                <div className="grid lg:grid-cols-[450px,1fr] gap-12 mb-16">
+                    {/* Left - Image */}
+                    <div className="space-y-4">
+                        <div className="relative aspect-square bg-white rounded-xl border overflow-hidden shadow-sm">
+                            {product.images && product.images[0] && product.images[0].img?.src ? (
+                                <Image
+                                    src={product.images[0].img.src}
+                                    alt={product.name}
+                                    fill
+                                    sizes="(max-width: 1024px) 100vw, 450px"
+                                    className="object-contain p-8"
+                                    priority
+                                />
+                            ) : (
+                                <div className="absolute inset-0 flex items-center justify-center">
+                                    <Beaker className="w-24 h-24 text-muted-foreground/30" />
+                                </div>
+                            )}
+                        </div>
+
+                        {/* Thumbnail Gallery */}
+                        {product.images && product.images.length > 1 && (
+                            <div className="grid grid-cols-4 gap-3">
+                                {product.images.slice(0, 4).map((img: any, idx: number) => (
+                                    <button
+                                        key={idx}
+                                        className="relative aspect-square bg-white rounded-lg border hover:border-primary transition-colors"
+                                    >
+                                        {img.img?.src && (
+                                            <Image
+                                                src={img.img.src}
+                                                alt={`${product.name} ${idx + 1}`}
+                                                fill
+                                                sizes="(max-width: 1024px) 25vw, 100px"
+                                                className="object-contain p-2"
+                                            />
+                                        )}
+                                    </button>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+
+                    {/* Right - Product Info */}
+                    <div className="space-y-6">
+                        {/* Product Name */}
+                        <h1 className="text-3xl lg:text-4xl font-bold capitalize leading-tight">
+                            {product.name}
+                        </h1>
+
+                        {/* Category Badge */}
+                        <div className="flex items-center gap-3 flex-wrap">
+                            {product.animal_health_category && (
+                                <div className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300">
+                                    {product.animal_health_category.name}
+                                </div>
+                            )}
+                        </div>
+
+                        {/* Divider */}
+                        <div className="h-px bg-border" />
+
+                        {/* Overview */}
+                        <div>
+                            <h2 className="text-lg font-semibold mb-3 text-foreground">Overview</h2>
+                            <p className="text-muted-foreground leading-relaxed text-sm">
+                                {categorySlug ? (
+                                    <><span className="font-medium text-foreground">{capitalizeFirstLetter(product.name)}</span> is {overviewDesc[categorySlug] || `a ${product.animal_health_category?.name?.toLowerCase() || 'veterinary'} product for effective animal health management. It supports animal health when used according to recommended guidelines.`}</>
+                                ) : (
+                                    <><span className="font-medium text-foreground">{product.name}</span> is a professional animal health product for poultry and livestock management.</>
+                                )}
+                            </p>
+                        </div>
+
+                        {/* Active Ingredients Section */}
+                        <div>
+                            <h2 className="text-lg font-semibold mb-3 text-foreground">
+                                Active Ingredients
+                            </h2>
+                            {product.active_ingredients && product.active_ingredients.length > 0 ? (
+                                <div className="space-y-2">
+                                    {product.active_ingredients.map((ai: any, idx: number) => (
+                                        <div key={idx} className="flex items-center justify-between p-3 bg-gradient-to-r from-purple-50/50 to-transparent dark:from-purple-950/30 rounded-lg border border-purple-100 dark:border-purple-900 hover:border-purple-300 dark:hover:border-purple-700 transition-colors">
+                                            <div className="font-medium capitalize text-sm text-foreground">{ai.name}</div>
+                                            <div className="text-right">
+                                                <div className="font-bold text-purple-600 dark:text-purple-400">{ai.dosage_value} {ai.dosage_unit}</div>
+                                            </div>
+                                        </div>
+                                    ))}
+                                </div>
+                            ) : (
+                                <p className="text-sm text-muted-foreground p-4 bg-muted/30 rounded-lg border">No active ingredient information available.</p>
+                            )}
+                        </div>
+
+                        {/* AdSense Ad */}
+                        <AdSenseInFeed />
+
+                        {/* Used On & Targets Grid */}
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                            {/* Used On Section */}
+                            {product.dosage_rates && product.dosage_rates.length > 0 && (
+                                <div className="rounded-xl border bg-card p-4">
+                                    <h2 className="text-sm font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-400 mb-3">
+                                        Used On
+                                    </h2>
+                                    <ul className="space-y-1.5">
+                                        {Array.from(new Set(product.dosage_rates.map((rate: any) => rate.animal))).map((animal: any, idx: number) => (
+                                            <li key={idx} className="flex items-center gap-2 text-sm text-foreground">
+                                                <span className="h-1.5 w-1.5 rounded-full bg-amber-500 dark:bg-amber-400 flex-shrink-0" />
+                                                <span className="capitalize">{animal}</span>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                </div>
+                            )}
+
+                            {/* Target Diseases Section */}
+                            <div className="rounded-xl border bg-card p-4">
+                                <h2 className="text-sm font-semibold uppercase tracking-wide text-green-700 dark:text-green-400 mb-3">
+                                    Target Diseases & Conditions
+                                </h2>
+                                {product.targets && product.targets.length > 0 ? (
+                                    <ul className="space-y-1.5">
+                                        {product.targets.map((target: any, idx: number) => (
+                                            <li key={idx} className="flex items-start gap-2 text-sm text-foreground">
+                                                <span className="h-1.5 w-1.5 rounded-full bg-green-500 dark:bg-green-400 flex-shrink-0 mt-1.5" />
+                                                <span>
+                                                    <span className="capitalize">{target.name}</span>
+                                                    {target.scientific_name && (
+                                                        <span className="text-xs text-muted-foreground italic ml-1">({target.scientific_name})</span>
+                                                    )}
+                                                </span>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                ) : (
+                                    <p className="text-sm text-muted-foreground">No target disease information available.</p>
+                                )}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                {/* Dosage Rates & Application Guide Section */}
+                {product.dosage_rates && product.dosage_rates.length > 0 && (
+                    <div className="mb-12">
+                        <h2 className="sticky top-16 z-10 text-2xl font-bold py-4 text-foreground bg-background">Dosage Rates & Application Guide</h2>
+                        <div className="overflow-x-auto">
+                            <table className="w-full border-collapse">
+                                <thead>
+                                    <tr className="bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-950/50 dark:to-indigo-950/50 border-b-2 border-blue-200 dark:border-blue-800">
+                                        <th className="text-left p-3 text-sm font-semibold text-blue-900 dark:text-blue-100">Animal</th>
+                                        <th className="text-left p-3 text-sm font-semibold text-blue-900 dark:text-blue-100">Target</th>
+                                        <th className="text-left p-3 text-sm font-semibold text-blue-900 dark:text-blue-100 min-w-[200px]">Dosage</th>
+                                        <th className="text-left p-3 text-sm font-semibold text-orange-700 dark:text-orange-300">Max Applications</th>
+                                        <th className="text-left p-3 text-sm font-semibold text-teal-700 dark:text-teal-300">Application Interval</th>
+                                        <th className="text-left p-3 text-sm font-semibold text-rose-700 dark:text-rose-300">Withdrawal Period</th>
+                                        <th className="text-left p-3 text-sm font-semibold text-blue-900 dark:text-blue-100">Remarks</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {(() => {
+                                        const grouped = new Map<string, any[]>()
+                                        const ungrouped: any[] = []
+
+                                        product.dosage_rates.forEach((rate: any) => {
+                                            if (rate.animal_group_id) {
+                                                const existing = grouped.get(rate.animal_group_id) || []
+                                                existing.push(rate)
+                                                grouped.set(rate.animal_group_id, existing)
+                                            } else {
+                                                ungrouped.push(rate)
+                                            }
+                                        })
+
+                                        const renderTargetGrid = (targets: string[]) => (
+                                            <div className="grid grid-cols-2 gap-x-4 gap-y-0.5">
+                                                {targets.map((t: string, i: number) => {
+                                                    const parenIdx = t.indexOf(" (")
+                                                    const mainName = parenIdx > -1 ? t.slice(0, parenIdx) : t
+                                                    const sciName = parenIdx > -1 ? t.slice(parenIdx) : ""
+                                                    return (
+                                                        <div key={i} className="text-sm flex items-start gap-1">
+                                                            <span className="h-1 w-1 mt-1.5 rounded-full bg-muted-foreground/50 flex-shrink-0" />
+                                                            <span>
+                                                                <span className="text-foreground">{mainName}</span>
+                                                                {sciName && <span className="text-muted-foreground text-xs">{sciName}</span>}
+                                                            </span>
+                                                        </div>
+                                                    )
+                                                })}
+                                            </div>
+                                        )
+
+                                        const renderEntryRows = (rate: any, rateKey: string, animalCell: React.ReactNode, targetCell: React.ReactNode) => {
+                                            const entries = rate.entries || []
+                                            const lastIdx = entries.length - 1
+                                            return entries.map((entry: any, entryIdx: number) => (
+                                                <tr key={`${rateKey}-${entryIdx}`} className={`hover:bg-muted/30 transition-colors ${entryIdx === 0 ? "border-t border-border" : ""} ${entryIdx === lastIdx ? "border-b border-border" : ""}`}>
+                                                    <td className="p-3 align-top">
+                                                        {entryIdx === 0 ? animalCell : null}
+                                                    </td>
+                                                    <td className="p-3 align-top">
+                                                        {entryIdx === 0 ? targetCell : null}
+                                                    </td>
+                                                    <td className="p-3 align-top">
+                                                        <div className="font-bold text-blue-600 dark:text-blue-400 text-base">
+                                                            {entry.dosage.value} {formatUnit(entry.dosage.unit)}
+                                                        </div>
+                                                        <div className="text-xs text-muted-foreground">per {entry.dosage.per}</div>
+                                                    </td>
+                                                    <td className="p-3 align-top">
+                                                        <div className="font-semibold text-orange-700 dark:text-orange-300">{entry.max_applications.max}</div>
+                                                        {entry.max_applications.note && entry.max_applications.note.trim() !== '' && (
+                                                            <div className="text-xs text-muted-foreground mt-1">{entry.max_applications.note}</div>
+                                                        )}
+                                                    </td>
+                                                    <td className="p-3 align-top">
+                                                        <div className="font-semibold text-teal-700 dark:text-teal-300 text-sm">{entry.application_interval}</div>
+                                                    </td>
+                                                    <td className="p-3 align-top">
+                                                        <div className="font-semibold text-rose-700 dark:text-rose-300 text-sm">{entry.withdrawal_period}</div>
+                                                    </td>
+                                                    <td className="p-3 align-top">
+                                                        {entry.remarks && entry.remarks.length > 0 ? (
+                                                            <ul className="space-y-1">
+                                                                {entry.remarks.map((remark: string, remarkIdx: number) => (
+                                                                    <li key={remarkIdx} className="text-xs text-foreground flex items-start gap-1.5">
+                                                                        <span className="h-1 w-1 mt-1.5 rounded-full bg-foreground/50 flex-shrink-0" />
+                                                                        <span className="flex-1">{remark}</span>
+                                                                    </li>
+                                                                ))}
+                                                            </ul>
+                                                        ) : (
+                                                            <span className="text-xs text-muted-foreground">—</span>
+                                                        )}
+                                                    </td>
+                                                </tr>
+                                            ))
+                                        }
+
+                                        return (
+                                            <>
+                                                {/* Grouped rates */}
+                                                {Array.from(grouped.entries()).map(([groupId, rates]) => {
+                                                    const firstRate = rates[0]
+                                                    const animalCell = (
+                                                        <div>
+                                                            <div className="font-semibold text-sm text-blue-700 dark:text-blue-300">
+                                                                {firstRate.animal_group}
+                                                            </div>
+                                                            <div className="mt-1 space-y-0.5">
+                                                                {rates.map((r: any, idx: number) => (
+                                                                    <div key={idx} className="text-xs text-muted-foreground capitalize flex items-start gap-1">
+                                                                        <span className="h-1 w-1 mt-1.5 rounded-full bg-blue-400 flex-shrink-0" />
+                                                                        <span className="flex-1">{r.animal}</span>
+                                                                    </div>
+                                                                ))}
+                                                            </div>
+                                                        </div>
+                                                    )
+                                                    const targetCell = renderTargetGrid(firstRate.targets || [])
+                                                    return renderEntryRows(firstRate, `group-${groupId}`, animalCell, targetCell)
+                                                })}
+
+                                                {/* Ungrouped rates */}
+                                                {(() => {
+                                                    const targetGrouped = new Map<string, any[]>()
+                                                    const targetOrder: string[] = []
+                                                    ungrouped.forEach((rate: any) => {
+                                                        const key = Array.isArray(rate.targets) ? rate.targets.slice().sort().join("|") : ""
+                                                        if (!targetGrouped.has(key)) {
+                                                            targetGrouped.set(key, [])
+                                                            targetOrder.push(key)
+                                                        }
+                                                        targetGrouped.get(key)!.push(rate)
+                                                    })
+                                                    return targetOrder.map((targetKey, tgIdx) => {
+                                                        const rates = targetGrouped.get(targetKey)!
+                                                        if (rates.length === 1) {
+                                                            const rate = rates[0]
+                                                            const animalCell = (
+                                                                <div>
+                                                                    <div className="font-semibold capitalize text-sm text-foreground">{rate.animal}</div>
+                                                                </div>
+                                                            )
+                                                            const targetCell = renderTargetGrid(rate.targets || [])
+                                                            return renderEntryRows(rate, `tg-${tgIdx}`, animalCell, targetCell)
+                                                        }
+                                                        return rates.map((rate: any, rateIdx: number) => {
+                                                            const animalCell = (
+                                                                <div>
+                                                                    <div className="font-semibold capitalize text-sm text-foreground">{rate.animal}</div>
+                                                                </div>
+                                                            )
+                                                            const targetCell = rateIdx === 0 ? renderTargetGrid(rate.targets || []) : null
+                                                            return renderEntryRows(rate, `tg-${tgIdx}-${rateIdx}`, animalCell, targetCell)
+                                                        })
+                                                    })
+                                                })()}
+                                            </>
+                                        )
+                                    })()}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                )}
+
+                {/* Product Labels Section */}
+                {(product.front_label?.img?.src || product.back_label?.img?.src) && (
+                    <div className="mb-12">
+                        <h2 className="text-2xl font-bold mb-6">Product Labels</h2>
+                        <div className="grid md:grid-cols-2 gap-6">
+                            {product.front_label?.img?.src && (
+                                <div className="space-y-3">
+                                    <h3 className="text-lg font-semibold">Front Label</h3>
+                                    <div className="relative aspect-[3/4] bg-white rounded-lg border overflow-hidden">
+                                        <Image
+                                            src={product.front_label.img.src}
+                                            alt={`${product.name} - Front Label`}
+                                            fill
+                                            sizes="(max-width: 768px) 100vw, 50vw"
+                                            className="object-contain p-4"
+                                        />
+                                    </div>
+                                </div>
+                            )}
+
+                            {product.back_label?.img?.src && (
+                                <div className="space-y-3">
+                                    <h3 className="text-lg font-semibold">Back Label</h3>
+                                    <div className="relative aspect-[3/4] bg-white rounded-lg border overflow-hidden">
+                                        <Image
+                                            src={product.back_label.img.src}
+                                            alt={`${product.name} - Back Label`}
+                                            fill
+                                            sizes="(max-width: 768px) 100vw, 50vw"
+                                            className="object-contain p-4"
+                                        />
+                                    </div>
+                                </div>
+                            )}
+                        </div>
+                    </div>
+                )}
+
+                {/* Safety Warning */}
+                <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-lg p-6">
+                    <div className="flex items-start gap-3">
+                        <AlertTriangle className="w-6 h-6 text-yellow-600 dark:text-yellow-500 flex-shrink-0" />
+                        <div>
+                            <h3 className="font-semibold mb-2 text-yellow-900 dark:text-yellow-100">Safety Information</h3>
+                            <p className="text-sm text-yellow-800 dark:text-yellow-200">
+                                Always read and follow label directions. Consult a veterinarian before administering animal health products.
+                                Observe withdrawal periods before slaughter or sale of animal products. Store in original containers in a cool, dry place away from children.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/apps/client-fnp/app/(landing)/animal-health-guides/[category]/layout.tsx
+++ b/apps/client-fnp/app/(landing)/animal-health-guides/[category]/layout.tsx
@@ -1,0 +1,60 @@
+import { Metadata } from 'next'
+
+interface LayoutProps {
+  children: React.ReactNode
+  params: Promise<{
+    category: string
+  }>
+}
+
+export async function generateMetadata({ params }: LayoutProps): Promise<Metadata> {
+  const { category } = await params
+
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://farmnport.com'
+  const url = `${baseUrl}/animal-health-guides/${category}`
+
+  const categoryName = category
+    .split('-')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+
+  const description = `Browse our comprehensive collection of ${categoryName.toLowerCase()} products for poultry and livestock. Find detailed information on active ingredients, dosage rates, and withdrawal periods.`
+
+  return {
+    title: `${categoryName} - Animal Health Guides | farmnport`,
+    description,
+    keywords: `${categoryName}, animal health, poultry, livestock, veterinary products, dosage rates, withdrawal periods, active ingredients`,
+    authors: [{ name: 'farmnport' }],
+    openGraph: {
+      title: `${categoryName} - Animal Health Guides`,
+      description,
+      url,
+      siteName: 'farmnport',
+      locale: 'en_US',
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary',
+      title: `${categoryName} - Animal Health Guides`,
+      description,
+    },
+    alternates: {
+      canonical: url,
+    },
+    robots: {
+      index: true,
+      follow: true,
+      googleBot: {
+        index: true,
+        follow: true,
+        'max-video-preview': -1,
+        'max-image-preview': 'large',
+        'max-snippet': -1,
+      },
+    },
+  }
+}
+
+export default function AnimalHealthCategoryLayout({ children }: LayoutProps) {
+  return <>{children}</>
+}

--- a/apps/client-fnp/app/(landing)/animal-health-guides/[category]/page.tsx
+++ b/apps/client-fnp/app/(landing)/animal-health-guides/[category]/page.tsx
@@ -1,0 +1,177 @@
+"use client"
+
+import { use } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { queryAnimalHealthProductsByCategory } from "@/lib/query"
+import { Button } from "@/components/ui/button"
+import { Beaker } from "lucide-react"
+import { AnimalHealthFilterSidebar } from "@/components/generic/animalHealthFilterSidebar"
+import { AnimalHealthCard } from "@/components/animalhealth/AnimalHealthCard"
+import { useQueryStates, parseAsArrayOf, parseAsString, parseAsInteger } from "nuqs"
+import Link from "next/link"
+
+interface CategoryPageProps {
+    params: Promise<{
+        category: string
+    }>
+}
+
+export default function AnimalHealthCategoryPage({ params }: CategoryPageProps) {
+    const { category } = use(params)
+
+    const [queryState, setQueryState] = useQueryStates({
+        brand: parseAsArrayOf(parseAsString),
+        target: parseAsArrayOf(parseAsString),
+        active_ingredient: parseAsArrayOf(parseAsString),
+        p: parseAsInteger.withDefault(1),
+    })
+
+    const { data: productsData, isLoading: productsLoading } = useQuery({
+        queryKey: ["animal-health-category", category, queryState.p, queryState.brand, queryState.target, queryState.active_ingredient],
+        queryFn: () => queryAnimalHealthProductsByCategory({
+            category,
+            p: queryState.p,
+            brand: queryState.brand || [],
+            target: queryState.target || [],
+            active_ingredient: queryState.active_ingredient || [],
+        }),
+        refetchOnWindowFocus: false,
+    })
+
+    const products = productsData?.data?.data || []
+    const totalPages = Math.ceil((productsData?.data?.total || 0) / 20)
+    const categoryName = products[0]?.animal_health_category?.name || category
+
+    const handlePageChange = (newPage: number) => {
+        setQueryState({ p: newPage })
+    }
+
+    return (
+        <div className="min-h-screen bg-gradient-to-b from-background to-muted/20">
+            {/* Breadcrumb */}
+            <div className="border-b bg-muted/30">
+                <div className="max-w-7xl mx-auto px-6 lg:px-8 py-4">
+                    <nav className="flex text-sm text-muted-foreground">
+                        <Link href="/" className="hover:text-foreground">Home</Link>
+                        <span className="mx-2">/</span>
+                        <Link href="/animal-health-guides/all" className="hover:text-foreground">Guides</Link>
+                        <span className="mx-2">/</span>
+                        <span className="text-foreground capitalize">{categoryName}</span>
+                    </nav>
+                </div>
+            </div>
+
+            <div className="mx-auto max-w-7xl px-6 lg:px-8 py-12">
+                {/* Header */}
+                <div className="mb-8">
+                    <h1 className="text-4xl font-bold tracking-tight font-heading mb-4 capitalize">
+                        {categoryName}
+                    </h1>
+                    <p className="text-lg text-muted-foreground">
+                        Browse our collection of {typeof categoryName === 'string' ? categoryName.toLowerCase() : category} products for poultry and livestock
+                    </p>
+                </div>
+
+                <div className="flex flex-col lg:flex-row gap-8">
+                    {/* Sidebar Filters */}
+                    <aside className="w-full lg:w-64 flex-shrink-0">
+                        <AnimalHealthFilterSidebar />
+                    </aside>
+
+                    {/* Main Content */}
+                    <main className="flex-1">
+                        {productsLoading ? (
+                            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+                                {[...Array(6)].map((_, i) => (
+                                    <div key={i} className="animate-pulse">
+                                        <div className="bg-card border border-border rounded-lg overflow-hidden">
+                                            <div className="aspect-square bg-muted" />
+                                            <div className="p-4 space-y-3 border-t">
+                                                <div className="h-3 bg-muted rounded w-1/3" />
+                                                <div className="h-4 bg-muted rounded w-4/5" />
+                                                <div className="h-4 bg-muted rounded w-3/5" />
+                                                <div className="flex gap-4 pt-2 border-t">
+                                                    <div className="h-3 bg-muted rounded w-16" />
+                                                    <div className="h-3 bg-muted rounded w-16" />
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        ) : products.length === 0 ? (
+                            <div className="text-center py-12">
+                                <Beaker className="w-16 h-16 mx-auto text-muted-foreground mb-4" />
+                                <p className="text-muted-foreground mb-4">No {typeof categoryName === 'string' ? categoryName.toLowerCase() : ''} products found matching your filters.</p>
+                                <Link href="/animal-health-guides/all">
+                                    <Button variant="outline">View All Animal Health Products</Button>
+                                </Link>
+                            </div>
+                        ) : (
+                            <>
+                                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+                                    {products.map((product: any) => (
+                                        <AnimalHealthCard
+                                            key={product.id}
+                                            product={product}
+                                        />
+                                    ))}
+                                </div>
+
+                                {/* Pagination */}
+                                {totalPages > 1 && (
+                                    <div className="mt-8 flex justify-center gap-1">
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            onClick={() => handlePageChange(Math.max(1, queryState.p - 1))}
+                                            disabled={queryState.p === 1}
+                                        >
+                                            Previous
+                                        </Button>
+                                        {Array.from({ length: totalPages }, (_, i) => i + 1)
+                                            .filter(pageNum => {
+                                                return (
+                                                    pageNum === 1 ||
+                                                    pageNum === totalPages ||
+                                                    (pageNum >= queryState.p - 2 && pageNum <= queryState.p + 2)
+                                                )
+                                            })
+                                            .map((pageNum, idx, arr) => {
+                                                const prevPageNum = arr[idx - 1]
+                                                const showEllipsis = prevPageNum && pageNum - prevPageNum > 1
+
+                                                return (
+                                                    <div key={pageNum} className="flex items-center gap-1">
+                                                        {showEllipsis && (
+                                                            <span className="px-2 text-muted-foreground">...</span>
+                                                        )}
+                                                        <Button
+                                                            variant={queryState.p === pageNum ? "default" : "outline"}
+                                                            size="sm"
+                                                            onClick={() => handlePageChange(pageNum)}
+                                                            className="min-w-[40px]"
+                                                        >
+                                                            {pageNum}
+                                                        </Button>
+                                                    </div>
+                                                )
+                                            })}
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            onClick={() => handlePageChange(queryState.p + 1)}
+                                            disabled={queryState.p >= totalPages}
+                                        >
+                                            Next
+                                        </Button>
+                                    </div>
+                                )}
+                            </>
+                        )}
+                    </main>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/apps/client-fnp/app/(landing)/animal-health-guides/all/layout.tsx
+++ b/apps/client-fnp/app/(landing)/animal-health-guides/all/layout.tsx
@@ -1,0 +1,39 @@
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'All Animal Health Products - Complete Product Catalog | farmnport',
+  description: 'Browse our complete catalog of animal health products. Filter by brand, target disease, active ingredient, and animal type. Find detailed dosage rates and withdrawal periods.',
+  keywords: 'animal health products catalog, poultry vaccines, livestock antibiotics, veterinary supplements, dosage rates, withdrawal periods, Newcastle disease, coccidiosis',
+  authors: [{ name: 'farmnport' }],
+  openGraph: {
+    title: 'All Animal Health Products - Complete Product Catalog',
+    description: 'Browse our complete catalog of animal health products with detailed information on active ingredients, dosage rates, and withdrawal periods.',
+    url: `${process.env.NEXT_PUBLIC_BASE_URL || 'https://farmnport.com'}/animal-health-guides/all`,
+    siteName: 'farmnport',
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'All Animal Health Products - Complete Catalog',
+    description: 'Browse our complete catalog of animal health products with detailed guides.',
+  },
+  alternates: {
+    canonical: `${process.env.NEXT_PUBLIC_BASE_URL || 'https://farmnport.com'}/animal-health-guides/all`,
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-video-preview': -1,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+    },
+  },
+}
+
+export default function AllAnimalHealthLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/apps/client-fnp/app/(landing)/animal-health-guides/all/page.tsx
+++ b/apps/client-fnp/app/(landing)/animal-health-guides/all/page.tsx
@@ -1,0 +1,151 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+import { queryAllAnimalHealthProducts } from "@/lib/query"
+import { Button } from "@/components/ui/button"
+import { Beaker } from "lucide-react"
+import { AnimalHealthFilterSidebar } from "@/components/generic/animalHealthFilterSidebar"
+import { AnimalHealthCard } from "@/components/animalhealth/AnimalHealthCard"
+import { useQueryStates, parseAsArrayOf, parseAsString, parseAsInteger } from "nuqs"
+
+export default function AllAnimalHealthPage() {
+    const [queryState, setQueryState] = useQueryStates({
+        brand: parseAsArrayOf(parseAsString),
+        target: parseAsArrayOf(parseAsString),
+        active_ingredient: parseAsArrayOf(parseAsString),
+        used_on: parseAsArrayOf(parseAsString),
+        p: parseAsInteger.withDefault(1),
+    })
+
+    const { data: productsData, isLoading: productsLoading } = useQuery({
+        queryKey: ["animal-health-all", queryState.p, queryState.brand, queryState.target, queryState.active_ingredient, queryState.used_on],
+        queryFn: () => queryAllAnimalHealthProducts({
+            p: queryState.p,
+            brand: queryState.brand || [],
+            target: queryState.target || [],
+            active_ingredient: queryState.active_ingredient || [],
+            used_on: queryState.used_on || [],
+        }),
+        refetchOnWindowFocus: false,
+    })
+
+    const products = productsData?.data?.data || []
+    const totalPages = Math.ceil((productsData?.data?.total || 0) / 20)
+
+    const handlePageChange = (newPage: number) => {
+        setQueryState({ p: newPage })
+    }
+
+    return (
+        <div className="min-h-screen bg-gradient-to-b from-background to-muted/20">
+            <div className="mx-auto max-w-7xl px-6 lg:px-8 py-12">
+                {/* Header */}
+                <div className="mb-8">
+                    <h1 className="text-4xl font-bold tracking-tight font-heading mb-4">
+                        All Animal Health Products
+                    </h1>
+                    <p className="text-lg text-muted-foreground">
+                        Browse our complete collection of animal health products for poultry and livestock
+                    </p>
+                </div>
+
+                <div className="flex flex-col lg:flex-row gap-8">
+                    {/* Sidebar Filters */}
+                    <aside className="w-full lg:w-64 flex-shrink-0">
+                        <AnimalHealthFilterSidebar />
+                    </aside>
+
+                    {/* Main Content */}
+                    <main className="flex-1">
+                        {productsLoading ? (
+                            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+                                {[...Array(6)].map((_, i) => (
+                                    <div key={i} className="animate-pulse">
+                                        <div className="bg-card border border-border rounded-lg overflow-hidden">
+                                            <div className="aspect-square bg-muted" />
+                                            <div className="p-4 space-y-3 border-t">
+                                                <div className="h-3 bg-muted rounded w-1/3" />
+                                                <div className="h-4 bg-muted rounded w-4/5" />
+                                                <div className="h-4 bg-muted rounded w-3/5" />
+                                                <div className="flex gap-4 pt-2 border-t">
+                                                    <div className="h-3 bg-muted rounded w-16" />
+                                                    <div className="h-3 bg-muted rounded w-16" />
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        ) : products.length === 0 ? (
+                            <div className="text-center py-12">
+                                <Beaker className="w-16 h-16 mx-auto text-muted-foreground mb-4" />
+                                <p className="text-muted-foreground">No animal health products found matching your filters.</p>
+                            </div>
+                        ) : (
+                            <>
+                                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+                                    {products.map((product: any) => (
+                                        <AnimalHealthCard
+                                            key={product.id}
+                                            product={product}
+                                        />
+                                    ))}
+                                </div>
+
+                                {/* Pagination */}
+                                {totalPages > 1 && (
+                                    <div className="mt-8 flex justify-center gap-1">
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            onClick={() => handlePageChange(Math.max(1, queryState.p - 1))}
+                                            disabled={queryState.p === 1}
+                                        >
+                                            Previous
+                                        </Button>
+                                        {Array.from({ length: totalPages }, (_, i) => i + 1)
+                                            .filter(pageNum => {
+                                                return (
+                                                    pageNum === 1 ||
+                                                    pageNum === totalPages ||
+                                                    (pageNum >= queryState.p - 2 && pageNum <= queryState.p + 2)
+                                                )
+                                            })
+                                            .map((pageNum, idx, arr) => {
+                                                const prevPageNum = arr[idx - 1]
+                                                const showEllipsis = prevPageNum && pageNum - prevPageNum > 1
+
+                                                return (
+                                                    <div key={pageNum} className="flex items-center gap-1">
+                                                        {showEllipsis && (
+                                                            <span className="px-2 text-muted-foreground">...</span>
+                                                        )}
+                                                        <Button
+                                                            variant={queryState.p === pageNum ? "default" : "outline"}
+                                                            size="sm"
+                                                            onClick={() => handlePageChange(pageNum)}
+                                                            className="min-w-[40px]"
+                                                        >
+                                                            {pageNum}
+                                                        </Button>
+                                                    </div>
+                                                )
+                                            })}
+                                        <Button
+                                            variant="outline"
+                                            size="sm"
+                                            onClick={() => handlePageChange(queryState.p + 1)}
+                                            disabled={queryState.p >= totalPages}
+                                        >
+                                            Next
+                                        </Button>
+                                    </div>
+                                )}
+                            </>
+                        )}
+                    </main>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/apps/client-fnp/app/(landing)/animal-health-guides/layout.tsx
+++ b/apps/client-fnp/app/(landing)/animal-health-guides/layout.tsx
@@ -1,0 +1,39 @@
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Animal Health Guides - Vaccines, Antibiotics & Supplements for Poultry | farmnport',
+  description: 'Comprehensive animal health product guides covering vaccines, antibiotics, supplements, and more for poultry and livestock. Find dosage rates, active ingredients, and withdrawal periods.',
+  keywords: 'animal health guides, poultry vaccines, livestock antibiotics, veterinary products, dosage rates, withdrawal periods, active ingredients, Newcastle disease vaccine, coccidiosis treatment',
+  authors: [{ name: 'farmnport' }],
+  openGraph: {
+    title: 'Animal Health Guides - Vaccines, Antibiotics & Supplements for Poultry',
+    description: 'Comprehensive animal health product guides covering vaccines, antibiotics, supplements, and more. Find dosage rates, active ingredients, and withdrawal periods.',
+    url: `${process.env.NEXT_PUBLIC_BASE_URL || 'https://farmnport.com'}/animal-health-guides`,
+    siteName: 'farmnport',
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Animal Health Guides - Complete Veterinary Product Resource',
+    description: 'Comprehensive guides for vaccines, antibiotics, supplements, and animal health products.',
+  },
+  alternates: {
+    canonical: `${process.env.NEXT_PUBLIC_BASE_URL || 'https://farmnport.com'}/animal-health-guides`,
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-video-preview': -1,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+    },
+  },
+}
+
+export default function AnimalHealthGuidesRootLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/apps/client-fnp/app/(landing)/animal-health-guides/page.tsx
+++ b/apps/client-fnp/app/(landing)/animal-health-guides/page.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { sendGTMEvent } from "@next/third-parties/google"
+import Link from "next/link"
+import { Pill, Syringe, Shield, Heart, Beaker, ArrowRight, Bug, Scissors, Bandage, Zap, Baby } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { useQuery } from "@tanstack/react-query"
+import { queryAnimalHealthCategories } from "@/lib/query"
+
+const categoryIcons: Record<string, any> = {
+    "vaccines": Syringe,
+    "antibiotics": Pill,
+    "nutrition-supplements": Heart,
+    "anti-protozoa": Shield,
+    "biosecurity-disinfectants": Shield,
+    "tick-flea-control": Bug,
+    "worm-fluke-control": Scissors,
+    "wound-remedies": Bandage,
+    "fly-control": Zap,
+    "stud-management": Baby,
+    "equipment": Beaker,
+}
+
+export default function AnimalHealthGuidesPage() {
+    const { data } = useQuery({
+        queryKey: ["animal-health-categories"],
+        queryFn: () => queryAnimalHealthCategories(),
+        refetchOnWindowFocus: false,
+    })
+
+    const categories = data?.data?.data || []
+
+    return (
+        <main className="bg-gradient-to-b from-background to-muted/20">
+            {/* Hero Section */}
+            <section className="py-12 lg:py-16 relative overflow-hidden">
+                <div className="mx-auto max-w-7xl px-6 lg:px-8">
+                    {/* Hero Content */}
+                    <div className="text-center max-w-3xl mx-auto mb-12">
+                        <h1 className="text-4xl font-bold tracking-tight sm:text-5xl font-heading mb-4">
+                            Animal Health Product Guides
+                        </h1>
+                        <p className="text-lg text-muted-foreground leading-7 mb-6">
+                            Find dosage rates, active ingredients, and withdrawal periods for vaccines, antibiotics, and supplements. No more squinting at bottle labels.
+                        </p>
+                        <Button
+                            size="lg"
+                            asChild
+                            onClick={() => sendGTMEvent({ event: "click", value: "ReadAnimalHealthGuides" })}
+                            className="text-base px-6 py-5 h-auto font-semibold shadow-lg hover:shadow-xl transition-all group"
+                        >
+                            <Link href="/animal-health-guides/all" className="flex items-center gap-2">
+                                Browse All Guides
+                                <ArrowRight className="h-5 w-5 transition-transform group-hover:translate-x-1" />
+                            </Link>
+                        </Button>
+                    </div>
+
+                    {/* Categories Grid */}
+                    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+                        {categories.map((category: any) => {
+                            const Icon = categoryIcons[category.slug] || Pill
+                            return (
+                                <Link
+                                    key={category.slug}
+                                    href={`/animal-health-guides/${category.slug}`}
+                                    className="flex flex-col items-center gap-3 p-5 rounded-xl bg-card border border-border hover:border-primary hover:bg-accent transition-all group"
+                                >
+                                    <div className="flex items-center justify-center w-12 h-12 rounded-lg bg-primary/10 group-hover:bg-primary/20 transition-colors">
+                                        <Icon className="w-5 h-5 text-primary" strokeWidth={2} />
+                                    </div>
+                                    <span className="text-sm font-medium text-center text-foreground group-hover:text-primary transition-colors">
+                                        {category.name}
+                                    </span>
+                                </Link>
+                            )
+                        })}
+                    </div>
+                </div>
+            </section>
+        </main>
+    )
+}

--- a/apps/client-fnp/app/(landing)/prices/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/prices/[slug]/page.tsx
@@ -6,7 +6,8 @@ import { formatDate, capitalizeFirstLetter } from "@/lib/utilities"
 import { AppURL } from "@/lib/schemas"
 import axios from "axios"
 import { notFound } from "next/navigation"
-import { Calendar, Building2, CheckCircle2 } from "lucide-react"
+import Link from "next/link"
+import { Calendar, Building2, CheckCircle2, ArrowLeft } from "lucide-react"
 import { auth } from "@/auth"
 import type { Metadata } from "next"
 
@@ -113,6 +114,14 @@ export default async function PriceDetailsPage({ params }: PriceDetailsPageProps
       />
 
       <div className="mx-auto max-w-7xl px-6 lg:px-8 py-12 min-h-[70lvh]">
+        <Link
+          href="/prices/lwt"
+          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Back to LWT Prices
+        </Link>
+
         <div className="mb-8">
           <div className="flex items-center gap-3 mb-4">
             <h1 className="text-4xl font-bold font-heading">

--- a/apps/client-fnp/app/(landing)/prices/cdm/[slug]/layout.tsx
+++ b/apps/client-fnp/app/(landing)/prices/cdm/[slug]/layout.tsx
@@ -1,0 +1,3 @@
+export default function CdmPriceDetailLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/apps/client-fnp/app/(landing)/prices/cdm/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/prices/cdm/[slug]/page.tsx
@@ -1,0 +1,157 @@
+import { CdmPriceCard } from "@/components/structures/cdm-price-card"
+import { RelatedCdmPricesSidebar } from "@/components/structures/related-cdm-prices-sidebar"
+import { formatDate, capitalizeFirstLetter, slug as slugify } from "@/lib/utilities"
+import { AppURL } from "@/lib/schemas"
+import axios from "axios"
+import { notFound } from "next/navigation"
+import Link from "next/link"
+import { Calendar, ArrowLeft } from "lucide-react"
+import type { Metadata } from "next"
+
+interface CdmDetailPageProps {
+  params: Promise<{
+    slug: string
+  }>
+}
+
+async function getCdmPriceBySlug(slug: string) {
+  try {
+    const baseURL = process.env.NEXT_PUBLIC_BASE_URL || process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3744"
+    const response = await axios.get(`${baseURL}/v1/cdmprices/all?p=1&limit=100`)
+    const prices = response.data?.data || []
+
+    const price = prices.find((p: any) => {
+      const pDate = new Date(p.effectiveDate).toISOString().split('T')[0]
+      const pSlug = `${p.client_name.toLowerCase().replace(/\s+/g, '-')}-${pDate}`
+      return pSlug === slug
+    })
+
+    return { price: price || null, allPrices: prices }
+  } catch {
+    return { price: null, allPrices: [] }
+  }
+}
+
+export async function generateMetadata({ params }: CdmDetailPageProps): Promise<Metadata> {
+  const { slug } = await params
+  const { price } = await getCdmPriceBySlug(slug)
+
+  if (!price) {
+    return { title: 'CDM Price List Not Found | farmnport.com' }
+  }
+
+  const name = capitalizeFirstLetter(price.client_name)
+  const date = formatDate(price.effectiveDate)
+
+  return {
+    alternates: {
+      canonical: `${AppURL}/prices/cdm/${slug}`,
+    },
+    title: `${name} CDM Cattle Prices — ${date} | farmnport.com`,
+    description: `${name} Cold Dress Mass cattle pricing effective ${date}. Carcass grades and liveweight prices per kg in USD and ZiG.`,
+    openGraph: {
+      title: `${name} — CDM Cattle Price List`,
+      description: `${name} Cold Dress Mass cattle pricing effective ${date}. View carcass grades and liveweight prices on Farmnport.`,
+      url: `${AppURL}/prices/cdm/${slug}`,
+      siteName: 'farmnport',
+      type: 'website',
+    },
+  }
+}
+
+export default async function CdmPriceDetailPage({ params }: CdmDetailPageProps) {
+  const { slug } = await params
+  const { price, allPrices } = await getCdmPriceBySlug(slug)
+
+  if (!price) {
+    notFound()
+  }
+
+  const formattedDate = formatDate(price.effectiveDate)
+
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    "name": `${price.client_name} CDM Price List`,
+    "description": `Cold Dress Mass cattle pricing from ${price.client_name} effective ${formattedDate}`,
+    "datePublished": price.effectiveDate,
+    "publisher": {
+      "@type": "Organization",
+      "name": price.client_name
+    },
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "item": { "@type": "Product", "name": "Commercial Grade CDM", "offers": { "@type": "Offer", "price": price.carcass_grades.commercial.delivered_usd, "priceCurrency": "USD" } } },
+      { "@type": "ListItem", "position": 2, "item": { "@type": "Product", "name": "Economy Grade CDM", "offers": { "@type": "Offer", "price": price.carcass_grades.economy.delivered_usd, "priceCurrency": "USD" } } },
+      { "@type": "ListItem", "position": 3, "item": { "@type": "Product", "name": "Manufacturing Grade CDM", "offers": { "@type": "Offer", "price": price.carcass_grades.manufacturing.delivered_usd, "priceCurrency": "USD" } } },
+    ]
+  }
+
+  return (
+    <main>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+
+      <div className="mx-auto max-w-7xl px-6 lg:px-8 py-12 min-h-[70lvh]">
+        {/* Back link */}
+        <Link
+          href="/prices/cdm"
+          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Back to CDM Prices
+        </Link>
+
+        {/* Header */}
+        <div className="mb-8">
+          <div className="flex items-center gap-3 mb-4">
+            <h1 className="text-3xl font-bold font-heading">
+              {capitalizeFirstLetter(price.client_name)}
+            </h1>
+            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider bg-muted px-2.5 py-1 rounded">
+              CDM
+            </span>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-4 text-sm">
+            <div className="flex items-center gap-2">
+              <Calendar className="h-4 w-4 text-muted-foreground" />
+              <span className="text-muted-foreground">Effective:</span>
+              <span className="font-medium text-foreground">{formattedDate}</span>
+            </div>
+
+            {price.exchange_rate > 0 && (
+              <div className="text-muted-foreground">
+                1 USD = {price.exchange_rate} ZiG
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="lg:flex lg:items-start lg:gap-8">
+          <div className="flex-1">
+            <CdmPriceCard price={price} hideHeader />
+          </div>
+
+          <aside className="hidden lg:block lg:w-72 lg:flex-shrink-0 sticky top-20 self-start">
+            <RelatedCdmPricesSidebar
+              currentClientName={price.client_name}
+              currentPriceId={price.id}
+              allPrices={allPrices}
+            />
+          </aside>
+        </div>
+
+        {/* Mobile: Related prices at bottom */}
+        <div className="mt-8 lg:hidden">
+          <RelatedCdmPricesSidebar
+            currentClientName={price.client_name}
+            currentPriceId={price.id}
+            allPrices={allPrices}
+          />
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/apps/client-fnp/app/(landing)/prices/cdm/page.tsx
+++ b/apps/client-fnp/app/(landing)/prices/cdm/page.tsx
@@ -1,0 +1,53 @@
+import { CdmPriceCardsView } from "@/components/structures/cdm-price-cards-view"
+import { ActionsSidebar } from "@/components/generic/actions-sidebar"
+import Link from "next/link"
+import { ChevronLeft } from "lucide-react"
+
+export const metadata = {
+  title: 'Cold Dress Mass Cattle Prices (CDM) – Carcass & Liveweight Rates | farmnport.com',
+  description: 'Browse current cold dress mass cattle prices from abattoirs across Zimbabwe. Commercial, economy and manufacturing carcass grades, ex leakage, in USD and ZiG.',
+  alternates: {
+    canonical: '/prices/cdm',
+  },
+  openGraph: {
+    title: 'Cold Dress Mass Cattle Prices (CDM) – Carcass & Liveweight Rates',
+    description: 'Browse current cold dress mass cattle prices from abattoirs across Zimbabwe. Carcass grades and liveweight rates.',
+    siteName: 'farmnport',
+    type: 'website',
+  },
+}
+
+export default async function CdmPricesPage() {
+  return (
+    <main>
+      <div className="mx-auto max-w-7xl px-6 lg:px-8 min-h-[70lvh]">
+        <div className="pt-6 pb-4">
+          <Link
+            href="/prices"
+            className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ChevronLeft className="h-3.5 w-3.5" />
+            All prices
+          </Link>
+        </div>
+
+        <h1 className="text-3xl font-bold font-heading pb-2">
+          Cold Dress Mass Cattle Prices
+        </h1>
+        <p className="text-muted-foreground mb-6">
+          Carcass grade pricing and liveweight rates from abattoirs, ex leakage, in USD and ZiG.
+        </p>
+
+        <div className="lg:flex lg:space-x-10">
+          <div className="lg:flex-1">
+            <CdmPriceCardsView />
+          </div>
+
+          <div className="hidden lg:block lg:w-56 shrink-0 relative">
+            <ActionsSidebar type="buyers" />
+          </div>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/apps/client-fnp/app/(landing)/prices/layout.tsx
+++ b/apps/client-fnp/app/(landing)/prices/layout.tsx
@@ -1,25 +1,30 @@
 import { Metadata } from 'next'
 
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://farmnport.com'
+
 export const metadata: Metadata = {
-  title: 'Farm Produce Prices | farmnport',
-  description: 'Browse current farm produce price lists from verified buyers and suppliers. Real-time market prices for fresh fruits, vegetables, and agricultural products.',
-  keywords: 'farm produce prices, market prices, agricultural prices, fresh produce, buyer prices, supplier prices, farm products',
+  title: {
+    template: '%s | farmnport',
+    default: 'Agricultural Market Prices Zimbabwe | farmnport',
+  },
+  description: 'Compare current agricultural prices from verified buyers across Zimbabwe. Livestock, cattle, grains and more — updated weekly in USD and ZiG.',
+  keywords: 'agricultural prices zimbabwe, cattle prices, liveweight prices, CDM prices, cold dress mass, beef prices, livestock market, farm produce prices, abattoir rates',
   authors: [{ name: 'farmnport' }],
   openGraph: {
-    title: 'Farm Produce Prices',
-    description: 'Browse current farm produce price lists from verified buyers and suppliers. Real-time market prices for fresh fruits, vegetables, and agricultural products.',
-    url: `${process.env.NEXT_PUBLIC_BASE_URL || 'https://farmnport.com'}/prices`,
+    title: 'Agricultural Market Prices Zimbabwe',
+    description: 'Compare current agricultural prices from verified buyers across Zimbabwe.',
+    url: `${baseUrl}/prices`,
     siteName: 'farmnport',
     locale: 'en_US',
     type: 'website',
   },
   twitter: {
     card: 'summary',
-    title: 'Farm Produce Prices',
-    description: 'Browse current farm produce price lists from verified buyers and suppliers.',
+    title: 'Agricultural Market Prices Zimbabwe',
+    description: 'Compare current agricultural prices from verified buyers across Zimbabwe.',
   },
   alternates: {
-    canonical: `${process.env.NEXT_PUBLIC_BASE_URL || 'https://farmnport.com'}/prices`,
+    canonical: `${baseUrl}/prices`,
   },
   robots: {
     index: true,

--- a/apps/client-fnp/app/(landing)/prices/lwt/page.tsx
+++ b/apps/client-fnp/app/(landing)/prices/lwt/page.tsx
@@ -1,0 +1,61 @@
+import { FilterSidebar } from "@/components/generic/filterSidebar"
+import { PriceCardsView } from "@/components/structures/price-cards-view"
+import { ActionsSidebar } from "@/components/generic/actions-sidebar"
+import Link from "next/link"
+import { ChevronLeft } from "lucide-react"
+
+export const metadata = {
+  title: 'Liveweight Cattle Prices (LWT) – Per Kg Delivered Rates | farmnport.com',
+  description: 'Browse current liveweight cattle prices per kg delivered across Zimbabwe. Prices by teeth category (Milk Teeth, 2T, 4T, 6T) and weight range in USD and ZiG.',
+  alternates: {
+    canonical: '/prices/lwt',
+  },
+  openGraph: {
+    title: 'Liveweight Cattle Prices (LWT) – Per Kg Delivered Rates',
+    description: 'Browse current liveweight cattle prices per kg delivered across Zimbabwe. Prices by teeth category and weight range.',
+    siteName: 'farmnport',
+    type: 'website',
+  },
+}
+
+export default async function LwtPricesPage() {
+  return (
+    <main>
+      <div className="mx-auto max-w-7xl px-6 lg:px-8 min-h-[70lvh]">
+        <div className="pt-6 pb-4">
+          <Link
+            href="/prices"
+            className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ChevronLeft className="h-3.5 w-3.5" />
+            All prices
+          </Link>
+        </div>
+
+        <h1 className="text-3xl font-bold font-heading pb-2">
+          Liveweight Cattle Prices
+        </h1>
+        <p className="text-muted-foreground mb-6">
+          Per kg delivered prices for cattle by teeth category and weight range, in USD and ZiG.
+        </p>
+
+        <div className="lg:flex lg:space-x-10">
+          <div className="hidden lg:block lg:w-64 relative">
+            <FilterSidebar />
+          </div>
+
+          <div className="lg:flex-1">
+            <div className="lg:hidden mb-6">
+              <FilterSidebar />
+            </div>
+            <PriceCardsView />
+          </div>
+
+          <div className="hidden lg:block lg:w-56 shrink-0 relative">
+            <ActionsSidebar type="buyers" />
+          </div>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/apps/client-fnp/app/(landing)/prices/page.tsx
+++ b/apps/client-fnp/app/(landing)/prices/page.tsx
@@ -1,55 +1,154 @@
-import { FilterSidebar } from "@/components/generic/filterSidebar"
 import { PriceCardsView } from "@/components/structures/price-cards-view"
 import { CdmPriceCardsView } from "@/components/structures/cdm-price-cards-view"
-import { ActionsSidebar } from "@/components/generic/actions-sidebar"
+import Link from "next/link"
+import { ArrowRight, Scale, Beef, TrendingUp, RefreshCw, ShieldCheck } from "lucide-react"
 
 export const metadata = {
-  title: 'Agricultural Produce Prices – Market Rates | farmnport.com',
-  description: 'Stay updated with current market prices for agricultural produce. Trusted by farmers and bulk buyers for pricing on crops, poultry, and livestock across Zimbabwe.',
+  title: 'Agricultural Market Prices Zimbabwe – Livestock, Produce & More | farmnport.com',
+  description: 'Compare current agricultural prices from verified buyers across Zimbabwe. Liveweight cattle, cold dress mass, beef, lamb, mutton, goat, chicken, pork — updated weekly in USD and ZiG.',
   alternates: {
     canonical: '/prices',
   },
   openGraph: {
-    title: 'Agricultural Produce Prices – Market Rates',
-    description: 'Stay updated with current market prices for agricultural produce across Zimbabwe.',
+    title: 'Agricultural Market Prices Zimbabwe',
+    description: 'Compare current agricultural prices from verified buyers across Zimbabwe. Updated weekly in USD and ZiG.',
     siteName: 'farmnport',
     type: 'website',
   },
 }
 
+const categories = [
+  {
+    title: "Liveweight Prices",
+    tag: "LWT",
+    description: "Per kg delivered rates for cattle, sheep, goats and pigs — by grade, teeth category and weight range.",
+    href: "/prices/lwt",
+    icon: Scale,
+    gradient: "from-emerald-500 to-teal-600",
+    iconBg: "bg-emerald-500",
+  },
+  {
+    title: "Cold Dress Mass",
+    tag: "CDM",
+    description: "Carcass grade pricing from abattoirs — commercial, economy and manufacturing grades, ex leakage.",
+    href: "/prices/cdm",
+    icon: Beef,
+    gradient: "from-blue-500 to-indigo-600",
+    iconBg: "bg-blue-500",
+  },
+]
+
 export default async function PricesPage() {
   return (
     <main>
-      <div className="mx-auto max-w-7xl px-6 lg:px-8 min-h-[70lvh]">
-        <h1 className="text-3xl font-bold font-heading pt-8 pb-4">
-          Producer Price Lists
-        </h1>
-        <p className="text-muted-foreground mb-6">
-          Browse and compare current market prices from verified buyers and producers across Zimbabwe.
-        </p>
-
-        <div className="lg:flex lg:space-x-10">
-          <div className="hidden lg:block lg:w-64 relative">
-            <FilterSidebar />
-          </div>
-
-          <div className="lg:flex-1">
-            {/* Mobile filter button */}
-            <div className="lg:hidden mb-6">
-              <FilterSidebar />
-            </div>
-
-            <PriceCardsView />
-            <div className="mt-10">
-              <CdmPriceCardsView />
-            </div>
-          </div>
-
-          <div className="hidden lg:block lg:w-56 shrink-0 relative">
-            <ActionsSidebar type="buyers" />
+      {/* Hero */}
+      <section className="border-b">
+        <div className="mx-auto max-w-7xl px-6 lg:px-8 pt-10 pb-8">
+          <p className="text-xs font-semibold text-primary tracking-wide uppercase">Market Intelligence</p>
+          <h1 className="mt-1 text-3xl font-bold font-heading tracking-tight">
+            Market Prices
+          </h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Transparent pricing from verified buyers across Zimbabwe.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-4 text-xs text-muted-foreground">
+            {[
+              { icon: RefreshCw, text: "Updated weekly" },
+              { icon: ShieldCheck, text: "Verified sources" },
+              { icon: TrendingUp, text: "USD & ZiG rates" },
+            ].map(({ icon: Icon, text }) => (
+              <div key={text} className="flex items-center gap-1.5">
+                <Icon className="h-3 w-3 text-primary" />
+                <span className="font-medium">{text}</span>
+              </div>
+            ))}
           </div>
         </div>
-      </div>
+      </section>
+
+      {/* Categories */}
+      <section className="mx-auto max-w-7xl px-6 lg:px-8 py-8">
+        <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-4">Browse by type</h2>
+
+        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {categories.map((cat) => {
+            const Icon = cat.icon
+            return (
+              <Link key={cat.href} href={cat.href} className="group block">
+                <div className="relative h-full rounded-xl border bg-card p-4 hover:shadow-md hover:border-primary/20 transition-all">
+                  <div className="flex items-center gap-3 mb-2">
+                    <div className={`flex items-center justify-center h-8 w-8 rounded-lg bg-gradient-to-br ${cat.gradient}`}>
+                      <Icon className="h-4 w-4 text-white" />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <h3 className="text-sm font-bold font-heading group-hover:text-primary transition-colors">
+                        {cat.title}
+                      </h3>
+                      <span className="text-[9px] font-bold text-muted-foreground uppercase tracking-widest">
+                        {cat.tag}
+                      </span>
+                    </div>
+                    <ArrowRight className="h-3.5 w-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
+                  </div>
+                  <p className="text-xs text-muted-foreground leading-relaxed">
+                    {cat.description}
+                  </p>
+                </div>
+              </Link>
+            )
+          })}
+
+          <div className="relative h-full rounded-xl border border-dashed bg-muted/20 p-4 flex flex-col items-center justify-center text-center">
+            <p className="text-xs font-semibold text-muted-foreground">More coming soon</p>
+            <p className="mt-0.5 text-[11px] text-muted-foreground">
+              Grains, vegetables, dairy and more
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Latest Prices */}
+      <section className="border-t bg-muted/20">
+        <div className="mx-auto max-w-7xl px-6 lg:px-8 py-8">
+          <h2 className="text-lg font-bold font-heading mb-5">Latest Prices</h2>
+
+          <div className="grid md:grid-cols-2 gap-6">
+            <div>
+              <div className="flex items-center gap-2 mb-3">
+                <div className="flex items-center justify-center h-6 w-6 rounded-md bg-gradient-to-br from-emerald-500 to-teal-600">
+                  <Scale className="h-3 w-3 text-white" />
+                </div>
+                <h3 className="text-xs font-bold uppercase tracking-wide text-muted-foreground">Liveweight</h3>
+              </div>
+              <div className="rounded-lg border bg-card px-3">
+                <PriceCardsView limit={4} viewAllHref="/prices/lwt" />
+              </div>
+            </div>
+
+            <div>
+              <div className="flex items-center gap-2 mb-3">
+                <div className="flex items-center justify-center h-6 w-6 rounded-md bg-gradient-to-br from-blue-500 to-indigo-600">
+                  <Beef className="h-3 w-3 text-white" />
+                </div>
+                <h3 className="text-xs font-bold uppercase tracking-wide text-muted-foreground">Cold Dress Mass</h3>
+              </div>
+              <div className="rounded-lg border bg-card px-3">
+                <CdmPriceCardsView limit={4} viewAllHref="/prices/cdm" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* SEO Content */}
+      <section className="border-t">
+        <div className="mx-auto max-w-7xl px-6 lg:px-8 py-8">
+          <h2 className="text-base font-bold font-heading mb-2">About Agricultural Pricing in Zimbabwe</h2>
+          <p className="text-xs text-muted-foreground">
+            Transparent market prices from verified buyers and abattoirs across Zimbabwe.
+          </p>
+        </div>
+      </section>
     </main>
   )
 }

--- a/apps/client-fnp/app/(landing)/prices/page.tsx
+++ b/apps/client-fnp/app/(landing)/prices/page.tsx
@@ -1,5 +1,6 @@
 import { FilterSidebar } from "@/components/generic/filterSidebar"
 import { PriceCardsView } from "@/components/structures/price-cards-view"
+import { CdmPriceCardsView } from "@/components/structures/cdm-price-cards-view"
 import { ActionsSidebar } from "@/components/generic/actions-sidebar"
 
 export const metadata = {
@@ -39,6 +40,9 @@ export default async function PricesPage() {
             </div>
 
             <PriceCardsView />
+            <div className="mt-10">
+              <CdmPriceCardsView />
+            </div>
           </div>
 
           <div className="hidden lg:block lg:w-56 shrink-0 relative">

--- a/apps/client-fnp/app/(landing)/spray-programs/[slug]/layout.tsx
+++ b/apps/client-fnp/app/(landing)/spray-programs/[slug]/layout.tsx
@@ -1,0 +1,94 @@
+import { Metadata } from 'next'
+import { querySprayProgramBySlug } from '@/lib/query'
+
+interface LayoutProps {
+  children: React.ReactNode
+  params: Promise<{
+    slug: string
+  }>
+}
+
+export async function generateMetadata({ params }: LayoutProps): Promise<Metadata> {
+  const { slug } = await params
+
+  try {
+    const response = await querySprayProgramBySlug(slug)
+    const program = response?.data
+
+    if (!program) {
+      return {
+        title: 'Spray Program Not Found | farmnport',
+        description: 'The spray program you are looking for could not be found.',
+      }
+    }
+
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://farmnport.com'
+    const url = `${baseUrl}/spray-programs/${slug}`
+    const imageUrl = program.cover_image?.img?.src || `${baseUrl}/og-image.png`
+
+    const stageCount = program.stages?.length || 0
+    const description = `${program.name} spray program for ${program.farm_produce_name || 'crops'} with ${stageCount} growth stages. View recommended agrochemicals, dosages, and application methods for each stage.`
+
+    const keywords = [
+      program.name,
+      program.farm_produce_name,
+      'spray program',
+      'crop protection',
+      'agrochemical schedule',
+      ...(program.stages?.map((s: any) => s.name) || []),
+    ].filter(Boolean).join(', ')
+
+    return {
+      title: `${program.name} - Spray Program | farmnport`,
+      description,
+      keywords,
+      authors: [{ name: 'farmnport' }],
+      openGraph: {
+        title: `${program.name} - Spray Program`,
+        description,
+        url,
+        siteName: 'farmnport',
+        images: [
+          {
+            url: imageUrl,
+            width: 1200,
+            height: 630,
+            alt: program.name,
+          },
+        ],
+        locale: 'en_US',
+        type: 'website',
+      },
+      twitter: {
+        card: 'summary_large_image',
+        title: `${program.name} - Spray Program`,
+        description,
+        images: [imageUrl],
+      },
+      alternates: {
+        canonical: url,
+      },
+      robots: {
+        index: true,
+        follow: true,
+        googleBot: {
+          index: true,
+          follow: true,
+          'max-video-preview': -1,
+          'max-image-preview': 'large',
+          'max-snippet': -1,
+        },
+      },
+    }
+  } catch (error) {
+    console.error('Error generating metadata:', error)
+    return {
+      title: 'Spray Program | farmnport',
+      description: 'Crop spray program with stage-by-stage application schedules.',
+    }
+  }
+}
+
+export default function SprayProgramDetailLayout({ children }: LayoutProps) {
+  return <>{children}</>
+}

--- a/apps/client-fnp/app/(landing)/spray-programs/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/spray-programs/[slug]/page.tsx
@@ -1,0 +1,650 @@
+"use client"
+
+import { use, useEffect, useRef, useState } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { querySprayProgramBySlug } from "@/lib/query"
+import Image from "next/image"
+import Link from "next/link"
+import {
+    Sprout, AlertTriangle, ChevronRight, Droplets,
+    Bug, Leaf, TrendingUp, Beaker, Shield, X
+} from "lucide-react"
+import { capitalizeFirstLetter } from "@/lib/utilities"
+
+// Unified stage styling — clean, minimal
+const STAGE_STYLE = {
+    dot: "bg-green-600 dark:bg-green-500",
+    bg: "bg-muted/40",
+    text: "text-foreground",
+    border: "border-border",
+}
+
+const PURPOSE_COLORS: Record<string, { bg: string; text: string; icon: any }> = {
+    "Weed Control": { bg: "bg-green-100 dark:bg-green-900/40", text: "text-green-700 dark:text-green-300", icon: Leaf },
+    "Insect Control": { bg: "bg-red-100 dark:bg-red-900/40", text: "text-red-700 dark:text-red-300", icon: Bug },
+    "Disease Prevention": { bg: "bg-purple-100 dark:bg-purple-900/40", text: "text-purple-700 dark:text-purple-300", icon: Shield },
+    "Disease Control": { bg: "bg-purple-100 dark:bg-purple-900/40", text: "text-purple-700 dark:text-purple-300", icon: Shield },
+    "Growth Regulation": { bg: "bg-blue-100 dark:bg-blue-900/40", text: "text-blue-700 dark:text-blue-300", icon: TrendingUp },
+    "Nutrient Management": { bg: "bg-amber-100 dark:bg-amber-900/40", text: "text-amber-700 dark:text-amber-300", icon: Droplets },
+    "Soil Treatment": { bg: "bg-orange-100 dark:bg-orange-900/40", text: "text-orange-700 dark:text-orange-300", icon: Beaker },
+    "Seed Treatment": { bg: "bg-teal-100 dark:bg-teal-900/40", text: "text-teal-700 dark:text-teal-300", icon: Sprout },
+}
+
+function getPurposeStyle(purpose: string) {
+    return PURPOSE_COLORS[purpose] || { bg: "bg-gray-100 dark:bg-gray-800", text: "text-gray-700 dark:text-gray-300", icon: Beaker }
+}
+
+interface SprayProgramDetailPageProps {
+    params: Promise<{ slug: string }>
+}
+
+export default function SprayProgramDetailPage({ params }: SprayProgramDetailPageProps) {
+    const { slug } = use(params)
+    const [activeStage, setActiveStage] = useState(0)
+    const [quickViewProduct, setQuickViewProduct] = useState<any>(null)
+    const [selectedBrand, setSelectedBrand] = useState<string | null>(null)
+    const stageRefs = useRef<(HTMLDivElement | null)[]>([])
+    const navRef = useRef<HTMLDivElement>(null)
+
+    const { data, isLoading } = useQuery({
+        queryKey: ["spray-program", slug],
+        queryFn: () => querySprayProgramBySlug(slug),
+        refetchOnWindowFocus: false,
+    })
+
+    const program = data?.data
+
+    // IntersectionObserver for sticky nav highlighting
+    useEffect(() => {
+        if (!program?.stages?.length) return
+
+        const observer = new IntersectionObserver(
+            (entries) => {
+                entries.forEach((entry) => {
+                    if (entry.isIntersecting) {
+                        const index = stageRefs.current.indexOf(entry.target as HTMLDivElement)
+                        if (index !== -1) {
+                            setActiveStage(index)
+                        }
+                    }
+                })
+            },
+            { rootMargin: "-120px 0px -60% 0px", threshold: 0 }
+        )
+
+        stageRefs.current.forEach((ref) => {
+            if (ref) observer.observe(ref)
+        })
+
+        return () => observer.disconnect()
+    }, [program?.stages])
+
+    const scrollToStage = (index: number) => {
+        const el = stageRefs.current[index]
+        if (el) {
+            const offset = 140
+            const y = el.getBoundingClientRect().top + window.scrollY - offset
+            window.scrollTo({ top: y, behavior: "smooth" })
+        }
+    }
+
+    if (isLoading) {
+        return (
+            <div className="min-h-screen bg-background">
+                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                    <div className="animate-pulse space-y-8">
+                        <div className="h-64 bg-muted rounded-xl" />
+                        <div className="h-12 bg-muted rounded-lg w-full" />
+                        <div className="space-y-6">
+                            {[1, 2, 3].map((i) => (
+                                <div key={i} className="h-48 bg-muted rounded-xl" />
+                            ))}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        )
+    }
+
+    if (!program) {
+        return (
+            <div className="min-h-screen bg-background flex items-center justify-center px-4 pb-4">
+                <div className="text-center max-w-md">
+                    <div className="mb-6">
+                        <div className="mx-auto w-20 h-20 bg-muted rounded-full flex items-center justify-center">
+                            <Sprout className="w-10 h-10 text-muted-foreground" />
+                        </div>
+                    </div>
+                    <h2 className="text-2xl font-semibold mb-2">Spray Program Not Found</h2>
+                    <p className="text-muted-foreground mb-6">
+                        We couldn&apos;t find the spray program you&apos;re looking for.
+                    </p>
+                    <Link
+                        href="/spray-programs"
+                        className="inline-flex items-center justify-center rounded-md text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2 transition-colors"
+                    >
+                        Browse All Programs
+                    </Link>
+                </div>
+            </div>
+        )
+    }
+
+    const stages = program.stages || []
+
+    // Extract unique brands from all recommendations
+    const allBrands = new Set<string>()
+    stages.forEach((stage: any) => {
+        (stage.recommendations || []).forEach((rec: any) => {
+            const brand = rec.agrochemical?.brand?.name
+            if (brand) allBrands.add(brand)
+        })
+    })
+    const brands = Array.from(allBrands).sort()
+    const hasBrands = brands.length > 0
+
+    // Filter helper
+    const matchesBrand = (rec: any) => {
+        if (!selectedBrand) return true
+        return rec.agrochemical?.brand?.name === selectedBrand
+    }
+
+    return (
+        <div className="min-h-screen bg-background">
+            {/* Breadcrumb */}
+            <div className="border-b bg-muted/30">
+                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+                    <nav className="flex text-sm text-muted-foreground">
+                        <Link href="/" className="hover:text-foreground">Home</Link>
+                        <span className="mx-2">/</span>
+                        <Link href="/spray-programs" className="hover:text-foreground">Spray Programs</Link>
+                        <span className="mx-2">/</span>
+                        <span className="text-foreground">{capitalizeFirstLetter(program.name)}</span>
+                    </nav>
+                </div>
+            </div>
+
+            {/* Hero Header */}
+            <section className="relative overflow-hidden">
+                {program.cover_image?.img?.src ? (
+                    <div className="relative h-56 sm:h-72 lg:h-80">
+                        <Image
+                            src={program.cover_image.img.src}
+                            alt={program.name}
+                            fill
+                            sizes="100vw"
+                            className="object-cover"
+                            priority
+                        />
+                        <div className="absolute inset-0 bg-gradient-to-t from-background via-background/60 to-transparent" />
+                        <div className="absolute bottom-0 left-0 right-0 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-8">
+                            <div className="flex items-center gap-3 mb-3">
+                                {program.farm_produce_name && (
+                                    <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium bg-amber-100/90 text-amber-800 dark:bg-amber-900/60 dark:text-amber-300 backdrop-blur-sm">
+                                        <Sprout className="h-3 w-3" />
+                                        {capitalizeFirstLetter(program.farm_produce_name)}
+                                    </span>
+                                )}
+                                <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-white/90 text-foreground dark:bg-gray-900/60 dark:text-gray-200 backdrop-blur-sm">
+                                    {stages.length} Growth {stages.length === 1 ? "Stage" : "Stages"}
+                                </span>
+                            </div>
+                            <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-foreground">
+                                {capitalizeFirstLetter(program.name)}
+                            </h1>
+                            {program.description && (
+                                <p className="mt-3 text-base sm:text-lg text-muted-foreground max-w-2xl">
+                                    {program.description}
+                                </p>
+                            )}
+                        </div>
+                    </div>
+                ) : (
+                    <div className="relative bg-gradient-to-br from-green-50 to-emerald-50 dark:from-green-950/30 dark:to-emerald-950/20 py-12 lg:py-16">
+                        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                            <div className="flex items-center gap-3 mb-3">
+                                {program.farm_produce_name && (
+                                    <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
+                                        <Sprout className="h-3 w-3" />
+                                        {capitalizeFirstLetter(program.farm_produce_name)}
+                                    </span>
+                                )}
+                                <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-muted text-muted-foreground">
+                                    {stages.length} Growth {stages.length === 1 ? "Stage" : "Stages"}
+                                </span>
+                            </div>
+                            <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold">
+                                {capitalizeFirstLetter(program.name)}
+                            </h1>
+                            {program.description && (
+                                <p className="mt-3 text-base sm:text-lg text-muted-foreground max-w-2xl">
+                                    {program.description}
+                                </p>
+                            )}
+                        </div>
+                    </div>
+                )}
+            </section>
+
+            {/* Sticky Stage Navigator */}
+            {stages.length > 0 && (
+                <div ref={navRef} className="sticky top-16 z-20 bg-background/95 backdrop-blur-md border-b shadow-sm">
+                    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                        <div className="flex gap-1 overflow-x-auto py-3 scrollbar-hide">
+                            {/* Overview tab */}
+                            <button
+                                onClick={() => scrollToStage(0)}
+                                className={`flex-shrink-0 px-4 py-2 rounded-full text-sm font-medium transition-all ${
+                                    activeStage === 0
+                                        ? "bg-primary text-primary-foreground"
+                                        : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                                }`}
+                            >
+                                <span className="flex items-center gap-2">
+                                    <span className={`w-2 h-2 rounded-full ${activeStage === 0 ? "bg-primary-foreground" : STAGE_STYLE.dot}`} />
+                                    Overview
+                                </span>
+                            </button>
+                            {/* Stage tabs */}
+                            {stages.map((stage: any, index: number) => {
+                                const tabIndex = index + 1
+                                const isActive = activeStage === tabIndex
+                                return (
+                                    <button
+                                        key={index}
+                                        onClick={() => scrollToStage(tabIndex)}
+                                        className={`flex-shrink-0 px-4 py-2 rounded-full text-sm font-medium transition-all ${
+                                            isActive
+                                                ? "bg-primary text-primary-foreground"
+                                                : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                                        }`}
+                                    >
+                                        <span className="flex items-center gap-2">
+                                            <span className={`w-2 h-2 rounded-full ${isActive ? "bg-primary-foreground" : STAGE_STYLE.dot}`} />
+                                            {capitalizeFirstLetter(stage.name)}
+                                        </span>
+                                    </button>
+                                )
+                            })}
+                            {/* Brand Filter - inline after tabs */}
+                            {hasBrands && (
+                                <>
+                                    <div className="flex-shrink-0 w-px h-6 bg-border self-center mx-1" />
+                                    <div className="flex items-center gap-1.5 flex-shrink-0">
+                                        <span className="text-[11px] text-muted-foreground flex-shrink-0">Brand:</span>
+                                        <button
+                                            onClick={() => setSelectedBrand(null)}
+                                            className={`flex-shrink-0 px-2.5 py-1 rounded text-[11px] font-medium transition-all ${
+                                                !selectedBrand
+                                                    ? "bg-foreground text-background"
+                                                    : "bg-muted text-muted-foreground hover:text-foreground"
+                                            }`}
+                                        >
+                                            All
+                                        </button>
+                                        {brands.map((brand) => (
+                                            <button
+                                                key={brand}
+                                                onClick={() => setSelectedBrand(brand)}
+                                                className={`flex-shrink-0 px-2.5 py-1 rounded text-[11px] font-medium transition-all ${
+                                                    selectedBrand === brand
+                                                        ? "bg-foreground text-background"
+                                                        : "bg-muted text-muted-foreground hover:text-foreground"
+                                                }`}
+                                            >
+                                                {capitalizeFirstLetter(brand)}
+                                            </button>
+                                        ))}
+                                    </div>
+                                </>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* Program Chart */}
+            {stages.length > 0 && (() => {
+                // Build purpose → stage → recommendations map
+                const purposeMap = new Map<string, Map<number, any[]>>()
+                stages.forEach((stage: any, stageIdx: number) => {
+                    (stage.recommendations || []).forEach((rec: any) => {
+                        const purpose = rec.purpose || "Other"
+                        if (!purposeMap.has(purpose)) purposeMap.set(purpose, new Map())
+                        const stageMap = purposeMap.get(purpose)!
+                        if (!stageMap.has(stageIdx)) stageMap.set(stageIdx, [])
+                        stageMap.get(stageIdx)!.push(rec)
+                    })
+                })
+                const purposes = Array.from(purposeMap.keys())
+
+                if (purposes.length === 0) return null
+
+                return (
+                    <div
+                        ref={(el) => { stageRefs.current[0] = el }}
+                        className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-8"
+                    >
+                        <h2 className="text-lg font-semibold mb-4 text-foreground">Program Overview</h2>
+                        <div className="rounded-xl border border-border overflow-hidden">
+                            <div className="overflow-x-auto">
+                                <table className="w-full border-collapse min-w-[640px]">
+                                    <thead>
+                                        <tr className="bg-muted/60">
+                                            <th className="text-left text-xs font-semibold text-muted-foreground uppercase tracking-wide p-3 w-36 border-r border-border sticky left-0 bg-muted/60 z-10">
+                                                Category
+                                            </th>
+                                            {stages.map((stage: any, idx: number) => (
+                                                <th key={idx} className="text-center p-3 border-r border-border last:border-r-0 min-w-[140px]">
+                                                    <div className="text-xs font-semibold text-foreground">{capitalizeFirstLetter(stage.name)}</div>
+                                                    {stage.timing_description && (
+                                                        <div className="text-[10px] text-muted-foreground font-normal mt-0.5">{stage.timing_description}</div>
+                                                    )}
+                                                </th>
+                                            ))}
+                                        </tr>
+                                    </thead>
+                                    <tbody className="divide-y divide-border">
+                                        {purposes.map((purpose) => {
+                                            const stageMap = purposeMap.get(purpose)!
+                                            const style = getPurposeStyle(purpose)
+                                            const Icon = style.icon
+                                            return (
+                                                <tr key={purpose} className="hover:bg-muted/20 transition-colors">
+                                                    <td className="p-3 border-r border-border sticky left-0 bg-background z-10">
+                                                        <div className={`inline-flex items-center gap-1.5 px-2 py-1 rounded text-[11px] font-medium ${style.bg} ${style.text}`}>
+                                                            <Icon className="h-3 w-3" />
+                                                            {purpose}
+                                                        </div>
+                                                    </td>
+                                                    {stages.map((_: any, stageIdx: number) => {
+                                                        const recs = (stageMap.get(stageIdx) || []).filter(matchesBrand)
+                                                        return (
+                                                            <td key={stageIdx} className="p-2 border-r border-border last:border-r-0 align-top">
+                                                                {recs.length > 0 ? (
+                                                                    <div className="space-y-1.5">
+                                                                        {recs.map((rec: any, i: number) => {
+                                                                            const brandName = rec.agrochemical?.brand?.name
+                                                                            return (
+                                                                                <button
+                                                                                    key={i}
+                                                                                    onClick={() => rec.agrochemical && setQuickViewProduct({ ...rec, agrochemical: rec.agrochemical })}
+                                                                                    className={`block w-full text-left p-1.5 rounded ${style.bg} cursor-pointer hover:ring-1 hover:ring-current transition-all`}
+                                                                                >
+                                                                                    <div className={`text-[11px] font-medium ${style.text} leading-tight`}>
+                                                                                        {capitalizeFirstLetter(rec.agrochemical_name)}
+                                                                                    </div>
+                                                                                    {brandName && hasBrands && (
+                                                                                        <div className="text-[9px] text-muted-foreground mt-0.5">{capitalizeFirstLetter(brandName)}</div>
+                                                                                    )}
+                                                                                    {rec.dosage?.value && (
+                                                                                        <div className="text-[10px] text-muted-foreground mt-0.5">
+                                                                                            {rec.dosage.value} {rec.dosage.unit}
+                                                                                        </div>
+                                                                                    )}
+                                                                                </button>
+                                                                            )
+                                                                        })}
+                                                                    </div>
+                                                                ) : (
+                                                                    <div className="text-center text-muted-foreground/30 text-xs py-2">—</div>
+                                                                )}
+                                                            </td>
+                                                        )
+                                                    })}
+                                                </tr>
+                                            )
+                                        })}
+                                    </tbody>
+                                </table>
+                            </div>
+                        </div>
+                    </div>
+                )
+            })()}
+
+            {/* Stage Sections */}
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-10">
+                {stages.map((stage: any, stageIndex: number) => {
+                    const recommendations = stage.recommendations || []
+
+                    return (
+                        <div
+                            key={stageIndex}
+                            ref={(el) => { stageRefs.current[stageIndex + 1] = el }}
+                            className="rounded-xl border border-border overflow-hidden"
+                        >
+                            {/* Stage Header */}
+                            <div className="bg-muted/40 px-6 py-5">
+                                <div className="flex items-start justify-between flex-wrap gap-3">
+                                    <div>
+                                        <h2 className="text-xl sm:text-2xl font-bold text-foreground">
+                                            {capitalizeFirstLetter(stage.name)}
+                                        </h2>
+                                        {stage.description && (
+                                            <p className="text-sm text-muted-foreground mt-1 max-w-2xl">
+                                                {stage.description}
+                                            </p>
+                                        )}
+                                    </div>
+                                    {stage.timing_description && (
+                                        <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-muted text-muted-foreground border border-border">
+                                            {stage.timing_description}
+                                        </span>
+                                    )}
+                                </div>
+                            </div>
+
+                            {/* Recommendations */}
+                            {recommendations.filter(matchesBrand).length > 0 ? (
+                                <div className="divide-y divide-border">
+                                    {recommendations.filter(matchesBrand).map((rec: any, recIndex: number) => {
+                                        const purposeStyle = getPurposeStyle(rec.purpose)
+                                        const PurposeIcon = purposeStyle.icon
+                                        const agrochemical = rec.agrochemical
+                                        const brandName = agrochemical?.brand?.name
+                                        const guideHref = agrochemical?.agrochemical_category?.slug && rec.agrochemical_slug
+                                            ? `/agrochemical-guides/${agrochemical.agrochemical_category.slug}/${rec.agrochemical_slug}?from=${slug}`
+                                            : null
+
+                                        return (
+                                            <div key={recIndex} className="flex items-center gap-4 px-6 py-3 hover:bg-muted/30 transition-colors">
+                                                {/* Thumbnail */}
+                                                <button
+                                                    onClick={() => agrochemical && setQuickViewProduct({ ...rec, agrochemical })}
+                                                    className="relative w-10 h-10 rounded-md bg-white dark:bg-gray-900 border overflow-hidden flex-shrink-0 cursor-pointer"
+                                                >
+                                                    {agrochemical?.images?.[0]?.img?.src ? (
+                                                        <Image
+                                                            src={agrochemical.images[0].img.src}
+                                                            alt={rec.agrochemical_name}
+                                                            fill
+                                                            sizes="40px"
+                                                            className="object-contain p-0.5"
+                                                        />
+                                                    ) : (
+                                                        <div className="absolute inset-0 flex items-center justify-center">
+                                                            <Beaker className="w-4 h-4 text-muted-foreground/40" />
+                                                        </div>
+                                                    )}
+                                                </button>
+
+                                                {/* Name + Brand + Purpose */}
+                                                <div className="flex-1 min-w-0">
+                                                    <button
+                                                        onClick={() => agrochemical && setQuickViewProduct({ ...rec, agrochemical })}
+                                                        className="text-sm font-medium text-foreground hover:text-primary transition-colors text-left truncate block w-full cursor-pointer"
+                                                    >
+                                                        {capitalizeFirstLetter(rec.agrochemical_name)}
+                                                        {brandName && hasBrands && (
+                                                            <span className="text-muted-foreground font-normal"> — {capitalizeFirstLetter(brandName)}</span>
+                                                        )}
+                                                    </button>
+                                                    <div className={`inline-flex items-center gap-1 mt-0.5 px-1.5 py-0.5 rounded text-[10px] font-medium ${purposeStyle.bg} ${purposeStyle.text}`}>
+                                                        <PurposeIcon className="h-2.5 w-2.5" />
+                                                        {rec.purpose}
+                                                    </div>
+                                                </div>
+
+                                                {/* Dosage */}
+                                                {rec.dosage && (rec.dosage.value || rec.dosage.unit) && (
+                                                    <div className="hidden sm:block text-right flex-shrink-0">
+                                                        <div className="text-sm font-medium text-foreground">
+                                                            {rec.dosage.value} {rec.dosage.unit}
+                                                        </div>
+                                                        {rec.dosage.per && (
+                                                            <div className="text-[11px] text-muted-foreground">per {rec.dosage.per}</div>
+                                                        )}
+                                                    </div>
+                                                )}
+
+                                                {/* View Guide */}
+                                                {guideHref && (
+                                                    <Link
+                                                        href={guideHref}
+                                                        className="flex-shrink-0 text-xs font-medium text-primary hover:text-primary/80 transition-colors flex items-center gap-1"
+                                                    >
+                                                        View Guide
+                                                        <ChevronRight className="h-3 w-3" />
+                                                    </Link>
+                                                )}
+                                            </div>
+                                        )
+                                    })}
+                                </div>
+                            ) : (
+                                <div className="p-6 text-sm text-muted-foreground">
+                                    {selectedBrand ? `No ${capitalizeFirstLetter(selectedBrand)} recommendations for this stage.` : "No recommendations for this stage yet."}
+                                </div>
+                            )}
+                        </div>
+                    )
+                })}
+
+                {/* Safety Warning */}
+                <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-lg p-6">
+                    <div className="flex items-start gap-3">
+                        <AlertTriangle className="w-6 h-6 text-yellow-600 dark:text-yellow-500 flex-shrink-0" />
+                        <div>
+                            <h3 className="font-semibold mb-2 text-yellow-900 dark:text-yellow-100">Safety Information</h3>
+                            <p className="text-sm text-yellow-800 dark:text-yellow-200">
+                                Always read and follow label directions. Wear appropriate personal protective equipment (PPE) when handling agrochemicals.
+                                Store in original containers in a secure location away from children and animals. Dispose of containers properly according to local regulations.
+                                Consult your local extension officer for region-specific recommendations.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            {/* Product Quick-View Dialog */}
+            {quickViewProduct && (
+                <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+                    {/* Backdrop */}
+                    <div
+                        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+                        onClick={() => setQuickViewProduct(null)}
+                    />
+
+                    {/* Dialog */}
+                    <div className="relative bg-background rounded-xl border shadow-2xl max-w-2xl w-full">
+                        {/* Close Button */}
+                        <button
+                            onClick={() => setQuickViewProduct(null)}
+                            className="absolute right-3 top-3 z-10 p-1.5 rounded-full bg-muted hover:bg-muted/80 transition-colors"
+                        >
+                            <X className="h-4 w-4" />
+                        </button>
+
+                        <div className="flex gap-5 p-5">
+                            {/* Product Image */}
+                            <div className="relative w-32 h-32 sm:w-40 sm:h-40 bg-white dark:bg-gray-900 rounded-lg border overflow-hidden flex-shrink-0">
+                                {quickViewProduct.agrochemical?.images?.[0]?.img?.src ? (
+                                    <Image
+                                        src={quickViewProduct.agrochemical.images[0].img.src}
+                                        alt={quickViewProduct.agrochemical_name}
+                                        fill
+                                        sizes="160px"
+                                        className="object-contain p-3"
+                                    />
+                                ) : (
+                                    <div className="absolute inset-0 flex items-center justify-center">
+                                        <Beaker className="w-12 h-12 text-muted-foreground/30" />
+                                    </div>
+                                )}
+                            </div>
+
+                            {/* Product Details */}
+                            <div className="flex-1 min-w-0 space-y-2.5">
+                                <h3 className="text-lg font-bold leading-tight pr-8">
+                                    {capitalizeFirstLetter(quickViewProduct.agrochemical_name)}
+                                </h3>
+
+                                <div className="flex items-center gap-2 flex-wrap">
+                                    {/* Brand */}
+                                    {quickViewProduct.agrochemical?.brand?.name && (
+                                        <span className="text-xs text-muted-foreground">
+                                            {capitalizeFirstLetter(quickViewProduct.agrochemical.brand.name)}
+                                        </span>
+                                    )}
+                                    {/* Category */}
+                                    {quickViewProduct.agrochemical?.agrochemical_category?.name && (
+                                        <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-muted text-muted-foreground">
+                                            {quickViewProduct.agrochemical.agrochemical_category.name}
+                                        </span>
+                                    )}
+                                </div>
+
+                                {/* Dosage */}
+                                {quickViewProduct.dosage && (quickViewProduct.dosage.value || quickViewProduct.dosage.unit) && (
+                                    <div className="text-sm">
+                                        <span className="font-semibold">{quickViewProduct.dosage.value} {quickViewProduct.dosage.unit}</span>
+                                        {quickViewProduct.dosage.per && (
+                                            <span className="text-muted-foreground"> per {quickViewProduct.dosage.per}</span>
+                                        )}
+                                    </div>
+                                )}
+
+                                {/* Active Ingredients - inline */}
+                                {quickViewProduct.agrochemical?.active_ingredients?.length > 0 && (
+                                    <div className="flex flex-wrap gap-1.5">
+                                        {quickViewProduct.agrochemical.active_ingredients.map((ai: any, idx: number) => (
+                                            <span key={idx} className="px-2 py-0.5 rounded text-[11px] font-medium bg-muted text-foreground capitalize">
+                                                {ai.name} {ai.dosage_value}{ai.dosage_unit}
+                                            </span>
+                                        ))}
+                                    </div>
+                                )}
+
+                                {/* Targets - inline */}
+                                {quickViewProduct.agrochemical?.targets?.length > 0 && (
+                                    <div className="flex flex-wrap gap-1">
+                                        {quickViewProduct.agrochemical.targets.map((t: any, idx: number) => (
+                                            <span key={idx} className="px-1.5 py-0.5 rounded text-[10px] bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300 capitalize">
+                                                {t.name}
+                                            </span>
+                                        ))}
+                                    </div>
+                                )}
+                            </div>
+                        </div>
+
+                        {/* CTA */}
+                        {quickViewProduct.agrochemical?.agrochemical_category?.slug && quickViewProduct.agrochemical_slug && (
+                            <div className="px-5 pb-5">
+                                <Link
+                                    href={`/agrochemical-guides/${quickViewProduct.agrochemical.agrochemical_category.slug}/${quickViewProduct.agrochemical_slug}?from=${slug}`}
+                                    className="flex items-center justify-center gap-2 w-full py-2 rounded-md text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+                                    onClick={() => setQuickViewProduct(null)}
+                                >
+                                    View Full Guide
+                                    <ChevronRight className="h-4 w-4" />
+                                </Link>
+                            </div>
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/apps/client-fnp/app/(landing)/spray-programs/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/spray-programs/[slug]/page.tsx
@@ -10,6 +10,7 @@ import {
     Bug, Leaf, TrendingUp, Beaker, Shield, X
 } from "lucide-react"
 import { capitalizeFirstLetter } from "@/lib/utilities"
+import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
 
 // Unified stage styling — clean, minimal
 const STAGE_STYLE = {
@@ -402,6 +403,13 @@ export default function SprayProgramDetailPage({ params }: SprayProgramDetailPag
                     </div>
                 )
             })()}
+
+            {/* AdSense after overview */}
+            {stages.length > 0 && (
+                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-6">
+                    <AdSenseInFeed />
+                </div>
+            )}
 
             {/* Stage Sections */}
             <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-10">

--- a/apps/client-fnp/app/(landing)/spray-programs/layout.tsx
+++ b/apps/client-fnp/app/(landing)/spray-programs/layout.tsx
@@ -1,0 +1,39 @@
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Crop Spray Programs - Step-by-Step Application Schedules | farmnport',
+  description: 'Discover crop-specific spray programs with detailed stage-by-stage agrochemical application schedules. Find the right products for each growth stage of your crops.',
+  keywords: 'spray programs, crop protection, agrochemical schedule, farming guide, pest management, disease prevention, growth stages, agricultural spraying',
+  authors: [{ name: 'farmnport' }],
+  openGraph: {
+    title: 'Crop Spray Programs - Step-by-Step Application Schedules',
+    description: 'Discover crop-specific spray programs with detailed stage-by-stage agrochemical application schedules. Find the right products for each growth stage of your crops.',
+    url: `${process.env.NEXT_PUBLIC_BASE_URL || 'https://farmnport.com'}/spray-programs`,
+    siteName: 'farmnport',
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Crop Spray Programs - Application Schedules',
+    description: 'Crop-specific spray programs with stage-by-stage agrochemical application schedules.',
+  },
+  alternates: {
+    canonical: `${process.env.NEXT_PUBLIC_BASE_URL || 'https://farmnport.com'}/spray-programs`,
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-video-preview': -1,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+    },
+  },
+}
+
+export default function SprayProgramsRootLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/apps/client-fnp/app/(landing)/spray-programs/page.tsx
+++ b/apps/client-fnp/app/(landing)/spray-programs/page.tsx
@@ -1,0 +1,132 @@
+"use client"
+
+import Link from "next/link"
+import Image from "next/image"
+import { useQuery } from "@tanstack/react-query"
+import { Sprout, ArrowRight, Layers, ChevronRight } from "lucide-react"
+import { queryPublishedSprayPrograms } from "@/lib/query"
+import { capitalizeFirstLetter } from "@/lib/utilities"
+
+export default function SprayProgramsPage() {
+    const { data, isLoading } = useQuery({
+        queryKey: ["spray-programs"],
+        queryFn: () => queryPublishedSprayPrograms(),
+        refetchOnWindowFocus: false,
+    })
+
+    const programs = data?.data?.data || []
+
+    return (
+        <main className="bg-gradient-to-b from-background to-muted/20 min-h-screen">
+            {/* Hero Section */}
+            <section className="py-12 lg:py-20 relative overflow-hidden">
+                <div className="absolute inset-0 bg-gradient-to-br from-green-50/50 via-transparent to-emerald-50/30 dark:from-green-950/20 dark:to-emerald-950/10" />
+                <div className="mx-auto max-w-7xl px-6 lg:px-8 relative">
+                    <div className="text-center max-w-3xl mx-auto mb-14">
+                        <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300 text-sm font-medium mb-6">
+                            <Sprout className="h-4 w-4" />
+                            Crop Protection Made Simple
+                        </div>
+                        <h1 className="text-4xl font-bold tracking-tight sm:text-5xl font-heading mb-5">
+                            Crop Spray Programs
+                        </h1>
+                        <p className="text-lg text-muted-foreground leading-7">
+                            Step-by-step agrochemical application schedules for every growth stage.
+                            Know exactly what to spray, when to spray, and how much to use.
+                        </p>
+                    </div>
+
+                    {/* Loading State */}
+                    {isLoading && (
+                        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                            {[1, 2, 3].map((i) => (
+                                <div key={i} className="animate-pulse rounded-xl border bg-card overflow-hidden">
+                                    <div className="aspect-[16/9] bg-muted" />
+                                    <div className="p-5 space-y-3">
+                                        <div className="h-5 bg-muted rounded w-3/4" />
+                                        <div className="h-4 bg-muted rounded w-full" />
+                                        <div className="h-4 bg-muted rounded w-1/2" />
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+
+                    {/* Empty State */}
+                    {!isLoading && programs.length === 0 && (
+                        <div className="text-center py-16">
+                            <div className="mx-auto w-20 h-20 bg-muted rounded-full flex items-center justify-center mb-6">
+                                <Sprout className="w-10 h-10 text-muted-foreground" />
+                            </div>
+                            <h2 className="text-2xl font-semibold mb-2">No Spray Programs Yet</h2>
+                            <p className="text-muted-foreground max-w-md mx-auto">
+                                We&apos;re working on creating comprehensive spray programs for various crops. Check back soon!
+                            </p>
+                        </div>
+                    )}
+
+                    {/* Programs Grid */}
+                    {!isLoading && programs.length > 0 && (
+                        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                            {programs.map((program: any) => (
+                                <Link
+                                    key={program.id}
+                                    href={`/spray-programs/${program.slug}`}
+                                    className="group rounded-xl border bg-card overflow-hidden hover:border-primary hover:shadow-lg transition-all duration-300"
+                                >
+                                    {/* Cover Image */}
+                                    <div className="relative aspect-[16/9] bg-gradient-to-br from-green-50 to-emerald-50 dark:from-green-950/30 dark:to-emerald-950/30 overflow-hidden">
+                                        {program.cover_image?.img?.src ? (
+                                            <Image
+                                                src={program.cover_image.img.src}
+                                                alt={program.name}
+                                                fill
+                                                sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                                                className="object-cover group-hover:scale-105 transition-transform duration-500"
+                                            />
+                                        ) : (
+                                            <div className="absolute inset-0 flex items-center justify-center">
+                                                <Sprout className="w-16 h-16 text-green-300 dark:text-green-800" />
+                                            </div>
+                                        )}
+                                    </div>
+
+                                    {/* Card Content */}
+                                    <div className="p-5">
+                                        <h2 className="text-lg font-semibold mb-1.5 group-hover:text-primary transition-colors">
+                                            {capitalizeFirstLetter(program.name)}
+                                        </h2>
+
+                                        {program.farm_produce_name && (
+                                            <div className="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300 mb-3">
+                                                <Sprout className="h-3 w-3" />
+                                                {capitalizeFirstLetter(program.farm_produce_name)}
+                                            </div>
+                                        )}
+
+                                        {program.description && (
+                                            <p className="text-sm text-muted-foreground line-clamp-2 mb-4">
+                                                {program.description}
+                                            </p>
+                                        )}
+
+                                        <div className="flex items-center justify-between">
+                                            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                                                <Layers className="h-3.5 w-3.5" />
+                                                <span>{program.stages?.length || 0} stages</span>
+                                            </div>
+                                            <div className="flex items-center gap-1 text-sm font-medium text-primary opacity-0 group-hover:opacity-100 transition-opacity">
+                                                View Program
+                                                <ChevronRight className="h-4 w-4" />
+                                            </div>
+                                        </div>
+                                    </div>
+                                </Link>
+                            ))}
+                        </div>
+                    )}
+                </div>
+            </section>
+        </main>
+    )
+}

--- a/apps/client-fnp/components/agrochemical/AgroChemicalCard.tsx
+++ b/apps/client-fnp/components/agrochemical/AgroChemicalCard.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation"
 import { Bug, Beaker, ShoppingCart } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { sendGTMEvent } from '@next/third-parties/google'
+import { formatProductName } from "@/lib/utilities"
 
 interface AgroChemicalCardProps {
   chemical: any
@@ -49,8 +50,8 @@ export function AgroChemicalCard({ chemical, mode }: AgroChemicalCardProps) {
 
         {/* Product Name */}
         <Link href={href}>
-          <h3 className="font-semibold text-sm leading-tight capitalize line-clamp-2 min-h-[2.5rem] group-hover:text-primary transition-colors">
-            {chemical.name}
+          <h3 className="font-semibold text-sm leading-tight line-clamp-2 min-h-[2.5rem] group-hover:text-primary transition-colors">
+            {formatProductName(chemical.name)}
           </h3>
         </Link>
 

--- a/apps/client-fnp/components/agrochemical/GuidesHeroActions.tsx
+++ b/apps/client-fnp/components/agrochemical/GuidesHeroActions.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import { sendGTMEvent } from "@next/third-parties/google"
+import Link from "next/link"
+import { Search, Sprout, ArrowRight } from "lucide-react"
+import { Button } from "@/components/ui/button"
+
+export function GuidesHeroActions() {
+    return (
+        <div className="flex flex-wrap items-center justify-center gap-3">
+            <Button
+                size="lg"
+                asChild
+                onClick={() => sendGTMEvent({ event: "click", value: "ReadGuides" })}
+                className="text-base px-6 py-5 h-auto font-semibold shadow-lg hover:shadow-xl transition-all group"
+            >
+                <Link href="/agrochemical-guides/all" className="flex items-center gap-2">
+                    <Search className="h-5 w-5" />
+                    Browse All Products
+                </Link>
+            </Button>
+            <Button
+                size="lg"
+                variant="outline"
+                asChild
+                className="text-base px-6 py-5 h-auto font-semibold transition-all group"
+            >
+                <Link href="/spray-programs" className="flex items-center gap-2">
+                    <Sprout className="h-5 w-5" />
+                    All Spray Programs
+                    <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+                </Link>
+            </Button>
+        </div>
+    )
+}

--- a/apps/client-fnp/components/agrochemical/GuidesSearch.tsx
+++ b/apps/client-fnp/components/agrochemical/GuidesSearch.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { Search } from "lucide-react"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+
+export function GuidesSearch() {
+    const router = useRouter()
+    const [query, setQuery] = useState("")
+
+    const handleSearch = () => {
+        if (query.trim().length >= 2) {
+            router.push(`/agrochemical-guides/all?search=${encodeURIComponent(query.trim())}`)
+        } else {
+            router.push("/agrochemical-guides/all")
+        }
+    }
+
+    return (
+        <div className="flex items-center gap-2 w-full max-w-lg mx-auto">
+            <div className="relative flex-1">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                <Input
+                    placeholder="Search products, active ingredients..."
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+                    className="pl-10 h-11"
+                />
+            </div>
+            <Button onClick={handleSearch} size="default" className="h-11 px-5">
+                Search
+            </Button>
+        </div>
+    )
+}

--- a/apps/client-fnp/components/animalhealth/AnimalHealthCard.tsx
+++ b/apps/client-fnp/components/animalhealth/AnimalHealthCard.tsx
@@ -1,0 +1,78 @@
+import Link from "next/link"
+import Image from "next/image"
+import { Bug, Beaker } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { sendGTMEvent } from '@next/third-parties/google'
+
+interface AnimalHealthCardProps {
+  product: any
+}
+
+export function AnimalHealthCard({ product }: AnimalHealthCardProps) {
+  const categorySlug = product.animal_health_category?.slug || 'all'
+  const href = `/animal-health-guides/${categorySlug}/${product.slug}`
+
+  return (
+    <div className="bg-card border border-border rounded-lg overflow-hidden transition-all duration-200 hover:shadow-lg hover:border-primary/50 group">
+      {/* Image Section */}
+      <Link href={href} className="block">
+        <div className="relative aspect-square bg-white">
+          {product.images && product.images[0] && product.images[0].img?.src ? (
+            <Image
+              src={product.images[0].img.src}
+              alt={product.name}
+              fill
+              sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
+              className="object-contain transition-transform duration-200 group-hover:scale-105"
+            />
+          ) : (
+            <div className="absolute inset-0 flex items-center justify-center bg-muted/30">
+              <Beaker className="w-16 h-16 text-muted-foreground/30" />
+            </div>
+          )}
+        </div>
+      </Link>
+
+      {/* Content Section */}
+      <div className="p-4 space-y-3 border-t">
+        {/* Brand */}
+        {product.brand && (
+          <p className="text-xs text-muted-foreground uppercase tracking-wide font-medium">
+            {product.brand.name}
+          </p>
+        )}
+
+        {/* Product Name */}
+        <Link href={href}>
+          <h3 className="font-semibold text-sm leading-tight capitalize line-clamp-2 min-h-[2.5rem] group-hover:text-primary transition-colors">
+            {product.name}
+          </h3>
+        </Link>
+
+        {/* Stats */}
+        <div className="flex items-center gap-4 text-xs text-muted-foreground pt-2 border-t">
+          <div className="flex items-center gap-1.5">
+            <Bug className="w-3.5 h-3.5" />
+            <span>{product.targets?.length || 0} {product.targets?.length === 1 ? 'target' : 'targets'}</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <Beaker className="w-3.5 h-3.5" />
+            <span>{product.active_ingredients?.length || 0} active</span>
+          </div>
+        </div>
+
+        {/* CTA */}
+        <Link href={href} className="block pt-2">
+          <Button
+            variant="outline"
+            className="w-full"
+            size="sm"
+            onClick={() => sendGTMEvent({ event: 'link', value: 'ViewAnimalHealthGuide' })}
+          >
+            View Guide
+          </Button>
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/apps/client-fnp/components/generic/animalHealthFilterSidebar.tsx
+++ b/apps/client-fnp/components/generic/animalHealthFilterSidebar.tsx
@@ -1,0 +1,255 @@
+"use client"
+
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion"
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { capitalizeFirstLetter } from "@/lib/utilities"
+import { Checkbox } from "@/components/ui/checkbox"
+import { useQueryStates, parseAsArrayOf, parseAsString } from "nuqs"
+import { Filter, X, Search } from "lucide-react"
+import { useMediaQuery } from "@/hooks/use-media-query"
+import { useQuery } from "@tanstack/react-query"
+import { useState, useMemo } from "react"
+import { queryAnimalHealthFilterAggregates } from "@/lib/query"
+import { sendGTMEvent } from "@next/third-parties/google"
+
+interface FilterItem {
+  _id: string
+  name?: string
+  count: number
+}
+
+interface AnimalHealthFilterAggregates {
+  brands: FilterItem[]
+  targets: FilterItem[]
+  active_ingredients: FilterItem[]
+  used_on: FilterItem[]
+}
+
+function SearchableCheckboxList({
+  items,
+  filterKey,
+  selectedItems,
+  onToggle,
+  title,
+  isLoading
+}: {
+  items: FilterItem[]
+  filterKey: string
+  selectedItems: string[]
+  onToggle: (value: string) => void
+  title: string
+  isLoading: boolean
+}) {
+  const [search, setSearch] = useState("")
+
+  const filteredItems = useMemo(() => {
+    if (!search) return items
+    const searchLower = search.toLowerCase()
+    return items.filter(item => {
+      const displayName = item.name || item._id
+      return displayName.toLowerCase().includes(searchLower)
+    })
+  }, [items, search])
+
+  if (isLoading) {
+    return <p className="text-sm text-muted-foreground py-2">Loading...</p>
+  }
+
+  if (!items || items.length === 0) {
+    return <p className="text-sm text-muted-foreground py-2">No {title.toLowerCase()} available</p>
+  }
+
+  return (
+    <div className="space-y-3">
+      {items.length > 5 && (
+        <div className="relative">
+          <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder={`Search ${title.toLowerCase()}...`}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-8 h-9"
+          />
+        </div>
+      )}
+      <div className="max-h-[300px] overflow-y-auto space-y-2 pr-2">
+        {filteredItems.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-2">No results found</p>
+        ) : (
+          filteredItems.map((item) => {
+            const displayName = item.name || item._id
+            const value = item._id
+            const isChecked = selectedItems.includes(value)
+
+            return (
+              <div className="flex items-start space-x-2" key={item._id}>
+                <Checkbox
+                  id={`${filterKey}-${value}`}
+                  checked={isChecked}
+                  onCheckedChange={() => onToggle(value)}
+                  className="mt-0.5"
+                />
+                <label
+                  htmlFor={`${filterKey}-${value}`}
+                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer flex-1 flex items-center justify-between"
+                >
+                  <span>{capitalizeFirstLetter(displayName)}</span>
+                  <span className="text-xs text-muted-foreground ml-2">({item.count})</span>
+                </label>
+              </div>
+            )
+          })
+        )}
+      </div>
+    </div>
+  )
+}
+
+function FilterContent({
+  onClearAll,
+}: {
+  onClearAll: () => void
+}) {
+  const [queryState, setQueryState] = useQueryStates({
+    brand: parseAsArrayOf(parseAsString),
+    target: parseAsArrayOf(parseAsString),
+    active_ingredient: parseAsArrayOf(parseAsString),
+    used_on: parseAsArrayOf(parseAsString),
+  })
+
+  const { data: aggregateData, isLoading: isLoadingAggregates } = useQuery({
+    queryKey: ["animal-health-filter-aggregates"],
+    queryFn: async () => {
+      const response = await queryAnimalHealthFilterAggregates()
+      return response.data as AnimalHealthFilterAggregates
+    },
+  })
+
+  const brandItems = useMemo(() => aggregateData?.brands || [], [aggregateData])
+  const targetItems = useMemo(() => aggregateData?.targets || [], [aggregateData])
+  const activeIngredientItems = useMemo(() => aggregateData?.active_ingredients || [], [aggregateData])
+  const usedOnItems = useMemo(() => aggregateData?.used_on || [], [aggregateData])
+
+  const handleToggle = (filterKey: string, value: string) => {
+    const currentValues = queryState[filterKey as keyof typeof queryState] || []
+    const isAdding = !currentValues.includes(value)
+    const newValues = isAdding
+      ? [...currentValues, value]
+      : currentValues.filter(v => v !== value)
+
+    const filterTypeMap: Record<string, string> = {
+      'used_on': 'UsedOn',
+      'target': 'Target',
+      'active_ingredient': 'ActiveIngredient',
+      'brand': 'Brand'
+    }
+    const filterType = filterTypeMap[filterKey] || filterKey
+    const action = isAdding ? 'Add' : 'Remove'
+    sendGTMEvent({ event: 'filter', value: `${action}${filterType}Filter` })
+
+    setQueryState({
+      [filterKey]: newValues.length > 0 ? newValues : null
+    })
+  }
+
+  const totalFilters = Object.values(queryState).reduce((acc, val) => acc + (val?.length || 0), 0)
+
+  const filterSections = [
+    { name: "Used On", key: "used_on", items: usedOnItems, isLoading: isLoadingAggregates },
+    { name: "Targets", key: "target", items: targetItems, isLoading: isLoadingAggregates },
+    { name: "Active Ingredients", key: "active_ingredient", items: activeIngredientItems, isLoading: isLoadingAggregates },
+    { name: "Brands", key: "brand", items: brandItems, isLoading: isLoadingAggregates },
+  ]
+
+  return (
+    <div className="flex flex-col h-full">
+      {totalFilters > 0 && (
+        <div className="flex items-center justify-between mb-4 pb-4 border-b">
+          <span className="text-sm text-muted-foreground">
+            {totalFilters} filter{totalFilters !== 1 ? 's' : ''} applied
+          </span>
+          <Button variant="ghost" size="sm" onClick={onClearAll} className="h-8 px-2 lg:px-3">
+            Clear all
+            <X className="ml-2 h-4 w-4" />
+          </Button>
+        </div>
+      )}
+
+      <Accordion type="multiple" className="w-full flex-1" defaultValue={["Used On", "Targets", "Active Ingredients"]}>
+        {filterSections.map((section) => {
+          const selectedFilters = queryState[section.key as keyof typeof queryState] || []
+          return (
+            <AccordionItem value={section.name} key={section.key}>
+              <AccordionTrigger>
+                <div className="flex items-center justify-between w-full pr-2">
+                  <span>{section.name}</span>
+                  {selectedFilters.length > 0 && (
+                    <span className="text-xs bg-primary text-primary-foreground rounded-full px-2 py-0.5">
+                      {selectedFilters.length}
+                    </span>
+                  )}
+                </div>
+              </AccordionTrigger>
+              <AccordionContent>
+                <SearchableCheckboxList
+                  items={section.items}
+                  filterKey={section.key}
+                  selectedItems={selectedFilters}
+                  onToggle={(value) => handleToggle(section.key, value)}
+                  title={section.name}
+                  isLoading={section.isLoading}
+                />
+              </AccordionContent>
+            </AccordionItem>
+          )
+        })}
+      </Accordion>
+    </div>
+  )
+}
+
+export function AnimalHealthFilterSidebar() {
+  const isDesktop = useMediaQuery("(min-width: 1024px)")
+  const [, setQueryState] = useQueryStates({
+    brand: parseAsArrayOf(parseAsString),
+    target: parseAsArrayOf(parseAsString),
+    active_ingredient: parseAsArrayOf(parseAsString),
+    used_on: parseAsArrayOf(parseAsString),
+  })
+
+  const handleClearAll = () => {
+    setQueryState({
+      brand: null,
+      target: null,
+      active_ingredient: null,
+      used_on: null,
+    })
+  }
+
+  if (isDesktop) {
+    return (
+      <div className="sticky top-20 mt-[20px]">
+        <FilterContent onClearAll={handleClearAll} />
+      </div>
+    )
+  }
+
+  return (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button variant="outline" className="w-full mb-4">
+          <Filter className="mr-2 h-4 w-4" />
+          Filters
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="left" className="w-[300px] sm:w-[400px] overflow-y-auto">
+        <SheetHeader className="mb-4">
+          <SheetTitle>Filter Animal Health Products</SheetTitle>
+        </SheetHeader>
+        <FilterContent onClearAll={handleClearAll} />
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/apps/client-fnp/components/icons/lucide.ts
+++ b/apps/client-fnp/components/icons/lucide.ts
@@ -58,7 +58,8 @@ import {
     Lock,
     Eye,
     Shield,
-    Users
+    Users,
+    Sprout
 } from "lucide-react"
 
 export type Icon = LucideIcon
@@ -124,5 +125,6 @@ export const Icons = {
     lock: Lock,
     eye: Eye,
     shield: Shield,
-    users: Users
+    users: Users,
+    sprout: Sprout
 }

--- a/apps/client-fnp/components/layouts/client.tsx
+++ b/apps/client-fnp/components/layouts/client.tsx
@@ -4,8 +4,8 @@ import { useQuery } from "@tanstack/react-query"
 import { sendGTMEvent } from "@next/third-parties/google"
 import Link from "next/link"
 
-import { queryClient, queryClientPricing } from "@/lib/query"
-import { ApplicationUser, AuthenticatedUser } from "@/lib/schemas"
+import { queryClient, queryClientPricing, queryCdmPricesByClient } from "@/lib/query"
+import { ApplicationUser, AuthenticatedUser, CdmPrice } from "@/lib/schemas"
 import { capitalizeFirstLetter, makeAbbveriation, plural, titleCase } from "@/lib/utilities"
 import { paymentTermsLabel } from "@/components/structures/repository/data"
 import { Icons } from "@/components/icons/lucide"
@@ -15,6 +15,7 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Contacts } from "@/components/layouts/contacts"
 import { BuyerContacts } from "@/components/structures/buyer-contacts"
+import { CdmPriceCard } from "@/components/structures/cdm-price-card"
 
 
 interface ClientPageProps {
@@ -38,6 +39,16 @@ export function Client({ slug, user }: ClientPageProps) {
     enabled: !!client?.id && client?.type === 'buyer' && client?.has_prices,
     refetchOnWindowFocus: false
   })
+
+  // Fetch CDM pricing data (for buyers)
+  const { data: cdmData } = useQuery({
+    queryKey: [`client-cdm-pricing-${client?.id}`, client?.id],
+    queryFn: () => queryCdmPricesByClient(client?.id || ''),
+    enabled: !!client?.id && client?.type === 'buyer',
+    refetchOnWindowFocus: false
+  })
+
+  const cdmPrices: CdmPrice[] = cdmData?.data?.data || []
 
   if (isError) {
     return null
@@ -283,6 +294,15 @@ export function Client({ slug, user }: ClientPageProps) {
                     This buyer hasn&apos;t shared pricing information yet. Check back later or contact them directly for pricing details.
                   </p>
                 )}
+              </div>
+            )}
+
+            {/* CDM Pricing */}
+            {cdmPrices.length > 0 && (
+              <div className="space-y-4">
+                {cdmPrices.map((cdmPrice) => (
+                  <CdmPriceCard key={cdmPrice.id} price={cdmPrice} />
+                ))}
               </div>
             )}
 

--- a/apps/client-fnp/components/layouts/mobile-nav.tsx
+++ b/apps/client-fnp/components/layouts/mobile-nav.tsx
@@ -91,6 +91,18 @@ export function MobileNav({ user }: MobileNavProps) {
                    </Link>
 
                    <Link
+                     href="/spray-programs"
+                     onClick={() => {
+                       sendGTMEvent({ event: 'link', value: 'SprayProgramsTopNavigation' })
+                       setIsOpen(false)
+                     }}
+                     className="flex items-center gap-3 px-3 py-2 text-base font-medium rounded-md hover:bg-accent transition-colors"
+                   >
+                     <Icons.sprout className="h-5 w-5" />
+                     <span>Spray Programs</span>
+                   </Link>
+
+                   <Link
                      href="/buyers"
                      onClick={() => {
                        sendGTMEvent({ event: 'link', value: 'BuyerTopNavigation' })

--- a/apps/client-fnp/components/layouts/nav.tsx
+++ b/apps/client-fnp/components/layouts/nav.tsx
@@ -41,6 +41,14 @@ export function Navigation({ user }: NavigationProps) {
         >
           Guides
         </Link>
+        <Link href="/spray-programs" onClick={() => sendGTMEvent({ event: 'link', value: 'SprayProgramsTopNavigation' })}
+              className={buttonVariants({
+                size: "sm",
+                variant: "link"
+              })}
+        >
+          Spray Programs
+        </Link>
         <Link href="/buyers" onClick={() => sendGTMEvent({ event: 'link', value: 'BuyerTopNavigation' })}
               className={buttonVariants({
                 size: "sm",

--- a/apps/client-fnp/components/providers/QueryProvider.tsx
+++ b/apps/client-fnp/components/providers/QueryProvider.tsx
@@ -11,7 +11,14 @@ type QueryClientProps = {
 }
 
 export function QueryProvider({ children }: QueryClientProps) {
-    const [queryClient] = useState(() => new QueryClient())
+    const [queryClient] = useState(() => new QueryClient({
+        defaultOptions: {
+            queries: {
+                staleTime: process.env.NODE_ENV === "production" ? 5 * 60 * 1000 : 0,
+                refetchOnWindowFocus: false,
+            },
+        },
+    }))
     return (
         <QueryClientProvider client={queryClient}>
             {children}

--- a/apps/client-fnp/components/structures/cdm-price-card.tsx
+++ b/apps/client-fnp/components/structures/cdm-price-card.tsx
@@ -1,0 +1,243 @@
+"use client"
+
+import { Fragment } from "react"
+import { formatDate, capitalizeFirstLetter } from "@/lib/utilities"
+import { Calendar, Building2, Info } from "lucide-react"
+import { CdmPrice, LiveweightEntry } from "@/lib/schemas"
+
+interface CdmPriceCardProps {
+  price: CdmPrice
+}
+
+const gradeLabels: Record<string, { name: string; code: string; description: string }> = {
+  commercial: { name: "Commercial", code: "C", description: "Standard commercial grade carcass" },
+  economy: { name: "Economy", code: "X", description: "Economy grade - lower quality carcass" },
+  manufacturing: { name: "Manufacturing", code: "J", description: "Manufacturing grade - processing meat" },
+}
+
+const teethLabels: Record<string, string> = {
+  MT: "Milk Teeth (young cattle, under 2 years)",
+  "2T": "2 Teeth (approx. 2-2.5 years)",
+  "4T": "4 Teeth (approx. 2.5-3 years)",
+  "6T": "6 Teeth (approx. 3-3.5 years)",
+}
+
+function formatUSD(value: number): string {
+  if (!value || value === 0) return "—"
+  return `$${value.toFixed(2)}`
+}
+
+function formatZIG(value: number): string {
+  if (!value || value === 0) return "—"
+  return `ZiG ${value.toFixed(2)}`
+}
+
+export function CdmPriceCard({ price }: CdmPriceCardProps) {
+  const formattedDate = formatDate(price.effectiveDate)
+
+  const weightRanges = [...new Set(price.liveweight.map((e) => e.weight_range))]
+  const teethCategories = [...new Set(price.liveweight.map((e) => e.teeth))]
+
+  const getLiveweightEntry = (weightRange: string, teeth: string): LiveweightEntry | undefined => {
+    return price.liveweight.find(
+      (e) => e.weight_range === weightRange && e.teeth === teeth
+    )
+  }
+
+  return (
+    <div className="rounded-lg border bg-card overflow-hidden">
+      {/* Header */}
+      <div className="px-5 py-4 border-b">
+        <div className="flex items-start justify-between">
+          <div>
+            <h3 className="text-lg font-semibold text-foreground">
+              {capitalizeFirstLetter(price.client_name)}
+            </h3>
+            <div className="flex items-center gap-1.5 mt-1 text-xs text-muted-foreground">
+              <Building2 className="h-3.5 w-3.5" />
+              <span>Cold Dress Mass Pricing</span>
+            </div>
+          </div>
+          <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider bg-muted px-2 py-1 rounded">
+            CDM
+          </span>
+        </div>
+
+        <div className="flex items-center gap-4 mt-3 text-xs text-muted-foreground">
+          <span className="flex items-center gap-1.5">
+            <Calendar className="h-3.5 w-3.5" />
+            Effective: {formattedDate}
+          </span>
+          {price.exchange_rate > 0 && (
+            <span className="ml-auto">
+              Rate: 1 USD = {price.exchange_rate.toFixed(2)} ZiG
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="divide-y">
+        {/* Carcass Grades Table */}
+        <div>
+          <div className="px-5 py-2.5 bg-muted/30 border-b">
+            <h4 className="text-sm font-semibold text-foreground">
+              Carcass Grades (per kg)
+            </h4>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="min-w-full">
+              <thead>
+                <tr className="border-b">
+                  <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                    Grade
+                  </th>
+                  <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                    Code
+                  </th>
+                  <th className="px-4 py-2 text-right text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                    Collected USD
+                  </th>
+                  <th className="px-4 py-2 text-right text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                    Delivered USD
+                  </th>
+                  <th className="px-4 py-2 text-right text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                    Collected ZiG
+                  </th>
+                  <th className="px-4 py-2 text-right text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                    Delivered ZiG
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border/50">
+                {(["commercial", "economy", "manufacturing"] as const).map((grade) => {
+                  const gradeData = price.carcass_grades[grade]
+                  const label = gradeLabels[grade]
+                  return (
+                    <tr key={grade} className="hover:bg-muted/30 transition-colors">
+                      <td className="px-4 py-2.5 text-sm font-medium text-foreground">
+                        {label.name}
+                      </td>
+                      <td className="px-4 py-2.5">
+                        <span className="inline-flex items-center justify-center rounded px-2 py-0.5 text-xs font-semibold bg-muted text-muted-foreground min-w-[32px]">
+                          {label.code}
+                        </span>
+                      </td>
+                      <td className="px-4 py-2.5 text-right text-sm text-muted-foreground">
+                        {formatUSD(gradeData.collected_usd)}
+                      </td>
+                      <td className="px-4 py-2.5 text-right text-sm font-semibold text-foreground">
+                        {formatUSD(gradeData.delivered_usd)}
+                      </td>
+                      <td className="px-4 py-2.5 text-right text-sm text-muted-foreground">
+                        {formatZIG(gradeData.collected_zig)}
+                      </td>
+                      <td className="px-4 py-2.5 text-right text-sm font-semibold text-foreground">
+                        {formatZIG(gradeData.delivered_zig)}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* Liveweight Matrix Table */}
+        {price.liveweight && price.liveweight.length > 0 && (
+          <div>
+            <div className="px-5 py-2.5 bg-muted/30 border-b">
+              <h4 className="text-sm font-semibold text-foreground">
+                Liveweight Prices (per kg delivered)
+              </h4>
+            </div>
+            <div className="overflow-x-auto">
+                <table className="min-w-full">
+                  <thead>
+                    <tr className="border-b">
+                      <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                        Weight (kg)
+                      </th>
+                      {teethCategories.map((teeth) => (
+                        <th key={teeth} className="px-4 py-2 text-center text-[11px] font-medium uppercase tracking-wider text-muted-foreground" colSpan={2}>
+                          <span className="inline-flex items-center gap-1 cursor-help" title={teethLabels[teeth] || teeth}>
+                            {teeth}
+                            <Info className="h-3 w-3" />
+                          </span>
+                        </th>
+                      ))}
+                    </tr>
+                    <tr className="border-b bg-muted/10">
+                      <th></th>
+                      {teethCategories.map((teeth) => (
+                        <Fragment key={`${teeth}-sub`}>
+                          <th className="px-2 py-1.5 text-center text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                            USD
+                          </th>
+                          <th className="px-2 py-1.5 text-center text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                            ZiG
+                          </th>
+                        </Fragment>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border/50">
+                    {weightRanges.map((range) => (
+                      <tr key={range} className="hover:bg-muted/30 transition-colors">
+                        <td className="px-4 py-2.5 text-sm font-medium text-foreground whitespace-nowrap">
+                          {range}
+                        </td>
+                        {teethCategories.map((teeth) => {
+                          const entry = getLiveweightEntry(range, teeth)
+                          return (
+                            <Fragment key={`${range}-${teeth}`}>
+                              <td className="px-2 py-2.5 text-center text-sm font-semibold text-foreground">
+                                {entry ? formatUSD(entry.delivered_usd) : "—"}
+                              </td>
+                              <td className="px-2 py-2.5 text-center text-sm text-muted-foreground">
+                                {entry ? formatZIG(entry.delivered_zig) : "—"}
+                              </td>
+                            </Fragment>
+                          )
+                        })}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+            </div>
+
+            {/* Grade notes */}
+            {price.liveweight.some((e) => e.grade_note) && (
+              <div className="px-5 py-3 border-t bg-muted/10">
+                <p className="text-xs text-muted-foreground font-medium mb-1.5">Grade Notes:</p>
+                <div className="flex flex-wrap gap-1.5">
+                  {[...new Set(price.liveweight.filter((e) => e.grade_note).map((e) => `${e.weight_range} ${e.teeth}: ${e.grade_note}`))].map((note, i) => (
+                    <span key={i} className="text-[11px] text-muted-foreground bg-muted px-2 py-0.5 rounded">
+                      {note}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Notes */}
+        {price.notes && price.notes.length > 0 && (
+          <div>
+            <div className="px-5 py-2.5 bg-muted/30 border-b">
+              <h4 className="text-sm font-semibold text-foreground">Notes</h4>
+            </div>
+            <ul className="px-5 py-3 space-y-1">
+              {price.notes.map((note, i) => (
+                <li key={i} className="text-sm text-muted-foreground flex items-start gap-2">
+                  <span className="text-muted-foreground/60 mt-0.5">•</span>
+                  {note}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/client-fnp/components/structures/cdm-price-card.tsx
+++ b/apps/client-fnp/components/structures/cdm-price-card.tsx
@@ -1,25 +1,47 @@
 "use client"
 
-import { Fragment } from "react"
-import { formatDate, capitalizeFirstLetter } from "@/lib/utilities"
-import { Calendar, Building2, Info } from "lucide-react"
+import { formatDate, capitalizeFirstLetter, cn } from "@/lib/utilities"
+import { Calendar, Building2 } from "lucide-react"
 import { CdmPrice, LiveweightEntry } from "@/lib/schemas"
 
 interface CdmPriceCardProps {
   price: CdmPrice
+  hideHeader?: boolean
 }
 
-const gradeLabels: Record<string, { name: string; code: string; description: string }> = {
-  commercial: { name: "Commercial", code: "C", description: "Standard commercial grade carcass" },
-  economy: { name: "Economy", code: "X", description: "Economy grade - lower quality carcass" },
-  manufacturing: { name: "Manufacturing", code: "J", description: "Manufacturing grade - processing meat" },
+const gradeLabels: Record<string, { name: string; code: string }> = {
+  commercial: { name: "Commercial", code: "C" },
+  economy: { name: "Economy", code: "X" },
+  manufacturing: { name: "Manufacturing", code: "J" },
 }
 
-const teethLabels: Record<string, string> = {
-  MT: "Milk Teeth (young cattle, under 2 years)",
-  "2T": "2 Teeth (approx. 2-2.5 years)",
-  "4T": "4 Teeth (approx. 2.5-3 years)",
-  "6T": "6 Teeth (approx. 3-3.5 years)",
+const gradeColors = [
+  "text-green-700 bg-green-50 ring-green-600/20 dark:text-green-400 dark:bg-green-950/30 dark:ring-green-500/20",
+  "text-yellow-700 bg-yellow-50 ring-yellow-600/20 dark:text-yellow-400 dark:bg-yellow-950/30 dark:ring-yellow-500/20",
+  "text-orange-700 bg-orange-50 ring-orange-600/20 dark:text-orange-400 dark:bg-orange-950/30 dark:ring-orange-500/20",
+]
+
+const teethInfo: Record<string, { name: string; description: string; color: string }> = {
+  MT: {
+    name: "Milk Teeth",
+    description: "Young cattle, under 2 years",
+    color: "text-emerald-700 bg-emerald-50 ring-emerald-600/20 dark:text-emerald-400 dark:bg-emerald-950/30 dark:ring-emerald-500/20",
+  },
+  "2T": {
+    name: "2 Teeth",
+    description: "Approx. 2–2.5 years",
+    color: "text-blue-700 bg-blue-50 ring-blue-600/20 dark:text-blue-400 dark:bg-blue-950/30 dark:ring-blue-500/20",
+  },
+  "4T": {
+    name: "4 Teeth",
+    description: "Approx. 2.5–3 years",
+    color: "text-amber-700 bg-amber-50 ring-amber-600/20 dark:text-amber-400 dark:bg-amber-950/30 dark:ring-amber-500/20",
+  },
+  "6T": {
+    name: "6 Teeth",
+    description: "Approx. 3–3.5 years",
+    color: "text-red-700 bg-red-50 ring-red-600/20 dark:text-red-400 dark:bg-red-950/30 dark:ring-red-500/20",
+  },
 }
 
 function formatUSD(value: number): string {
@@ -32,7 +54,7 @@ function formatZIG(value: number): string {
   return `ZiG ${value.toFixed(2)}`
 }
 
-export function CdmPriceCard({ price }: CdmPriceCardProps) {
+export function CdmPriceCard({ price, hideHeader }: CdmPriceCardProps) {
   const formattedDate = formatDate(price.effectiveDate)
 
   const weightRanges = [...new Set(price.liveweight.map((e) => e.weight_range))]
@@ -45,199 +67,238 @@ export function CdmPriceCard({ price }: CdmPriceCardProps) {
   }
 
   return (
-    <div className="rounded-lg border bg-card overflow-hidden">
+    <div className="space-y-6">
       {/* Header */}
-      <div className="px-5 py-4 border-b">
-        <div className="flex items-start justify-between">
-          <div>
-            <h3 className="text-lg font-semibold text-foreground">
-              {capitalizeFirstLetter(price.client_name)}
-            </h3>
-            <div className="flex items-center gap-1.5 mt-1 text-xs text-muted-foreground">
-              <Building2 className="h-3.5 w-3.5" />
-              <span>Cold Dress Mass Pricing</span>
-            </div>
-          </div>
-          <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider bg-muted px-2 py-1 rounded">
-            CDM
-          </span>
-        </div>
-
-        <div className="flex items-center gap-4 mt-3 text-xs text-muted-foreground">
-          <span className="flex items-center gap-1.5">
-            <Calendar className="h-3.5 w-3.5" />
-            Effective: {formattedDate}
-          </span>
-          {price.exchange_rate > 0 && (
-            <span className="ml-auto">
-              Rate: 1 USD = {price.exchange_rate.toFixed(2)} ZiG
-            </span>
-          )}
-        </div>
-      </div>
-
-      <div className="divide-y">
-        {/* Carcass Grades Table */}
-        <div>
-          <div className="px-5 py-2.5 bg-muted/30 border-b">
-            <h4 className="text-sm font-semibold text-foreground">
-              Carcass Grades (per kg)
-            </h4>
-          </div>
-          <div className="overflow-x-auto">
-            <table className="min-w-full">
-              <thead>
-                <tr className="border-b">
-                  <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-                    Grade
-                  </th>
-                  <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-                    Code
-                  </th>
-                  <th className="px-4 py-2 text-right text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-                    Collected USD
-                  </th>
-                  <th className="px-4 py-2 text-right text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-                    Delivered USD
-                  </th>
-                  <th className="px-4 py-2 text-right text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-                    Collected ZiG
-                  </th>
-                  <th className="px-4 py-2 text-right text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-                    Delivered ZiG
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-border/50">
-                {(["commercial", "economy", "manufacturing"] as const).map((grade) => {
-                  const gradeData = price.carcass_grades[grade]
-                  const label = gradeLabels[grade]
-                  return (
-                    <tr key={grade} className="hover:bg-muted/30 transition-colors">
-                      <td className="px-4 py-2.5 text-sm font-medium text-foreground">
-                        {label.name}
-                      </td>
-                      <td className="px-4 py-2.5">
-                        <span className="inline-flex items-center justify-center rounded px-2 py-0.5 text-xs font-semibold bg-muted text-muted-foreground min-w-[32px]">
-                          {label.code}
-                        </span>
-                      </td>
-                      <td className="px-4 py-2.5 text-right text-sm text-muted-foreground">
-                        {formatUSD(gradeData.collected_usd)}
-                      </td>
-                      <td className="px-4 py-2.5 text-right text-sm font-semibold text-foreground">
-                        {formatUSD(gradeData.delivered_usd)}
-                      </td>
-                      <td className="px-4 py-2.5 text-right text-sm text-muted-foreground">
-                        {formatZIG(gradeData.collected_zig)}
-                      </td>
-                      <td className="px-4 py-2.5 text-right text-sm font-semibold text-foreground">
-                        {formatZIG(gradeData.delivered_zig)}
-                      </td>
-                    </tr>
-                  )
-                })}
-              </tbody>
-            </table>
-          </div>
-        </div>
-
-        {/* Liveweight Matrix Table */}
-        {price.liveweight && price.liveweight.length > 0 && (
-          <div>
-            <div className="px-5 py-2.5 bg-muted/30 border-b">
-              <h4 className="text-sm font-semibold text-foreground">
-                Liveweight Prices (per kg delivered)
-              </h4>
-            </div>
-            <div className="overflow-x-auto">
-                <table className="min-w-full">
-                  <thead>
-                    <tr className="border-b">
-                      <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-                        Weight (kg)
-                      </th>
-                      {teethCategories.map((teeth) => (
-                        <th key={teeth} className="px-4 py-2 text-center text-[11px] font-medium uppercase tracking-wider text-muted-foreground" colSpan={2}>
-                          <span className="inline-flex items-center gap-1 cursor-help" title={teethLabels[teeth] || teeth}>
-                            {teeth}
-                            <Info className="h-3 w-3" />
-                          </span>
-                        </th>
-                      ))}
-                    </tr>
-                    <tr className="border-b bg-muted/10">
-                      <th></th>
-                      {teethCategories.map((teeth) => (
-                        <Fragment key={`${teeth}-sub`}>
-                          <th className="px-2 py-1.5 text-center text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-                            USD
-                          </th>
-                          <th className="px-2 py-1.5 text-center text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-                            ZiG
-                          </th>
-                        </Fragment>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-border/50">
-                    {weightRanges.map((range) => (
-                      <tr key={range} className="hover:bg-muted/30 transition-colors">
-                        <td className="px-4 py-2.5 text-sm font-medium text-foreground whitespace-nowrap">
-                          {range}
-                        </td>
-                        {teethCategories.map((teeth) => {
-                          const entry = getLiveweightEntry(range, teeth)
-                          return (
-                            <Fragment key={`${range}-${teeth}`}>
-                              <td className="px-2 py-2.5 text-center text-sm font-semibold text-foreground">
-                                {entry ? formatUSD(entry.delivered_usd) : "—"}
-                              </td>
-                              <td className="px-2 py-2.5 text-center text-sm text-muted-foreground">
-                                {entry ? formatZIG(entry.delivered_zig) : "—"}
-                              </td>
-                            </Fragment>
-                          )
-                        })}
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-            </div>
-
-            {/* Grade notes */}
-            {price.liveweight.some((e) => e.grade_note) && (
-              <div className="px-5 py-3 border-t bg-muted/10">
-                <p className="text-xs text-muted-foreground font-medium mb-1.5">Grade Notes:</p>
-                <div className="flex flex-wrap gap-1.5">
-                  {[...new Set(price.liveweight.filter((e) => e.grade_note).map((e) => `${e.weight_range} ${e.teeth}: ${e.grade_note}`))].map((note, i) => (
-                    <span key={i} className="text-[11px] text-muted-foreground bg-muted px-2 py-0.5 rounded">
-                      {note}
-                    </span>
-                  ))}
-                </div>
+      {!hideHeader && (
+        <div className="rounded-lg border bg-card px-5 py-4">
+          <div className="flex items-start justify-between">
+            <div>
+              <h3 className="text-lg font-semibold text-foreground">
+                {capitalizeFirstLetter(price.client_name)}
+              </h3>
+              <div className="flex items-center gap-1.5 mt-1 text-xs text-muted-foreground">
+                <Building2 className="h-3.5 w-3.5" />
+                <span>Cold Dress Mass Pricing</span>
               </div>
+            </div>
+            <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider bg-muted px-2 py-1 rounded">
+              CDM
+            </span>
+          </div>
+
+          <div className="flex items-center gap-4 mt-3 text-xs text-muted-foreground">
+            <span className="flex items-center gap-1.5">
+              <Calendar className="h-3.5 w-3.5" />
+              Effective: {formattedDate}
+            </span>
+            {price.exchange_rate > 0 && (
+              <span className="ml-auto">
+                Rate: 1 USD = {price.exchange_rate.toFixed(2)} ZiG
+              </span>
             )}
           </div>
-        )}
+        </div>
+      )}
 
-        {/* Notes */}
-        {price.notes && price.notes.length > 0 && (
-          <div>
-            <div className="px-5 py-2.5 bg-muted/30 border-b">
-              <h4 className="text-sm font-semibold text-foreground">Notes</h4>
-            </div>
-            <ul className="px-5 py-3 space-y-1">
-              {price.notes.map((note, i) => (
-                <li key={i} className="text-sm text-muted-foreground flex items-start gap-2">
-                  <span className="text-muted-foreground/60 mt-0.5">•</span>
-                  {note}
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
+      {/* Carcass Grades */}
+      <div className="rounded-lg border bg-card overflow-hidden">
+        <div className="px-5 py-2.5 bg-muted/30 border-b">
+          <h4 className="text-sm font-semibold text-foreground">
+            Carcass Grades (per kg)
+          </h4>
+          <p className="text-[11px] text-muted-foreground mt-0.5">Ex Leakage — prices exclude carcass fluid loss</p>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="min-w-full">
+            <thead>
+              <tr className="border-b">
+                <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Grade</th>
+                <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Code</th>
+                <th className="px-4 py-2 text-right text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Collected USD</th>
+                <th className="px-4 py-2 text-right text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Delivered USD</th>
+                <th className="px-4 py-2 text-right text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Collected ZiG</th>
+                <th className="px-4 py-2 text-right text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Delivered ZiG</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border/50">
+              {(["commercial", "economy", "manufacturing"] as const).map((grade, idx) => {
+                const gradeData = price.carcass_grades[grade]
+                const label = gradeLabels[grade]
+                return (
+                  <tr key={grade} className={cn("transition-colors", idx % 2 === 1 && "bg-muted/15")}>
+                    <td className="px-4 py-2.5 text-sm font-medium text-foreground">{label.name}</td>
+                    <td className="px-4 py-2.5">
+                      <span className={cn(gradeColors[idx], "inline-flex items-center justify-center rounded-md px-2 py-0.5 text-xs font-bold ring-1 ring-inset min-w-[32px]")}>
+                        {label.code}
+                      </span>
+                    </td>
+                    <td className="px-4 py-2.5 text-right text-sm text-muted-foreground">{formatUSD(gradeData.collected_usd)}</td>
+                    <td className="px-4 py-2.5 text-right text-sm font-semibold text-foreground">{formatUSD(gradeData.delivered_usd)}</td>
+                    <td className="px-4 py-2.5 text-right text-sm text-muted-foreground">{formatZIG(gradeData.collected_zig)}</td>
+                    <td className="px-4 py-2.5 text-right text-sm font-semibold text-foreground">{formatZIG(gradeData.delivered_zig)}</td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
       </div>
+
+      {/* Liveweight Section */}
+      {price.liveweight && price.liveweight.length > 0 && (
+        <div className="space-y-4">
+          <h4 className="text-sm font-semibold text-foreground uppercase tracking-wide">
+            Steers + Heifers Liveweight (per kg delivered)
+          </h4>
+
+          {teethCategories.map((teeth) => {
+            const info = teethInfo[teeth]
+            if (!info) return null
+
+            const entries = price.liveweight.filter((e) => e.teeth === teeth)
+            const hasAnyPrice = entries.some((e) => e.delivered_usd > 0 || e.delivered_zig > 0)
+            const isMeaningfulNote = (note: string) => note && !/^\d*\s*teeth\s+liveweight$/i.test(note) && !/^milk\s+teeth\s+liveweight$/i.test(note)
+            const hasAnyNote = entries.some((e) => isMeaningfulNote(e.grade_note))
+
+            // Classification-only (no prices) — table with Weight + Status
+            if (!hasAnyPrice && hasAnyNote) {
+              return (
+                <div key={teeth} className="rounded-lg border bg-card overflow-hidden">
+                  <div className="px-5 py-2.5 bg-muted/30 border-b flex items-center gap-3">
+                    <h5 className="text-sm font-semibold text-foreground">{info.name}</h5>
+                    <span className={cn(info.color, "rounded-md px-2 py-0.5 text-[10px] font-bold ring-1 ring-inset")}>
+                      {teeth}
+                    </span>
+                    <span className="text-xs text-muted-foreground">{info.description}</span>
+                  </div>
+                  <div className="overflow-x-auto">
+                    <table className="min-w-full">
+                      <thead>
+                        <tr className="border-b">
+                          <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Weight (kg)</th>
+                          <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Status</th>
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-border/50">
+                        {weightRanges.map((range, i) => {
+                          const entry = getLiveweightEntry(range, teeth)
+                          const note = entry?.grade_note || ""
+                          const cleanNote = note.replace(/^\d+\s*teeth\s*-\s*/i, "")
+                          const isCondemn = note.toLowerCase().includes("condemn")
+                          const isKill = note.toLowerCase().includes("kill") || note.toLowerCase().includes("low grade")
+
+                          return (
+                            <tr key={range} className={cn("transition-colors", i % 2 === 1 && "bg-muted/15")}>
+                              <td className="px-4 py-2.5 text-sm font-medium text-foreground whitespace-nowrap">{range}</td>
+                              <td className="px-4 py-2.5">
+                                {cleanNote ? (
+                                  <span className={cn(
+                                    "inline-flex items-center rounded-md px-2.5 py-1 text-xs font-medium ring-1 ring-inset",
+                                    isCondemn
+                                      ? "text-red-700 bg-red-50 ring-red-600/20 dark:text-red-400 dark:bg-red-950/30"
+                                      : isKill
+                                        ? "text-amber-700 bg-amber-50 ring-amber-600/20 dark:text-amber-400 dark:bg-amber-950/30"
+                                        : "text-muted-foreground bg-muted ring-border"
+                                  )}>
+                                    {cleanNote}
+                                  </span>
+                                ) : "—"}
+                              </td>
+                            </tr>
+                          )
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              )
+            }
+
+            // Has prices — full table
+            return (
+              <div key={teeth} className="rounded-lg border bg-card overflow-hidden">
+                <div className="px-5 py-2.5 bg-muted/30 border-b flex items-center gap-3">
+                  <h5 className="text-sm font-semibold text-foreground">{info.name}</h5>
+                  <span className={cn(info.color, "rounded-md px-2 py-0.5 text-[10px] font-bold ring-1 ring-inset")}>
+                    {teeth}
+                  </span>
+                  <span className="text-xs text-muted-foreground">{info.description}</span>
+                </div>
+                <div className="overflow-x-auto">
+                  <table className="min-w-full">
+                    <thead>
+                      <tr className="border-b">
+                        <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Weight (kg)</th>
+                        <th className="px-4 py-2 text-right text-[11px] font-medium uppercase tracking-wider text-muted-foreground">USD</th>
+                        <th className="px-4 py-2 text-right text-[11px] font-medium uppercase tracking-wider text-muted-foreground">ZiG</th>
+                        {hasAnyNote && (
+                          <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Status</th>
+                        )}
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-border/50">
+                      {weightRanges.map((range, i) => {
+                        const entry = getLiveweightEntry(range, teeth)
+                        const hasPrice = entry && (entry.delivered_usd > 0 || entry.delivered_zig > 0)
+                        const note = entry?.grade_note || ""
+                        const cleanNote = note.replace(/^\d+\s*teeth\s*-\s*/i, "")
+                        const isCondemn = note.toLowerCase().includes("condemn")
+                        const isKill = note.toLowerCase().includes("kill") || note.toLowerCase().includes("low grade")
+
+                        return (
+                          <tr key={range} className={cn("transition-colors", i % 2 === 1 && "bg-muted/15")}>
+                            <td className="px-4 py-2.5 text-sm font-medium text-foreground whitespace-nowrap">{range}</td>
+                            <td className="px-4 py-2.5 text-right text-sm font-semibold text-foreground">
+                              {hasPrice ? formatUSD(entry!.delivered_usd) : "—"}
+                            </td>
+                            <td className="px-4 py-2.5 text-right text-sm text-muted-foreground">
+                              {hasPrice ? formatZIG(entry!.delivered_zig) : "—"}
+                            </td>
+                            {hasAnyNote && (
+                              <td className="px-4 py-2.5">
+                                {cleanNote ? (
+                                  <span className={cn(
+                                    "inline-flex items-center rounded-md px-2.5 py-1 text-xs font-medium ring-1 ring-inset",
+                                    isCondemn
+                                      ? "text-red-700 bg-red-50 ring-red-600/20 dark:text-red-400 dark:bg-red-950/30"
+                                      : isKill
+                                        ? "text-amber-700 bg-amber-50 ring-amber-600/20 dark:text-amber-400 dark:bg-amber-950/30"
+                                        : "text-muted-foreground bg-muted ring-border"
+                                  )}>
+                                    {cleanNote}
+                                  </span>
+                                ) : hasPrice ? (
+                                  <span className="inline-flex items-center rounded-md px-2.5 py-1 text-xs font-medium ring-1 ring-inset text-emerald-700 bg-emerald-50 ring-emerald-600/20 dark:text-emerald-400 dark:bg-emerald-950/30">
+                                    Accepted
+                                  </span>
+                                ) : "—"}
+                              </td>
+                            )}
+                          </tr>
+                        )
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {/* Notes */}
+      {price.notes && price.notes.length > 0 && (
+        <div className="rounded-lg border bg-card px-5 py-4">
+          <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">Important Notes</h4>
+          <div className="space-y-2">
+            {price.notes.map((note, i) => (
+              <p key={i} className="text-sm text-muted-foreground leading-relaxed">
+                {note}
+              </p>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/client-fnp/components/structures/cdm-price-cards-view.tsx
+++ b/apps/client-fnp/components/structures/cdm-price-cards-view.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import { useState } from "react"
+import { useQuery } from "@tanstack/react-query"
+
+import { queryCdmPrices } from "@/lib/query"
+import { CdmPrice } from "@/lib/schemas"
+import { CdmPriceCard } from "@/components/structures/cdm-price-card"
+import { Button } from "@/components/ui/button"
+import { Icons } from "@/components/icons/lucide"
+
+export function CdmPriceCardsView() {
+  const [page, setPage] = useState(1)
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["cdm-prices", { p: page }],
+    queryFn: () => queryCdmPrices({ p: page }),
+    refetchOnWindowFocus: false,
+  })
+
+  const prices: CdmPrice[] = data?.data?.data || []
+  const total = data?.data?.total || 0
+  const hasMore = prices.length > 0 && page * 20 < total
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Icons.spinner className="h-6 w-6 animate-spin text-primary" />
+      </div>
+    )
+  }
+
+  if (isError || prices.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-xl font-bold font-heading">CDM Cattle Pricing</h2>
+      <div className="grid gap-6">
+        {prices.map((price) => (
+          <CdmPriceCard key={price.id} price={price} />
+        ))}
+      </div>
+      {hasMore && (
+        <div className="flex justify-center pt-4">
+          <Button variant="outline" onClick={() => setPage((p) => p + 1)}>
+            Load More
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/client-fnp/components/structures/cdm-price-cards-view.tsx
+++ b/apps/client-fnp/components/structures/cdm-price-cards-view.tsx
@@ -1,51 +1,159 @@
 "use client"
 
-import { useState } from "react"
+import { Fragment, useState, useMemo } from "react"
 import { useQuery } from "@tanstack/react-query"
 
 import { queryCdmPrices } from "@/lib/query"
 import { CdmPrice } from "@/lib/schemas"
-import { CdmPriceCard } from "@/components/structures/cdm-price-card"
+import { CdmPriceSummaryCard } from "@/components/structures/cdm-price-summary-card"
+import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
 import { Button } from "@/components/ui/button"
-import { Icons } from "@/components/icons/lucide"
+import { Input } from "@/components/ui/input"
+import { ArrowRight, ChevronLeft, ChevronRight, Search, X } from "lucide-react"
+import Link from "next/link"
 
-export function CdmPriceCardsView() {
-  const [page, setPage] = useState(1)
+interface CdmPriceCardsViewProps {
+  limit?: number
+  viewAllHref?: string
+}
+
+export function CdmPriceCardsView({ limit, viewAllHref }: CdmPriceCardsViewProps = {}) {
+  const [currentPage, setCurrentPage] = useState(1)
+  const [search, setSearch] = useState("")
 
   const { data, isLoading, isError } = useQuery({
-    queryKey: ["cdm-prices", { p: page }],
-    queryFn: () => queryCdmPrices({ p: page }),
+    queryKey: ["cdm-prices", { p: currentPage, limit }],
+    queryFn: () => queryCdmPrices({ p: currentPage, ...(limit ? { limit } : {}) }),
     refetchOnWindowFocus: false,
   })
 
-  const prices: CdmPrice[] = data?.data?.data || []
+  const allPrices: CdmPrice[] = data?.data?.data || []
   const total = data?.data?.total || 0
-  const hasMore = prices.length > 0 && page * 20 < total
 
-  if (isLoading) {
+  const prices = useMemo(() => {
+    if (!search || limit) return allPrices
+    const q = search.toLowerCase()
+    return allPrices.filter(p => p.client_name?.toLowerCase().includes(q))
+  }, [allPrices, search, limit])
+
+  const totalPages = Math.ceil(total / (limit || 20))
+
+  if (isError) {
     return (
-      <div className="flex items-center justify-center py-12">
-        <Icons.spinner className="h-6 w-6 animate-spin text-primary" />
+      <div className="text-center py-8 px-4">
+        <p className="text-sm font-medium mb-1">Error loading CDM prices</p>
+        <p className="text-xs text-muted-foreground">Please try refreshing the page</p>
       </div>
     )
   }
 
-  if (isError || prices.length === 0) {
+  if (isLoading) {
+    return (
+      <div className={limit ? "divide-y" : "space-y-3"}>
+        {[...Array(limit || 4)].map((_, i) => (
+          <div key={i} className={limit ? "py-3 px-1" : ""}>
+            <div className={`h-[52px] rounded-lg ${limit ? "bg-muted/20" : "border bg-muted/30"} animate-pulse`} />
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  if (prices.length === 0) {
     return null
   }
 
+  // Preview mode — clean divider list inside parent card
+  if (limit) {
+    return (
+      <div>
+        <div className="divide-y">
+          {prices.map((price) => (
+            <CdmPriceSummaryCard key={price.id} price={price} />
+          ))}
+        </div>
+        {viewAllHref && total > limit && (
+          <div className="pt-3 mt-1">
+            <Link
+              href={viewAllHref}
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+            >
+              View all CDM prices
+              <ArrowRight className="h-3.5 w-3.5" />
+            </Link>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  // Full paginated mode
   return (
     <div className="space-y-6">
-      <h2 className="text-xl font-bold font-heading">CDM Cattle Pricing</h2>
-      <div className="grid gap-6">
-        {prices.map((price) => (
-          <CdmPriceCard key={price.id} price={price} />
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          Showing {prices.length} of {total}
+        </p>
+      </div>
+
+      <div className="space-y-3">
+        {prices.map((price, index) => (
+          <Fragment key={price.id}>
+            <CdmPriceSummaryCard price={price} />
+            {(index + 1) % 3 === 0 && index < prices.length - 1 && (
+              <AdSenseInFeed />
+            )}
+          </Fragment>
         ))}
       </div>
-      {hasMore && (
-        <div className="flex justify-center pt-4">
-          <Button variant="outline" onClick={() => setPage((p) => p + 1)}>
-            Load More
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-2 pt-6 border-t">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
+            disabled={currentPage === 1}
+          >
+            <ChevronLeft className="h-4 w-4 mr-1" />
+            Previous
+          </Button>
+
+          <div className="flex items-center gap-1">
+            {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
+              let pageNumber: number
+              if (totalPages <= 5) {
+                pageNumber = i + 1
+              } else if (currentPage <= 3) {
+                pageNumber = i + 1
+              } else if (currentPage >= totalPages - 2) {
+                pageNumber = totalPages - 4 + i
+              } else {
+                pageNumber = currentPage - 2 + i
+              }
+
+              return (
+                <Button
+                  key={pageNumber}
+                  variant={currentPage === pageNumber ? "default" : "ghost"}
+                  size="sm"
+                  onClick={() => setCurrentPage(pageNumber)}
+                  className="w-9"
+                >
+                  {pageNumber}
+                </Button>
+              )
+            })}
+          </div>
+
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
+            disabled={currentPage === totalPages}
+          >
+            Next
+            <ChevronRight className="h-4 w-4 ml-1" />
           </Button>
         </div>
       )}

--- a/apps/client-fnp/components/structures/cdm-price-summary-card.tsx
+++ b/apps/client-fnp/components/structures/cdm-price-summary-card.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import Link from "next/link"
+import { formatDate, capitalizeFirstLetter, slug } from "@/lib/utilities"
+import { ArrowRight, Calendar } from "lucide-react"
+import { CdmPrice } from "@/lib/schemas"
+
+interface CdmPriceSummaryCardProps {
+  price: CdmPrice
+}
+
+export function CdmPriceSummaryCard({ price }: CdmPriceSummaryCardProps) {
+  const formattedDate = formatDate(price.effectiveDate)
+  const dateSlug = new Date(price.effectiveDate).toISOString().split('T')[0]
+  const nameSlug = slug(price.client_name)
+  const priceSlug = `${nameSlug}-${dateSlug}`
+
+  return (
+    <Link href={`/prices/cdm/${priceSlug}`} className="block group">
+      <div className="flex items-center justify-between gap-3 py-3 px-1 hover:bg-muted/30 transition-colors">
+        <div className="min-w-0">
+          <h3 className="text-sm font-semibold text-foreground truncate group-hover:text-primary transition-colors">
+            {capitalizeFirstLetter(price.client_name)}
+          </h3>
+          <div className="flex items-center gap-1.5 mt-0.5 text-xs text-muted-foreground">
+            <Calendar className="h-3 w-3 shrink-0" />
+            <span>{formattedDate}</span>
+          </div>
+        </div>
+        <ArrowRight className="h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 group-hover:translate-x-0.5 transition-all shrink-0" />
+      </div>
+    </Link>
+  )
+}

--- a/apps/client-fnp/components/structures/price-cards-view.tsx
+++ b/apps/client-fnp/components/structures/price-cards-view.tsx
@@ -7,9 +7,15 @@ import { queryProducerPriceLists } from "@/lib/query"
 import { Button } from "@/components/ui/button"
 import { PriceSummaryCard } from "@/components/structures/price-summary-card"
 import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
-import { ChevronLeft, ChevronRight } from "lucide-react"
+import { ArrowRight, ChevronLeft, ChevronRight } from "lucide-react"
+import Link from "next/link"
 
-export function PriceCardsView() {
+interface PriceCardsViewProps {
+  limit?: number
+  viewAllHref?: string
+}
+
+export function PriceCardsView({ limit, viewAllHref }: PriceCardsViewProps = {}) {
   const [currentPage, setCurrentPage] = useState(1)
 
   const [filters] = useQueryStates({
@@ -19,29 +25,31 @@ export function PriceCardsView() {
   })
 
   const { isError, isLoading, data } = useQuery({
-    queryKey: ["producer-price-lists", { p: currentPage, ...filters }],
-    queryFn: () => queryProducerPriceLists({ p: currentPage }),
+    queryKey: ["producer-price-lists", { p: currentPage, limit, ...filters }],
+    queryFn: () => queryProducerPriceLists({ p: currentPage, ...(limit ? { limit } : {}) }),
     refetchOnWindowFocus: false,
   })
 
   const producePriceLists = data?.data?.data || []
   const total = data?.data?.total || 0
-  const totalPages = Math.ceil(total / 20)
+  const totalPages = Math.ceil(total / (limit || 20))
 
   if (isError) {
     return (
-      <div className="text-center py-12 px-4 border-2 border-dashed border-destructive/30 rounded-xl">
-        <p className="text-lg font-medium mb-2">Error loading price lists</p>
-        <p className="text-sm text-muted-foreground">Please try refreshing the page</p>
+      <div className="text-center py-8 px-4">
+        <p className="text-sm font-medium mb-1">Error loading price lists</p>
+        <p className="text-xs text-muted-foreground">Please try refreshing the page</p>
       </div>
     )
   }
 
   if (isLoading) {
     return (
-      <div className="space-y-3">
-        {[...Array(6)].map((_, i) => (
-          <div key={i} className="h-16 rounded-xl border bg-card animate-pulse" />
+      <div className={limit ? "divide-y" : "space-y-3"}>
+        {[...Array(limit || 6)].map((_, i) => (
+          <div key={i} className={limit ? "py-3 px-1" : ""}>
+            <div className={`h-[52px] rounded-lg ${limit ? "bg-muted/20" : "border bg-muted/30"} animate-pulse`} />
+          </div>
         ))}
       </div>
     )
@@ -49,13 +57,38 @@ export function PriceCardsView() {
 
   if (producePriceLists.length === 0) {
     return (
-      <div className="text-center py-12 px-4 border-2 border-dashed rounded-xl">
-        <p className="text-lg font-medium mb-2">No price lists found</p>
-        <p className="text-sm text-muted-foreground">Check back later for updated prices</p>
+      <div className="text-center py-8 px-4">
+        <p className="text-sm font-medium mb-1">No price lists found</p>
+        <p className="text-xs text-muted-foreground">Check back later for updated prices</p>
       </div>
     )
   }
 
+  // Preview mode — clean divider list inside parent card
+  if (limit) {
+    return (
+      <div>
+        <div className="divide-y">
+          {producePriceLists.map((priceList: any) => (
+            <PriceSummaryCard key={priceList.id} priceList={priceList} />
+          ))}
+        </div>
+        {viewAllHref && total > limit && (
+          <div className="pt-3 mt-1">
+            <Link
+              href={viewAllHref}
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"
+            >
+              View all liveweight prices
+              <ArrowRight className="h-3.5 w-3.5" />
+            </Link>
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  // Full paginated mode
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">

--- a/apps/client-fnp/components/structures/price-details-grid.tsx
+++ b/apps/client-fnp/components/structures/price-details-grid.tsx
@@ -24,15 +24,6 @@ interface PriceDetailsGridProps {
 
 type ProducerPriceListKeys = "beef" | "lamb" | "mutton" | "goat" | "chicken" | "pork" | "slaughter"
 
-const statuses = [
-  "text-green-700 bg-green-50 ring-green-600/20 dark:text-green-400 dark:bg-green-950/30 dark:ring-green-500/20",
-  "text-lime-700 bg-lime-50 ring-lime-600/20 dark:text-lime-400 dark:bg-lime-950/30 dark:ring-lime-500/20",
-  "text-yellow-700 bg-yellow-50 ring-yellow-600/20 dark:text-yellow-400 dark:bg-yellow-950/30 dark:ring-yellow-500/20",
-  "text-amber-700 bg-amber-50 ring-amber-600/20 dark:text-amber-400 dark:bg-amber-950/30 dark:ring-amber-500/20",
-  "text-orange-700 bg-orange-50 ring-orange-600/20 dark:text-orange-400 dark:bg-orange-950/30 dark:ring-orange-500/20",
-  "text-red-700 bg-red-50 ring-red-600/10 dark:text-red-400 dark:bg-red-950/30 dark:ring-red-500/20",
-]
-
 const grades: Record<ProducerPriceListKeys, Record<string, string>> = {
   beef: { super: "S", choice: "O", commercial: "B", economy: "X", manufacturing: "J", condemned: "CD" },
   lamb: { superPremium: "SL", choice: "CL", standard: "TL", inferior: "IL" },
@@ -55,7 +46,6 @@ const formatGradeName = (key: string): string => {
 export function PriceDetailsGrid({ priceList }: PriceDetailsGridProps) {
   const categories = pricingTypes[priceList.client_specialization] || []
 
-  // Filter to only renderable categories
   const renderableCategories = categories.filter((pricingType) => {
     if (priceList[pricingType] === undefined) return false
     const categoryData = priceList[pricingType]
@@ -76,9 +66,9 @@ export function PriceDetailsGrid({ priceList }: PriceDetailsGridProps) {
         return (
           <div key={renderIndex}>
           {renderIndex > 0 && renderIndex % 2 === 0 && <AdSenseInFeed />}
-          <div className="rounded-xl border bg-card overflow-hidden shadow-sm">
-            <div className="px-6 py-3 bg-gradient-to-r from-muted/30 to-card border-b">
-              <h3 className="text-lg font-bold text-card-foreground">
+          <div className="rounded-lg border bg-card overflow-hidden">
+            <div className="px-5 py-3 border-b bg-muted/30">
+              <h3 className="text-sm font-semibold text-foreground uppercase tracking-wide">
                 {capitalizeFirstLetter(pricingType)}
               </h3>
             </div>
@@ -92,17 +82,17 @@ export function PriceDetailsGrid({ priceList }: PriceDetailsGridProps) {
                   <col className="w-[22.5%]" />
                 </colgroup>
                 <thead>
-                  <tr className="border-b border-border bg-muted/5">
-                    <th className="px-6 py-2 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  <tr className="border-b">
+                    <th className="px-5 py-2 text-left text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
                       Grade
                     </th>
-                    <th className="px-6 py-2 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                    <th className="px-5 py-2 text-left text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
                       Code
                     </th>
-                    <th className="px-6 py-2 text-right text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                    <th className="px-5 py-2 text-right text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
                       Delivered
                     </th>
-                    <th className="px-6 py-2 text-right text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                    <th className="px-5 py-2 text-right text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
                       Collected
                     </th>
                   </tr>
@@ -114,31 +104,25 @@ export function PriceDetailsGrid({ priceList }: PriceDetailsGridProps) {
                     const collectedPrice = gradeItem?.pricing?.collected || 0
 
                     return (
-                      <tr key={index} className="hover:bg-muted/5 transition-colors">
-                        <td className="px-6 py-2.5">
-                          <span className="text-sm font-semibold text-card-foreground">
+                      <tr key={index} className="hover:bg-muted/30 transition-colors">
+                        <td className="px-5 py-2.5">
+                          <span className="text-sm font-medium text-foreground">
                             {formatGradeName(key)}
                           </span>
                         </td>
-                        <td className="px-6 py-2.5">
-                          {grades?.[pricingType]?.[key] ? (
-                            <span className={cn(statuses[index % statuses.length], "inline-flex items-center justify-center rounded-md px-2 py-0.5 text-xs font-bold ring-1 ring-inset min-w-[40px]")}>
-                              {grades[pricingType][key]}
-                            </span>
-                          ) : (
-                            <span className="inline-flex items-center justify-center rounded-md px-2 py-0.5 text-xs font-bold ring-1 ring-inset min-w-[40px] text-gray-700 bg-gray-50 ring-gray-600/20 dark:text-gray-400 dark:bg-gray-950/30 dark:ring-gray-500/20">
-                              NG
-                            </span>
-                          )}
+                        <td className="px-5 py-2.5">
+                          <span className="inline-flex items-center justify-center rounded px-2 py-0.5 text-xs font-semibold bg-muted text-muted-foreground min-w-[36px]">
+                            {grades?.[pricingType]?.[key] || "—"}
+                          </span>
                         </td>
-                        <td className="px-6 py-2.5 text-right">
-                          <span className="text-sm font-bold text-card-foreground">
+                        <td className="px-5 py-2.5 text-right">
+                          <span className="text-sm font-semibold text-foreground">
                             {centsToDollars(deliveredPrice)}
                           </span>
                         </td>
-                        <td className="px-6 py-2.5 text-right">
-                          <span className="text-sm font-semibold text-muted-foreground">
-                            {collectedPrice > 0 ? centsToDollars(collectedPrice) : "-"}
+                        <td className="px-5 py-2.5 text-right">
+                          <span className="text-sm text-muted-foreground">
+                            {collectedPrice > 0 ? centsToDollars(collectedPrice) : "—"}
                           </span>
                         </td>
                       </tr>

--- a/apps/client-fnp/components/structures/price-details-grid.tsx
+++ b/apps/client-fnp/components/structures/price-details-grid.tsx
@@ -1,6 +1,15 @@
 "use client"
 
-import { capitalizeFirstLetter, centsToDollars, cn } from "@/lib/utilities"
+import { capitalizeFirstLetter, centsToDollars } from "@/lib/utilities"
+
+const gradeColors = [
+  "text-green-700 bg-green-50 ring-green-600/20 dark:text-green-400 dark:bg-green-950/30 dark:ring-green-500/20",
+  "text-lime-700 bg-lime-50 ring-lime-600/20 dark:text-lime-400 dark:bg-lime-950/30 dark:ring-lime-500/20",
+  "text-yellow-700 bg-yellow-50 ring-yellow-600/20 dark:text-yellow-400 dark:bg-yellow-950/30 dark:ring-yellow-500/20",
+  "text-amber-700 bg-amber-50 ring-amber-600/20 dark:text-amber-400 dark:bg-amber-950/30 dark:ring-amber-500/20",
+  "text-orange-700 bg-orange-50 ring-orange-600/20 dark:text-orange-400 dark:bg-orange-950/30 dark:ring-orange-500/20",
+  "text-red-700 bg-red-50 ring-red-600/10 dark:text-red-400 dark:bg-red-950/30 dark:ring-red-500/20",
+]
 import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
 
 interface PriceListData {
@@ -111,7 +120,7 @@ export function PriceDetailsGrid({ priceList }: PriceDetailsGridProps) {
                           </span>
                         </td>
                         <td className="px-5 py-2.5">
-                          <span className="inline-flex items-center justify-center rounded px-2 py-0.5 text-xs font-semibold bg-muted text-muted-foreground min-w-[36px]">
+                          <span className={`inline-flex items-center justify-center rounded-md px-2 py-0.5 text-xs font-bold ring-1 ring-inset min-w-[36px] ${gradeColors[index % gradeColors.length]}`}>
                             {grades?.[pricingType]?.[key] || "—"}
                           </span>
                         </td>

--- a/apps/client-fnp/components/structures/price-summary-card.tsx
+++ b/apps/client-fnp/components/structures/price-summary-card.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { formatDate, capitalizeFirstLetter, slug } from "@/lib/utilities"
-import { ArrowRight } from "lucide-react"
+import { ArrowRight, Calendar } from "lucide-react"
 
 interface PriceListData {
   id: string
@@ -28,18 +28,6 @@ type ProducerPriceListKeys = "beef" | "lamb" | "mutton" | "goat" | "chicken" | "
 
 const produceKeys: ProducerPriceListKeys[] = ["beef", "lamb", "mutton", "goat", "chicken", "pork", "slaughter"]
 
-const specializationColors: Record<string, { bg: string; accent: string; text: string }> = {
-  livestock: { bg: "bg-amber-50 dark:bg-amber-950/20", accent: "bg-amber-500", text: "text-amber-700 dark:text-amber-400" },
-  poultry: { bg: "bg-orange-50 dark:bg-orange-950/20", accent: "bg-orange-500", text: "text-orange-700 dark:text-orange-400" },
-  dairy: { bg: "bg-blue-50 dark:bg-blue-950/20", accent: "bg-blue-500", text: "text-blue-700 dark:text-blue-400" },
-  horticulture: { bg: "bg-green-50 dark:bg-green-950/20", accent: "bg-green-500", text: "text-green-700 dark:text-green-400" },
-  grain: { bg: "bg-yellow-50 dark:bg-yellow-950/20", accent: "bg-yellow-500", text: "text-yellow-700 dark:text-yellow-400" },
-  aquaculture: { bg: "bg-cyan-50 dark:bg-cyan-950/20", accent: "bg-cyan-500", text: "text-cyan-700 dark:text-cyan-400" },
-  plantation: { bg: "bg-emerald-50 dark:bg-emerald-950/20", accent: "bg-emerald-500", text: "text-emerald-700 dark:text-emerald-400" },
-}
-
-const defaultColors = { bg: "bg-slate-50 dark:bg-slate-950/20", accent: "bg-slate-500", text: "text-slate-700 dark:text-slate-400" }
-
 export function PriceSummaryCard({ priceList }: PriceSummaryCardProps) {
   const formattedDate = formatDate(priceList.effectiveDate.toString())
   const dateSlug = new Date(priceList.effectiveDate).toISOString().split('T')[0]
@@ -50,35 +38,34 @@ export function PriceSummaryCard({ priceList }: PriceSummaryCardProps) {
     (key) => priceList[key] !== undefined && priceList[key] !== null
   )
 
-  const colors = specializationColors[priceList.client_specialization?.toLowerCase()] || defaultColors
-
   return (
     <Link href={`/prices/${priceSlug}`} className="block group">
-      <div className={`relative rounded-xl ${colors.bg} border border-transparent hover:border-primary/20 p-4 transition-all duration-200 hover:shadow-md`}>
-        <div className={`absolute left-0 top-4 bottom-4 w-1 rounded-r-full ${colors.accent}`} />
-
-        <div className="pl-4 flex items-center justify-between">
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-3 mb-1">
-              <h3 className="text-base font-semibold text-card-foreground truncate">
-                {capitalizeFirstLetter(priceList.client_name)}
-              </h3>
-              <span className={`text-[11px] font-medium uppercase tracking-wider ${colors.text} shrink-0`}>
-                {capitalizeFirstLetter(priceList.client_specialization)}
-              </span>
-            </div>
-
-            <div className="flex items-center gap-4 text-sm text-muted-foreground">
-              <span className="text-green-600 dark:text-green-400">{formattedDate}</span>
-              <span className="hidden sm:inline">{availableProduce.map(p => capitalizeFirstLetter(p)).join(", ")}</span>
-              {priceList.pricing_basis && (
-                <span className="hidden md:inline text-xs uppercase tracking-wide">{priceList.pricing_basis}</span>
-              )}
-            </div>
+      <div className="flex items-center gap-4 px-4 py-3 rounded-lg border bg-card hover:bg-muted/50 transition-colors">
+        {/* Name + specialization */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <h3 className="text-sm font-semibold text-foreground truncate">
+              {capitalizeFirstLetter(priceList.client_name)}
+            </h3>
+            <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider shrink-0">
+              {capitalizeFirstLetter(priceList.client_specialization)}
+            </span>
           </div>
-
-          <ArrowRight className="h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 group-hover:translate-x-0.5 transition-all shrink-0 ml-4" />
+          <div className="flex items-center gap-3 mt-0.5 text-xs text-muted-foreground">
+            <span className="flex items-center gap-1">
+              <Calendar className="h-3 w-3" />
+              {formattedDate}
+            </span>
+            <span className="hidden sm:inline truncate">
+              {availableProduce.map(p => capitalizeFirstLetter(p)).join(", ")}
+            </span>
+            {priceList.pricing_basis && (
+              <span className="hidden md:inline uppercase tracking-wide">{priceList.pricing_basis}</span>
+            )}
+          </div>
         </div>
+
+        <ArrowRight className="h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
       </div>
     </Link>
   )

--- a/apps/client-fnp/components/structures/price-summary-card.tsx
+++ b/apps/client-fnp/components/structures/price-summary-card.tsx
@@ -28,6 +28,16 @@ type ProducerPriceListKeys = "beef" | "lamb" | "mutton" | "goat" | "chicken" | "
 
 const produceKeys: ProducerPriceListKeys[] = ["beef", "lamb", "mutton", "goat", "chicken", "pork", "slaughter"]
 
+const produceColors: Record<string, string> = {
+  beef: "bg-red-50 text-red-700 ring-red-600/10 dark:bg-red-950/30 dark:text-red-400",
+  lamb: "bg-amber-50 text-amber-700 ring-amber-600/10 dark:bg-amber-950/30 dark:text-amber-400",
+  mutton: "bg-orange-50 text-orange-700 ring-orange-600/10 dark:bg-orange-950/30 dark:text-orange-400",
+  goat: "bg-lime-50 text-lime-700 ring-lime-600/10 dark:bg-lime-950/30 dark:text-lime-400",
+  chicken: "bg-yellow-50 text-yellow-700 ring-yellow-600/10 dark:bg-yellow-950/30 dark:text-yellow-400",
+  pork: "bg-pink-50 text-pink-700 ring-pink-600/10 dark:bg-pink-950/30 dark:text-pink-400",
+  slaughter: "bg-slate-50 text-slate-700 ring-slate-600/10 dark:bg-slate-950/30 dark:text-slate-400",
+}
+
 export function PriceSummaryCard({ priceList }: PriceSummaryCardProps) {
   const formattedDate = formatDate(priceList.effectiveDate.toString())
   const dateSlug = new Date(priceList.effectiveDate).toISOString().split('T')[0]
@@ -40,32 +50,34 @@ export function PriceSummaryCard({ priceList }: PriceSummaryCardProps) {
 
   return (
     <Link href={`/prices/${priceSlug}`} className="block group">
-      <div className="flex items-center gap-4 px-4 py-3 rounded-lg border bg-card hover:bg-muted/50 transition-colors">
-        {/* Name + specialization */}
-        <div className="flex-1 min-w-0">
+      <div className="flex items-center justify-between gap-3 py-3 px-1 hover:bg-muted/30 transition-colors">
+        <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
-            <h3 className="text-sm font-semibold text-foreground truncate">
+            <h3 className="text-sm font-semibold text-foreground truncate group-hover:text-primary transition-colors">
               {capitalizeFirstLetter(priceList.client_name)}
             </h3>
-            <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider shrink-0">
-              {capitalizeFirstLetter(priceList.client_specialization)}
-            </span>
           </div>
-          <div className="flex items-center gap-3 mt-0.5 text-xs text-muted-foreground">
-            <span className="flex items-center gap-1">
-              <Calendar className="h-3 w-3" />
-              {formattedDate}
-            </span>
-            <span className="hidden sm:inline truncate">
-              {availableProduce.map(p => capitalizeFirstLetter(p)).join(", ")}
-            </span>
+          <div className="flex items-center gap-1.5 mt-0.5 text-xs text-muted-foreground">
+            <Calendar className="h-3 w-3 shrink-0" />
+            <span>{formattedDate}</span>
             {priceList.pricing_basis && (
-              <span className="hidden md:inline uppercase tracking-wide">{priceList.pricing_basis}</span>
+              <>
+                <span className="text-border">|</span>
+                <span className="uppercase tracking-wide">{priceList.pricing_basis}</span>
+              </>
             )}
           </div>
+          {availableProduce.length > 0 && (
+            <div className="flex gap-1 mt-1.5">
+              {availableProduce.map((p) => (
+                <span key={p} className={`inline-flex items-center rounded-md px-1.5 py-0.5 text-[10px] font-medium ring-1 ring-inset ${produceColors[p]}`}>
+                  {capitalizeFirstLetter(p)}
+                </span>
+              ))}
+            </div>
+          )}
         </div>
-
-        <ArrowRight className="h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
+        <ArrowRight className="h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 group-hover:translate-x-0.5 transition-all shrink-0" />
       </div>
     </Link>
   )

--- a/apps/client-fnp/components/structures/related-cdm-prices-sidebar.tsx
+++ b/apps/client-fnp/components/structures/related-cdm-prices-sidebar.tsx
@@ -1,0 +1,81 @@
+"use client"
+
+import Link from "next/link"
+import { formatDate, capitalizeFirstLetter, slug } from "@/lib/utilities"
+import { Calendar } from "lucide-react"
+
+interface CdmPriceData {
+  id: string
+  client_name: string
+  effectiveDate: string
+  exchange_rate: number
+}
+
+interface RelatedCdmPricesSidebarProps {
+  currentClientName: string
+  currentPriceId: string
+  allPrices: CdmPriceData[]
+}
+
+function getCdmSlug(price: CdmPriceData) {
+  const dateSlug = new Date(price.effectiveDate).toISOString().split('T')[0]
+  const nameSlug = slug(price.client_name)
+  return `${nameSlug}-${dateSlug}`
+}
+
+export function RelatedCdmPricesSidebar({ currentClientName, currentPriceId, allPrices }: RelatedCdmPricesSidebarProps) {
+  const sameClientPrices = allPrices
+    .filter(p => p.client_name.toLowerCase() === currentClientName.toLowerCase() && p.id !== currentPriceId)
+    .slice(0, 5)
+
+  const otherClientPrices = allPrices
+    .filter(p => p.client_name.toLowerCase() !== currentClientName.toLowerCase())
+    .slice(0, 3)
+
+  return (
+    <div className="space-y-6">
+      {sameClientPrices.length > 0 && (
+        <div>
+          <h3 className="text-sm font-semibold text-foreground mb-3 uppercase tracking-wide">
+            Other Dates — {capitalizeFirstLetter(currentClientName)}
+          </h3>
+          <div className="space-y-3">
+            {sameClientPrices.map((price) => (
+              <Link key={price.id} href={`/prices/cdm/${getCdmSlug(price)}`} className="block">
+                <div className="rounded-lg border bg-card p-3 hover:bg-muted/50 transition-colors">
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <Calendar className="h-3 w-3" />
+                    <span>{formatDate(price.effectiveDate)}</span>
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {otherClientPrices.length > 0 && (
+        <div>
+          <h3 className="text-sm font-semibold text-foreground mb-3 uppercase tracking-wide">
+            Other Buyers
+          </h3>
+          <div className="space-y-3">
+            {otherClientPrices.map((price) => (
+              <Link key={price.id} href={`/prices/cdm/${getCdmSlug(price)}`} className="block">
+                <div className="rounded-lg border bg-card p-3 hover:bg-muted/50 transition-colors">
+                  <p className="text-sm font-medium text-foreground mb-1">
+                    {capitalizeFirstLetter(price.client_name)}
+                  </p>
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <Calendar className="h-3 w-3" />
+                    <span>{formatDate(price.effectiveDate)}</span>
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/client-fnp/lib/query.ts
+++ b/apps/client-fnp/lib/query.ts
@@ -298,3 +298,110 @@ export function pollSubscription(reference: string) {
   const url = `${BaseURL}/subscription/poll`
   return api.post(url, { reference })
 }
+
+export function queryPublishedSprayPrograms(pagination?: PaginationModel) {
+  let url: string
+
+  if (pagination?.p !== undefined && pagination.p >= 2) {
+    url = `${BaseURL}/sprayprograms/?p=${pagination.p}`
+  } else {
+    url = `${BaseURL}/sprayprograms/`
+  }
+
+  return api.get(url)
+}
+
+export function querySprayProgramBySlug(slug: string) {
+  const url = `${BaseURL}/sprayprograms/${slug}`
+  return api.get(url)
+}
+
+// Animal Health
+export function queryAnimalHealthCategories() {
+  const url = `${BaseURL}/animalhealthcategories/`
+  return api.get(url)
+}
+
+export function queryAllAnimalHealthProducts(pagination?: PaginationModel & { brand?: string[], target?: string[], active_ingredient?: string[], used_on?: string[] }) {
+  const params = new URLSearchParams()
+
+  if (pagination?.p !== undefined && pagination.p >= 2) {
+    params.set('p', pagination.p.toString())
+  }
+
+  if (pagination?.brand && pagination.brand.length > 0) {
+    pagination.brand.forEach(b => params.append('brand', b))
+  }
+  if (pagination?.target && pagination.target.length > 0) {
+    pagination.target.forEach(t => params.append('target', t))
+  }
+  if (pagination?.active_ingredient && pagination.active_ingredient.length > 0) {
+    pagination.active_ingredient.forEach(ai => params.append('active_ingredient', ai))
+  }
+  if (pagination?.used_on && pagination.used_on.length > 0) {
+    pagination.used_on.forEach(uo => params.append('used_on', uo))
+  }
+
+  const queryString = params.toString()
+  const url = queryString ? `${BaseURL}/animalhealth/all?${queryString}` : `${BaseURL}/animalhealth/all`
+
+  return api.get(url)
+}
+
+export function queryAnimalHealthProductsByCategory(options: { category: string } & PaginationModel & { brand?: string[], target?: string[], active_ingredient?: string[] }) {
+  const params = new URLSearchParams()
+
+  if (options.p !== undefined && options.p >= 2) {
+    params.set('p', options.p.toString())
+  }
+
+  if (options.brand && options.brand.length > 0) {
+    options.brand.forEach(b => params.append('brand', b))
+  }
+  if (options.target && options.target.length > 0) {
+    options.target.forEach(t => params.append('target', t))
+  }
+  if (options.active_ingredient && options.active_ingredient.length > 0) {
+    options.active_ingredient.forEach(ai => params.append('active_ingredient', ai))
+  }
+
+  const queryString = params.toString()
+  const url = queryString ? `${BaseURL}/animalhealth/category/${options.category}?${queryString}` : `${BaseURL}/animalhealth/category/${options.category}`
+
+  return api.get(url)
+}
+
+export function queryAnimalHealthFilterAggregates() {
+  const url = `${BaseURL}/animalhealth/aggregates/filters`
+  return api.get(url)
+}
+
+export function queryAnimalHealthProduct(slug: string) {
+  const url = `${BaseURL}/animalhealth/${slug}`
+  return api.get(url)
+}
+
+// CDM Prices
+export function queryCdmPrices(pagination?: PaginationModel) {
+  let url: string
+
+  if (pagination?.p !== undefined && pagination.p >= 2) {
+    url = `${BaseURL}/cdmprices/all?p=${pagination.p}`
+  } else {
+    url = `${BaseURL}/cdmprices/all`
+  }
+
+  return api.get(url)
+}
+
+export function queryCdmPricesByClient(clientId: string, pagination?: PaginationModel) {
+  let url: string
+
+  if (pagination?.p !== undefined && pagination.p >= 2) {
+    url = `${BaseURL}/cdmprices/client/${clientId}?p=${pagination.p}`
+  } else {
+    url = `${BaseURL}/cdmprices/client/${clientId}`
+  }
+
+  return api.get(url)
+}

--- a/apps/client-fnp/lib/query.ts
+++ b/apps/client-fnp/lib/query.ts
@@ -123,14 +123,15 @@ export async function clientSignup(data: SignUpFormData) {
 }
 
 export function queryProducerPriceLists(pagination?: PaginationModel) {
-  let url: string
-
+  const params = new URLSearchParams()
   if (pagination?.p !== undefined && pagination.p >= 2) {
-    url = `${BaseURL}/prices/all?p=${pagination.p}`
-  } else {
-    url = `${BaseURL}/prices/all`
+    params.set("p", String(pagination.p))
   }
-
+  if (pagination?.limit) {
+    params.set("limit", String(pagination.limit))
+  }
+  const qs = params.toString()
+  const url = `${BaseURL}/prices/all${qs ? `?${qs}` : ""}`
   return api.get(url)
 }
 
@@ -201,12 +202,17 @@ export function queryAgroChemicalCategories() {
   return api.get(url)
 }
 
-export function queryAllAgroChemicals(pagination?: PaginationModel & { brand?: string[], target?: string[], active_ingredient?: string[], used_on?: string[] }) {
+export function queryAllAgroChemicals(pagination?: PaginationModel & { search?: string, brand?: string[], target?: string[], active_ingredient?: string[], used_on?: string[] }) {
   const params = new URLSearchParams()
 
   // Add pagination
   if (pagination?.p !== undefined && pagination.p >= 2) {
     params.set('p', pagination.p.toString())
+  }
+
+  // Add search
+  if (pagination?.search && pagination.search.length >= 2) {
+    params.set('search', pagination.search)
   }
 
   // Add filters
@@ -383,14 +389,15 @@ export function queryAnimalHealthProduct(slug: string) {
 
 // CDM Prices
 export function queryCdmPrices(pagination?: PaginationModel) {
-  let url: string
-
+  const params = new URLSearchParams()
   if (pagination?.p !== undefined && pagination.p >= 2) {
-    url = `${BaseURL}/cdmprices/all?p=${pagination.p}`
-  } else {
-    url = `${BaseURL}/cdmprices/all`
+    params.set("p", String(pagination.p))
   }
-
+  if (pagination?.limit) {
+    params.set("limit", String(pagination.limit))
+  }
+  const qs = params.toString()
+  const url = `${BaseURL}/cdmprices/all${qs ? `?${qs}` : ""}`
   return api.get(url)
 }
 

--- a/apps/client-fnp/lib/schemas.ts
+++ b/apps/client-fnp/lib/schemas.ts
@@ -352,6 +352,7 @@ export type ImageModel = {
 export const PagintionSchema = z.object({
     p: z.number().optional(),
     search: z.string().optional(),
+    limit: z.number().optional(),
 })
 
 export type PaginationModel = z.infer<typeof PagintionSchema>

--- a/apps/client-fnp/lib/schemas.ts
+++ b/apps/client-fnp/lib/schemas.ts
@@ -604,3 +604,45 @@ export type FarmProduceResponse = {
   total: number
   data: FarmProduce[]
 }
+
+// CDM (Cold Dress Mass) Types
+
+export type CarcassGradePrice = {
+  collected_usd: number
+  delivered_usd: number
+  collected_zig: number
+  delivered_zig: number
+}
+
+export type CarcassGrades = {
+  commercial: CarcassGradePrice
+  economy: CarcassGradePrice
+  manufacturing: CarcassGradePrice
+}
+
+export type LiveweightEntry = {
+  weight_range: string
+  teeth: string
+  delivered_usd: number
+  delivered_zig: number
+  grade_note: string
+}
+
+export type CdmPrice = {
+  id: string
+  created: string
+  updated: string
+  client_id: string
+  client_name: string
+  verified?: boolean
+  effectiveDate: string
+  exchange_rate: number
+  carcass_grades: CarcassGrades
+  liveweight: LiveweightEntry[]
+  notes: string[]
+}
+
+export type CdmPriceResponse = {
+  total: number
+  data: CdmPrice[]
+}

--- a/apps/client-fnp/lib/utilities.ts
+++ b/apps/client-fnp/lib/utilities.ts
@@ -101,3 +101,22 @@ export function formatUnit(unit?: string): string {
   if (!unit) return ""
   return unitLabels[unit.toLowerCase()] || unit
 }
+
+const UPPERCASE_TOKENS = new Set([
+  "ec", "sc", "sl", "wg", "wp", "ws", "se", "fs", "zc", "wdg", "od", "ew",
+  "sg", "sp", "gr", "cs", "me", "dc", "ii", "iii", "iv",
+])
+
+export function formatProductName(name?: string): string {
+  if (!name) return ""
+  return name.split(" ").map(word => {
+    if (UPPERCASE_TOKENS.has(word.toLowerCase())) return word.toUpperCase()
+    // Handle joined number+code like "960ec" → "960EC"
+    const numCodeMatch = word.match(/^(\d+\.?\d*)([a-zA-Z]+)$/)
+    if (numCodeMatch && UPPERCASE_TOKENS.has(numCodeMatch[2].toLowerCase())) {
+      return numCodeMatch[1] + numCodeMatch[2].toUpperCase()
+    }
+    if (/^\d/.test(word)) return word
+    return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
+  }).join(" ")
+}

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "2.9.0",
+  "version": "3.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- Add CDM pricing pages with detail views and related sidebar
- Add LWT dedicated listing page with filters
- Redesign /prices hub page with compact layout
- Convert agrochemical guides hub to server-side rendering
- Add quick search to guides and /agrochemical-guides/all
- Add AdSense on spray program detail pages
- Add formatProductName utility for consistent name display
- Fix broken search on admin tables
- Update price summary cards with produce tags

## Test Plan
- [x] Tested locally