### PR TITLE
Add Facebook SDK to client app

### DIFF
--- a/apps/client-fnp/app/layout.tsx
+++ b/apps/client-fnp/app/layout.tsx
@@ -3,6 +3,7 @@ import localFont from "next/font/local"
 
 import { GoogleTagManager } from '@next/third-parties/google'
 import { Analytics } from "@vercel/analytics/react"
+import Script from "next/script"
 
 import { QueryProvider } from "@/components/providers/QueryProvider"
 import { ThemeProvider } from "@/components/providers/ThemeProvider"
@@ -78,6 +79,31 @@ export default async function RootLayout({ children }: RootLayoutProps) {
             <QueryProvider>
               <NuqsAdapter>
                 {children}
+                <Script
+                  id="facebook-sdk-init"
+                  strategy="lazyOnload"
+                  dangerouslySetInnerHTML={{
+                    __html: `
+                      window.fbAsyncInit = function() {
+                        FB.init({
+                          appId      : '512373632579287',
+                          cookie     : true,
+                          xfbml      : true,
+                          version    : 'v22.0'
+                        });
+                        FB.AppEvents.logPageView();
+                      };
+
+                      (function(d, s, id){
+                        var js, fjs = d.getElementsByTagName(s)[0];
+                        if (d.getElementById(id)) {return;}
+                        js = d.createElement(s); js.id = id;
+                        js.src = "https://connect.facebook.net/en_US/sdk.js";
+                        fjs.parentNode.insertBefore(js, fjs);
+                      }(document, 'script', 'facebook-jssdk'));
+                    `,
+                  }}
+                />
                 <GoogleTagManager gtmId={GTM_ID} />
                 <Toaster />
                 {NEXT_ENV !== 'production' && <SpeedInsights />}


### PR DESCRIPTION
## Summary
- Adds Facebook SDK async initialization to the client app root layout
- Uses Next.js Script component with lazyOnload strategy
- App ID: 512373632579287, API version: v22.0