### PR TITLE
Fix pagination duplicate data in all admin tables

### DIFF
--- a/apps/admin-fnp/components/structures/tables/agroChemicalActiveIngredients.tsx
+++ b/apps/admin-fnp/components/structures/tables/agroChemicalActiveIngredients.tsx
@@ -15,15 +15,15 @@ export function AgroChemicalActiveIngredientsTable() {
   const [search, setSearch] = useState("")
 
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 1,
+    pageIndex: 0,
     pageSize: 20,
   })
 
   const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
-    queryKey: ["dashboard-agrochemical-active-ingredients", { p: pagination.pageIndex, search }],
+    queryKey: ["dashboard-agrochemical-active-ingredients", { p: pagination.pageIndex + 1, search }],
     queryFn: () =>
       queryAgroChemicalActiveIngredients({
-        p: pagination.pageIndex,
+        p: pagination.pageIndex + 1,
         search: search,
       }),
     refetchOnWindowFocus: false

--- a/apps/admin-fnp/components/structures/tables/agroChemicalCategories.tsx
+++ b/apps/admin-fnp/components/structures/tables/agroChemicalCategories.tsx
@@ -15,15 +15,15 @@ export function AgroChemicalCategoriesTable() {
   const [search, setSearch] = useState("")
 
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 1,
+    pageIndex: 0,
     pageSize: 20,
   })
 
   const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
-    queryKey: ["dashboard-agrochemical-categories", { p: pagination.pageIndex, search }],
+    queryKey: ["dashboard-agrochemical-categories", { p: pagination.pageIndex + 1, search }],
     queryFn: () =>
       queryAgroChemicalCategories({
-        p: pagination.pageIndex,
+        p: pagination.pageIndex + 1,
         search: search,
       }),
     refetchOnWindowFocus: false

--- a/apps/admin-fnp/components/structures/tables/agroChemicalTargets.tsx
+++ b/apps/admin-fnp/components/structures/tables/agroChemicalTargets.tsx
@@ -15,15 +15,15 @@ export function AgroChemicalTargetsTable() {
   const [search, setSearch] = useState("")
 
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 1,
+    pageIndex: 0,
     pageSize: 20,
   })
 
   const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
-    queryKey: ["dashboard-agrochemical-targets", { p: pagination.pageIndex, search }],
+    queryKey: ["dashboard-agrochemical-targets", { p: pagination.pageIndex + 1, search }],
     queryFn: () =>
       queryAgroChemicalTargets({
-        p: pagination.pageIndex,
+        p: pagination.pageIndex + 1,
         search: search,
       }),
     refetchOnWindowFocus: false

--- a/apps/admin-fnp/components/structures/tables/animalHealthActiveIngredients.tsx
+++ b/apps/admin-fnp/components/structures/tables/animalHealthActiveIngredients.tsx
@@ -15,15 +15,15 @@ export function AnimalHealthActiveIngredientsTable() {
   const [search, setSearch] = useState("")
 
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 1,
+    pageIndex: 0,
     pageSize: 20,
   })
 
   const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
-    queryKey: ["dashboard-animal-health-active-ingredients", { p: pagination.pageIndex, search }],
+    queryKey: ["dashboard-animal-health-active-ingredients", { p: pagination.pageIndex + 1, search }],
     queryFn: () =>
       queryAnimalHealthActiveIngredients({
-        p: pagination.pageIndex,
+        p: pagination.pageIndex + 1,
         search: search,
       }),
     refetchOnWindowFocus: false

--- a/apps/admin-fnp/components/structures/tables/animalHealthCategories.tsx
+++ b/apps/admin-fnp/components/structures/tables/animalHealthCategories.tsx
@@ -15,15 +15,15 @@ export function AnimalHealthCategoriesTable() {
   const [search, setSearch] = useState("")
 
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 1,
+    pageIndex: 0,
     pageSize: 20,
   })
 
   const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
-    queryKey: ["dashboard-animal-health-categories", { p: pagination.pageIndex, search }],
+    queryKey: ["dashboard-animal-health-categories", { p: pagination.pageIndex + 1, search }],
     queryFn: () =>
       queryAnimalHealthCategories({
-        p: pagination.pageIndex,
+        p: pagination.pageIndex + 1,
         search: search,
       }),
     refetchOnWindowFocus: false

