### PR TITLE
Compact prices page, remove ZiG from CDM, simplify spray programs

### DIFF
--- a/apps/client-fnp/app/(landing)/prices/cdm/page.tsx
+++ b/apps/client-fnp/app/(landing)/prices/cdm/page.tsx
@@ -1,4 +1,5 @@
 import { CdmPriceCardsView } from "@/components/structures/cdm-price-cards-view"
+import { FilterSidebar } from "@/components/generic/filterSidebar"
 import { ActionsSidebar } from "@/components/generic/actions-sidebar"
 import Link from "next/link"
 import { ChevronLeft } from "lucide-react"
@@ -39,7 +40,14 @@ export default async function CdmPricesPage() {
         </p>
 
         <div className="lg:flex lg:space-x-10">
+          <div className="hidden lg:block lg:w-64 relative">
+            <FilterSidebar hideProduce />
+          </div>
+
           <div className="lg:flex-1">
+            <div className="lg:hidden mb-6">
+              <FilterSidebar hideProduce />
+            </div>
             <CdmPriceCardsView />
           </div>
 

--- a/apps/client-fnp/app/(landing)/prices/page.tsx
+++ b/apps/client-fnp/app/(landing)/prices/page.tsx
@@ -133,7 +133,7 @@ export default async function PricesPage() {
         <div className="mx-auto max-w-7xl px-6 lg:px-8 py-8">
           <h2 className="text-base font-bold font-heading mb-2">About Agricultural Pricing in Zimbabwe</h2>
           <p className="text-xs text-muted-foreground">
-            Transparent market prices from verified buyers and abattoirs across Zimbabwe.
+            Transparent market prices from verified buyers across Zimbabwe.
           </p>
         </div>
       </section>

--- a/apps/client-fnp/app/(landing)/spray-programs/page.tsx
+++ b/apps/client-fnp/app/(landing)/spray-programs/page.tsx
@@ -1,9 +1,8 @@
 "use client"
 
 import Link from "next/link"
-import Image from "next/image"
 import { useQuery } from "@tanstack/react-query"
-import { Sprout, ArrowRight, Layers, ChevronRight } from "lucide-react"
+import { Sprout, Layers, ChevronRight } from "lucide-react"
 import { queryPublishedSprayPrograms } from "@/lib/query"
 import { capitalizeFirstLetter } from "@/lib/utilities"
 
@@ -17,115 +16,85 @@ export default function SprayProgramsPage() {
     const programs = data?.data?.data || []
 
     return (
-        <main className="bg-gradient-to-b from-background to-muted/20 min-h-screen">
-            {/* Hero Section */}
-            <section className="py-12 lg:py-20 relative overflow-hidden">
-                <div className="absolute inset-0 bg-gradient-to-br from-green-50/50 via-transparent to-emerald-50/30 dark:from-green-950/20 dark:to-emerald-950/10" />
-                <div className="mx-auto max-w-7xl px-6 lg:px-8 relative">
-                    <div className="text-center max-w-3xl mx-auto mb-14">
-                        <div className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300 text-sm font-medium mb-6">
-                            <Sprout className="h-4 w-4" />
-                            Crop Protection Made Simple
+        <main>
+            {/* Header */}
+            <section className="border-b">
+                <div className="mx-auto max-w-7xl px-6 lg:px-8 pt-10 pb-8">
+                    <p className="text-xs font-semibold text-primary tracking-wide uppercase">Crop Protection</p>
+                    <h1 className="mt-1 text-3xl font-bold font-heading tracking-tight">
+                        Spray Programs
+                    </h1>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                        Step-by-step agrochemical application schedules for every growth stage.
+                    </p>
+                </div>
+            </section>
+
+            <section className="mx-auto max-w-7xl px-6 lg:px-8 py-8">
+                {/* Loading State */}
+                {isLoading && (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                        {[1, 2, 3].map((i) => (
+                            <div key={i} className="animate-pulse rounded-xl border bg-card p-4 space-y-3">
+                                <div className="h-5 bg-muted rounded w-3/4" />
+                                <div className="h-4 bg-muted rounded w-full" />
+                                <div className="h-4 bg-muted rounded w-1/2" />
+                            </div>
+                        ))}
+                    </div>
+                )}
+
+                {/* Empty State */}
+                {!isLoading && programs.length === 0 && (
+                    <div className="text-center py-16">
+                        <div className="mx-auto w-16 h-16 bg-muted rounded-full flex items-center justify-center mb-4">
+                            <Sprout className="w-8 h-8 text-muted-foreground" />
                         </div>
-                        <h1 className="text-4xl font-bold tracking-tight sm:text-5xl font-heading mb-5">
-                            Crop Spray Programs
-                        </h1>
-                        <p className="text-lg text-muted-foreground leading-7">
-                            Step-by-step agrochemical application schedules for every growth stage.
-                            Know exactly what to spray, when to spray, and how much to use.
+                        <h2 className="text-lg font-semibold mb-1">No Spray Programs Yet</h2>
+                        <p className="text-sm text-muted-foreground max-w-md mx-auto">
+                            We&apos;re working on creating comprehensive spray programs. Check back soon.
                         </p>
                     </div>
+                )}
 
-                    {/* Loading State */}
-                    {isLoading && (
-                        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                            {[1, 2, 3].map((i) => (
-                                <div key={i} className="animate-pulse rounded-xl border bg-card overflow-hidden">
-                                    <div className="aspect-[16/9] bg-muted" />
-                                    <div className="p-5 space-y-3">
-                                        <div className="h-5 bg-muted rounded w-3/4" />
-                                        <div className="h-4 bg-muted rounded w-full" />
-                                        <div className="h-4 bg-muted rounded w-1/2" />
+                {/* Programs Grid */}
+                {!isLoading && programs.length > 0 && (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                        {programs.map((program: any) => (
+                            <Link
+                                key={program.id}
+                                href={`/spray-programs/${program.slug}`}
+                                className="group rounded-xl border bg-card overflow-hidden hover:shadow-md hover:border-primary/20 transition-all"
+                            >
+                                <div className="p-4">
+                                    <h2 className="text-sm font-bold font-heading mb-1 group-hover:text-primary transition-colors">
+                                        {capitalizeFirstLetter(program.name)}
+                                    </h2>
+
+                                    {program.farm_produce_name && (
+                                        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-600/10 dark:bg-amber-950/30 dark:text-amber-400 mb-2">
+                                            {capitalizeFirstLetter(program.farm_produce_name)}
+                                        </span>
+                                    )}
+
+                                    {program.description && (
+                                        <p className="text-xs text-muted-foreground line-clamp-2 mb-3">
+                                            {program.description}
+                                        </p>
+                                    )}
+
+                                    <div className="flex items-center justify-between">
+                                        <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                                            <Layers className="h-3 w-3" />
+                                            <span>{program.stages?.length || 0} stages</span>
+                                        </div>
+                                        <ChevronRight className="h-3.5 w-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
                                     </div>
                                 </div>
-                            ))}
-                        </div>
-                    )}
-
-                    {/* Empty State */}
-                    {!isLoading && programs.length === 0 && (
-                        <div className="text-center py-16">
-                            <div className="mx-auto w-20 h-20 bg-muted rounded-full flex items-center justify-center mb-6">
-                                <Sprout className="w-10 h-10 text-muted-foreground" />
-                            </div>
-                            <h2 className="text-2xl font-semibold mb-2">No Spray Programs Yet</h2>
-                            <p className="text-muted-foreground max-w-md mx-auto">
-                                We&apos;re working on creating comprehensive spray programs for various crops. Check back soon!
-                            </p>
-                        </div>
-                    )}
-
-                    {/* Programs Grid */}
-                    {!isLoading && programs.length > 0 && (
-                        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                            {programs.map((program: any) => (
-                                <Link
-                                    key={program.id}
-                                    href={`/spray-programs/${program.slug}`}
-                                    className="group rounded-xl border bg-card overflow-hidden hover:border-primary hover:shadow-lg transition-all duration-300"
-                                >
-                                    {/* Cover Image */}
-                                    <div className="relative aspect-[16/9] bg-gradient-to-br from-green-50 to-emerald-50 dark:from-green-950/30 dark:to-emerald-950/30 overflow-hidden">
-                                        {program.cover_image?.img?.src ? (
-                                            <Image
-                                                src={program.cover_image.img.src}
-                                                alt={program.name}
-                                                fill
-                                                sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-                                                className="object-cover group-hover:scale-105 transition-transform duration-500"
-                                            />
-                                        ) : (
-                                            <div className="absolute inset-0 flex items-center justify-center">
-                                                <Sprout className="w-16 h-16 text-green-300 dark:text-green-800" />
-                                            </div>
-                                        )}
-                                    </div>
-
-                                    {/* Card Content */}
-                                    <div className="p-5">
-                                        <h2 className="text-lg font-semibold mb-1.5 group-hover:text-primary transition-colors">
-                                            {capitalizeFirstLetter(program.name)}
-                                        </h2>
-
-                                        {program.farm_produce_name && (
-                                            <div className="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300 mb-3">
-                                                <Sprout className="h-3 w-3" />
-                                                {capitalizeFirstLetter(program.farm_produce_name)}
-                                            </div>
-                                        )}
-
-                                        {program.description && (
-                                            <p className="text-sm text-muted-foreground line-clamp-2 mb-4">
-                                                {program.description}
-                                            </p>
-                                        )}
-
-                                        <div className="flex items-center justify-between">
-                                            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                                                <Layers className="h-3.5 w-3.5" />
-                                                <span>{program.stages?.length || 0} stages</span>
-                                            </div>
-                                            <div className="flex items-center gap-1 text-sm font-medium text-primary opacity-0 group-hover:opacity-100 transition-opacity">
-                                                View Program
-                                                <ChevronRight className="h-4 w-4" />
-                                            </div>
-                                        </div>
-                                    </div>
-                                </Link>
-                            ))}
-                        </div>
-                    )}
-                </div>
+                            </Link>
+                        ))}
+                    </div>
+                )}
             </section>
         </main>
     )

--- a/apps/client-fnp/components/structures/cdm-price-card.tsx
+++ b/apps/client-fnp/components/structures/cdm-price-card.tsx
@@ -49,11 +49,6 @@ function formatUSD(value: number): string {
   return `$${value.toFixed(2)}`
 }
 
-function formatZIG(value: number): string {
-  if (!value || value === 0) return "—"
-  return `ZiG ${value.toFixed(2)}`
-}
-
 export function CdmPriceCard({ price, hideHeader }: CdmPriceCardProps) {
   const formattedDate = formatDate(price.effectiveDate)
 
@@ -91,11 +86,6 @@ export function CdmPriceCard({ price, hideHeader }: CdmPriceCardProps) {
               <Calendar className="h-3.5 w-3.5" />
               Effective: {formattedDate}
             </span>
-            {price.exchange_rate > 0 && (
-              <span className="ml-auto">
-                Rate: 1 USD = {price.exchange_rate.toFixed(2)} ZiG
-              </span>
-            )}
           </div>
         </div>
       )}
@@ -116,8 +106,6 @@ export function CdmPriceCard({ price, hideHeader }: CdmPriceCardProps) {
                 <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Code</th>
                 <th className="px-4 py-2 text-right text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Collected USD</th>
                 <th className="px-4 py-2 text-right text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Delivered USD</th>
-                <th className="px-4 py-2 text-right text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Collected ZiG</th>
-                <th className="px-4 py-2 text-right text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Delivered ZiG</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-border/50">
@@ -134,8 +122,6 @@ export function CdmPriceCard({ price, hideHeader }: CdmPriceCardProps) {
                     </td>
                     <td className="px-4 py-2.5 text-right text-sm text-muted-foreground">{formatUSD(gradeData.collected_usd)}</td>
                     <td className="px-4 py-2.5 text-right text-sm font-semibold text-foreground">{formatUSD(gradeData.delivered_usd)}</td>
-                    <td className="px-4 py-2.5 text-right text-sm text-muted-foreground">{formatZIG(gradeData.collected_zig)}</td>
-                    <td className="px-4 py-2.5 text-right text-sm font-semibold text-foreground">{formatZIG(gradeData.delivered_zig)}</td>
                   </tr>
                 )
               })}
@@ -230,7 +216,6 @@ export function CdmPriceCard({ price, hideHeader }: CdmPriceCardProps) {
                       <tr className="border-b">
                         <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Weight (kg)</th>
                         <th className="px-4 py-2 text-right text-[11px] font-medium uppercase tracking-wider text-muted-foreground">USD</th>
-                        <th className="px-4 py-2 text-right text-[11px] font-medium uppercase tracking-wider text-muted-foreground">ZiG</th>
                         {hasAnyNote && (
                           <th className="px-4 py-2 text-left text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Status</th>
                         )}
@@ -250,9 +235,6 @@ export function CdmPriceCard({ price, hideHeader }: CdmPriceCardProps) {
                             <td className="px-4 py-2.5 text-sm font-medium text-foreground whitespace-nowrap">{range}</td>
                             <td className="px-4 py-2.5 text-right text-sm font-semibold text-foreground">
                               {hasPrice ? formatUSD(entry!.delivered_usd) : "—"}
-                            </td>
-                            <td className="px-4 py-2.5 text-right text-sm text-muted-foreground">
-                              {hasPrice ? formatZIG(entry!.delivered_zig) : "—"}
                             </td>
                             {hasAnyNote && (
                               <td className="px-4 py-2.5">

--- a/apps/client-fnp/components/structures/cdm-price-cards-view.tsx
+++ b/apps/client-fnp/components/structures/cdm-price-cards-view.tsx
@@ -2,14 +2,14 @@
 
 import { Fragment, useState, useMemo } from "react"
 import { useQuery } from "@tanstack/react-query"
+import { useQueryStates, parseAsArrayOf, parseAsString } from "nuqs"
 
 import { queryCdmPrices } from "@/lib/query"
 import { CdmPrice } from "@/lib/schemas"
 import { CdmPriceSummaryCard } from "@/components/structures/cdm-price-summary-card"
 import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { ArrowRight, ChevronLeft, ChevronRight, Search, X } from "lucide-react"
+import { ArrowRight, ChevronLeft, ChevronRight } from "lucide-react"
 import Link from "next/link"
 
 interface CdmPriceCardsViewProps {
@@ -19,10 +19,13 @@ interface CdmPriceCardsViewProps {
 
 export function CdmPriceCardsView({ limit, viewAllHref }: CdmPriceCardsViewProps = {}) {
   const [currentPage, setCurrentPage] = useState(1)
-  const [search, setSearch] = useState("")
+
+  const [filters] = useQueryStates({
+    clients: parseAsArrayOf(parseAsString),
+  })
 
   const { data, isLoading, isError } = useQuery({
-    queryKey: ["cdm-prices", { p: currentPage, limit }],
+    queryKey: ["cdm-prices", { p: currentPage, limit, ...filters }],
     queryFn: () => queryCdmPrices({ p: currentPage, ...(limit ? { limit } : {}) }),
     refetchOnWindowFocus: false,
   })
@@ -31,10 +34,11 @@ export function CdmPriceCardsView({ limit, viewAllHref }: CdmPriceCardsViewProps
   const total = data?.data?.total || 0
 
   const prices = useMemo(() => {
-    if (!search || limit) return allPrices
-    const q = search.toLowerCase()
-    return allPrices.filter(p => p.client_name?.toLowerCase().includes(q))
-  }, [allPrices, search, limit])
+    if (limit) return allPrices
+    const clientFilter = filters.clients
+    if (!clientFilter || clientFilter.length === 0) return allPrices
+    return allPrices.filter(p => clientFilter.includes(p.client_name?.toLowerCase()))
+  }, [allPrices, filters.clients, limit])
 
   const totalPages = Math.ceil(total / (limit || 20))
 


### PR DESCRIPTION
## Summary
- Prices page: compact layout with tighter spacing
- Remove "abattoirs" from SEO copy (scaling beyond abattoirs)
- CDM price card: remove ZiG columns and exchange rate (USD only)
- Spray programs page: match compact header style from prices page

## Test plan
- [ ] /prices renders compact layout with LWT + CDM previews
- [ ] /prices/cdm/[slug] detail page shows USD only (no ZiG columns)
- [ ] /spray-programs matches compact header style