--- a/apps/admin-fnp/components/structures/tables/animalHealthProducts.tsx
+++ b/apps/admin-fnp/components/structures/tables/animalHealthProducts.tsx
@@ -15,15 +15,15 @@ export function AnimalHealthProductsTable() {
   const [search, setSearch] = useState("")
 
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 1,
+    pageIndex: 0,
     pageSize: 20,
   })
 
   const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
-    queryKey: ["dashboard-animal-health-products", { p: pagination.pageIndex, search }],
+    queryKey: ["dashboard-animal-health-products", { p: pagination.pageIndex + 1, search }],
     queryFn: () =>
       queryAnimalHealthProducts({
-        p: pagination.pageIndex,
+        p: pagination.pageIndex + 1,
         search: search,
       }),
     refetchOnWindowFocus: false

--- a/apps/admin-fnp/components/structures/tables/animalHealthTargets.tsx
+++ b/apps/admin-fnp/components/structures/tables/animalHealthTargets.tsx
@@ -15,15 +15,15 @@ export function AnimalHealthTargetsTable() {
   const [search, setSearch] = useState("")
 
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 1,
+    pageIndex: 0,
     pageSize: 20,
   })
 
   const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
-    queryKey: ["dashboard-animal-health-targets", { p: pagination.pageIndex, search }],
+    queryKey: ["dashboard-animal-health-targets", { p: pagination.pageIndex + 1, search }],
     queryFn: () =>
       queryAnimalHealthTargets({
-        p: pagination.pageIndex,
+        p: pagination.pageIndex + 1,
         search: search,
       }),
     refetchOnWindowFocus: false

--- a/apps/admin-fnp/components/structures/tables/brands.tsx
+++ b/apps/admin-fnp/components/structures/tables/brands.tsx
@@ -15,15 +15,15 @@ export function BrandsTable() {
   const [search, setSearch] = useState("")
 
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 1,
+    pageIndex: 0,
     pageSize: 20,
   })
 
   const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
-    queryKey: ["dashboard-brands", { p: pagination.pageIndex, search }],
+    queryKey: ["dashboard-brands", { p: pagination.pageIndex + 1, search }],
     queryFn: () =>
       queryBrands({
-        p: pagination.pageIndex,
+        p: pagination.pageIndex + 1,
         search: search,
       }),
     refetchOnWindowFocus: false

--- a/apps/admin-fnp/components/structures/tables/cdmPriceLists.tsx
+++ b/apps/admin-fnp/components/structures/tables/cdmPriceLists.tsx
@@ -15,15 +15,15 @@ export function CdmPriceLists() {
   const [search, setSearch] = useState("")
 
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 1,
+    pageIndex: 0,
     pageSize: 20,
   })
 
   const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
-    queryKey: ["dashboard-cdm-prices", { p: pagination.pageIndex }],
+    queryKey: ["dashboard-cdm-prices", { p: pagination.pageIndex + 1 }],
     queryFn: () =>
       queryCdmPrices({
-        p: pagination.pageIndex,
+        p: pagination.pageIndex + 1,
       }),
     refetchOnWindowFocus: false
   })

--- a/apps/admin-fnp/components/structures/tables/cropGroups.tsx
+++ b/apps/admin-fnp/components/structures/tables/cropGroups.tsx
@@ -15,15 +15,15 @@ export function CropGroupsTable() {
   const [search, setSearch] = useState("")
 
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 1,
+    pageIndex: 0,
     pageSize: 20,
   })
 
   const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
-    queryKey: ["dashboard-crop-groups", { p: pagination.pageIndex, search }],
+    queryKey: ["dashboard-crop-groups", { p: pagination.pageIndex + 1, search }],
     queryFn: () =>
       queryCropGroups({
-        p: pagination.pageIndex,
+        p: pagination.pageIndex + 1,
         search: search,
       }),
     refetchOnWindowFocus: false

--- a/apps/admin-fnp/components/structures/tables/farmProduce.tsx
+++ b/apps/admin-fnp/components/structures/tables/farmProduce.tsx
@@ -17,15 +17,15 @@ export function FarmProduceTable() {
   const [search, setSearch] = useState("")
 
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 1,
+    pageIndex: 0,
     pageSize: 20,
   })
 
   const { isError, isLoading, isFetching, refetch, data } = useQuery({
-    queryKey: ["dashboard-farm-produce", { p: pagination.pageIndex, search }],
+    queryKey: ["dashboard-farm-produce", { p: pagination.pageIndex + 1, search }],
     queryFn: () =>
       queryFarmProduce({
-        p: pagination.pageIndex,
+        p: pagination.pageIndex + 1,
         search: search,
       }),
     refetchOnWindowFocus: false

--- a/apps/admin-fnp/components/structures/tables/farmProduceCategories.tsx
+++ b/apps/admin-fnp/components/structures/tables/farmProduceCategories.tsx
@@ -17,15 +17,15 @@ export function FarmProduceCategoriesTable() {
   const [search, setSearch] = useState("")
 
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 1,
+    pageIndex: 0,
     pageSize: 20,
   })
 
   const { isError, isLoading, isFetching, refetch, data } = useQuery({
-    queryKey: ["dashboard-farm-produce-categories", { p: pagination.pageIndex, search }],
+    queryKey: ["dashboard-farm-produce-categories", { p: pagination.pageIndex + 1, search }],
     queryFn: () =>
       queryFarmProduceCategories({
-        p: pagination.pageIndex,
+        p: pagination.pageIndex + 1,
         search: search,
       }),
     refetchOnWindowFocus: false

--- a/apps/admin-fnp/components/structures/tables/feedActiveIngredients.tsx
+++ b/apps/admin-fnp/components/structures/tables/feedActiveIngredients.tsx
@@ -15,15 +15,15 @@ export function FeedActiveIngredientsTable() {
   const [search, setSearch] = useState("")
 
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 1,
+    pageIndex: 0,
     pageSize: 20,
   })
 
   const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
-    queryKey: ["dashboard-feed-active-ingredients", { p: pagination.pageIndex, search }],
+    queryKey: ["dashboard-feed-active-ingredients", { p: pagination.pageIndex + 1, search }],
     queryFn: () =>
       queryFeedActiveIngredients({
-        p: pagination.pageIndex,
+        p: pagination.pageIndex + 1,
         search: search,
       }),
     refetchOnWindowFocus: false

--- a/apps/admin-fnp/components/structures/tables/feedCategories.tsx
+++ b/apps/admin-fnp/components/structures/tables/feedCategories.tsx
@@ -15,15 +15,15 @@ export function FeedCategoriesTable() {
   const [search, setSearch] = useState("")
 
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 1,
+    pageIndex: 0,
     pageSize: 20,
   })
 
   const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
-    queryKey: ["dashboard-feed-categories", { p: pagination.pageIndex, search }],
+    queryKey: ["dashboard-feed-categories", { p: pagination.pageIndex + 1, search }],
     queryFn: () =>
       queryFeedCategories({
-        p: pagination.pageIndex,
+        p: pagination.pageIndex + 1,
         search: search,
       }),
     refetchOnWindowFocus: false

--- a/apps/admin-fnp/components/structures/tables/feedNutritionalSpecs.tsx
+++ b/apps/admin-fnp/components/structures/tables/feedNutritionalSpecs.tsx
@@ -15,15 +15,15 @@ export function FeedNutritionalSpecsTable() {
   const [search, setSearch] = useState("")
 
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 1,
+    pageIndex: 0,
     pageSize: 20,
   })
 
   const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
-    queryKey: ["dashboard-feed-nutritional-specs", { p: pagination.pageIndex, search }],
+    queryKey: ["dashboard-feed-nutritional-specs", { p: pagination.pageIndex + 1, search }],
     queryFn: () =>
       queryFeedNutritionalSpecs({
-        p: pagination.pageIndex,
+        p: pagination.pageIndex + 1,
         search: search,
       }),
     refetchOnWindowFocus: false

--- a/apps/admin-fnp/components/structures/tables/feedProducts.tsx
+++ b/apps/admin-fnp/components/structures/tables/feedProducts.tsx
@@ -15,15 +15,15 @@ export function FeedProductsTable() {
   const [search, setSearch] = useState("")
 
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 1,
+    pageIndex: 0,
     pageSize: 20,
   })
 
   const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
-    queryKey: ["dashboard-feed-products", { p: pagination.pageIndex, search }],
+    queryKey: ["dashboard-feed-products", { p: pagination.pageIndex + 1, search }],
     queryFn: () =>
       queryFeedProducts({
-        p: pagination.pageIndex,
+        p: pagination.pageIndex + 1,
         search: search,
       }),
     refetchOnWindowFocus: false

--- a/apps/admin-fnp/components/structures/tables/feedTargets.tsx
+++ b/apps/admin-fnp/components/structures/tables/feedTargets.tsx
@@ -15,15 +15,15 @@ export function FeedTargetsTable() {
   const [search, setSearch] = useState("")
 
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 1,
+    pageIndex: 0,
     pageSize: 20,
   })
 
   const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
-    queryKey: ["dashboard-feed-targets", { p: pagination.pageIndex, search }],
+    queryKey: ["dashboard-feed-targets", { p: pagination.pageIndex + 1, search }],
     queryFn: () =>
       queryFeedTargets({
-        p: pagination.pageIndex,
+        p: pagination.pageIndex + 1,
         search: search,
       }),
     refetchOnWindowFocus: false

--- a/apps/admin-fnp/components/structures/tables/feedingPrograms.tsx
+++ b/apps/admin-fnp/components/structures/tables/feedingPrograms.tsx
@@ -15,15 +15,15 @@ export function FeedingProgramsTable() {
   const [search, setSearch] = useState("")
 
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 1,
+    pageIndex: 0,
     pageSize: 20,
   })
 
   const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
-    queryKey: ["dashboard-feeding-programs", { p: pagination.pageIndex, search }],
+    queryKey: ["dashboard-feeding-programs", { p: pagination.pageIndex + 1, search }],
     queryFn: () =>
       queryFeedingPrograms({
-        p: pagination.pageIndex,
+        p: pagination.pageIndex + 1,
         search: search,
       }),
     refetchOnWindowFocus: false

--- a/apps/admin-fnp/components/structures/tables/producerPriceLists.tsx
+++ b/apps/admin-fnp/components/structures/tables/producerPriceLists.tsx
@@ -15,15 +15,15 @@ export function ProducePriceLists() {
   const [search, setSearch] = useState("")
 
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 1,
+    pageIndex: 0,
     pageSize: 20,
   })
 
   const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
-    queryKey: ["dashboard-producer-price-lists", { p: pagination.pageIndex, search }],
+    queryKey: ["dashboard-producer-price-lists", { p: pagination.pageIndex + 1, search }],
     queryFn: () =>
       queryProducerPriceLists({
-        p: pagination.pageIndex,
+        p: pagination.pageIndex + 1,
         search: search,
       }),
     refetchOnWindowFocus: false

--- a/apps/admin-fnp/components/structures/tables/products.tsx
+++ b/apps/admin-fnp/components/structures/tables/products.tsx
@@ -15,15 +15,15 @@ export function AgroChemicalsTable() {
   const [search, setSearch] = useState("")
 
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 1,
+    pageIndex: 0,
     pageSize: 10,
   })
 
   const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
-    queryKey: ["dashboard-products", { p: pagination.pageIndex, search }],
+    queryKey: ["dashboard-products", { p: pagination.pageIndex + 1, search }],
     queryFn: () =>
       queryAgroChemicals({
-        p: pagination.pageIndex,
+        p: pagination.pageIndex + 1,
         search: search,
       }),
     refetchOnWindowFocus: false

--- a/apps/admin-fnp/components/structures/tables/sprayPrograms.tsx
+++ b/apps/admin-fnp/components/structures/tables/sprayPrograms.tsx
@@ -15,15 +15,15 @@ export function SprayProgramsTable() {
   const [search, setSearch] = useState("")
 
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 1,
+    pageIndex: 0,
     pageSize: 20,
   })
 
   const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
-    queryKey: ["dashboard-spray-programs", { p: pagination.pageIndex, search }],
+    queryKey: ["dashboard-spray-programs", { p: pagination.pageIndex + 1, search }],
     queryFn: () =>
       querySprayPrograms({
-        p: pagination.pageIndex,
+        p: pagination.pageIndex + 1,
         search: search,
       }),
     refetchOnWindowFocus: false

--- a/apps/admin-fnp/components/structures/tables/weedGroups.tsx
+++ b/apps/admin-fnp/components/structures/tables/weedGroups.tsx
@@ -15,15 +15,15 @@ export function WeedGroupsTable() {
   const [search, setSearch] = useState("")
 
   const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 1,
+    pageIndex: 0,
     pageSize: 20,
   })
 
   const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
-    queryKey: ["dashboard-weed-groups", { p: pagination.pageIndex, search }],
+    queryKey: ["dashboard-weed-groups", { p: pagination.pageIndex + 1, search }],
     queryFn: () =>
       queryWeedGroups({
-        p: pagination.pageIndex,
+        p: pagination.pageIndex + 1,
         search: search,
       }),
     refetchOnWindowFocus: false


### PR DESCRIPTION
## Summary
- Fix 0-based vs 1-based pageIndex mismatch causing pages 1 and 2 to show identical data
- All 22 admin dashboard tables now use `pageIndex: 0` with `p: pageIndex + 1` for the backend API