### PR TITLE
Add personalized dashboard, product cross-sell, and produce price browsing

### DIFF
--- a/apps/admin-fnp/components/structures/forms/excelImport.tsx
+++ b/apps/admin-fnp/components/structures/forms/excelImport.tsx
@@ -141,10 +141,12 @@ export function ExcelImport({ setValue, setSelectedFarmProduce, setSelectedClien
 
             // Update current category
             if (category) {
-              // Normalize category name - map "SERVICE SLAUGHTER" to "slaughter"
+              // Normalize category name
               currentCategory = category.toLowerCase()
               if (currentCategory === "service slaughter") {
                 currentCategory = "slaughter"
+              } else if (currentCategory === "chickens") {
+                currentCategory = "chicken"
               }
 
               // Add to livestock list using display name
@@ -186,7 +188,13 @@ export function ExcelImport({ setValue, setSelectedFarmProduce, setSelectedClien
               "a_grade_over_1_75kg": "a_grade_over_1_75",
               "a_grade_under_1_55kg_average_liveweight": "a_grade_under_1_55",
               "a_grade_under_1_55kg": "a_grade_under_1_55",
+              // Surrey format - missing weight numbers in grade names
+              "a_grade_per_kg_live_kg_average_liveweight": "a_grade_1_55_1_75",
+              "a_grade_per_kg_live_over_kg_average_liveweight": "a_grade_over_1_75",
+              "a_grade_per_kg_live_under_kg_average_liveweight": "a_grade_under_1_55",
+              "off_layers_per_kg": "off_layers",
               "off_layers": "off_layers",
+              "condemned_doa_pet_food_grade": "condemned",
               "head": "head",
               // Slaughter services
               "cattle": "cattle",
@@ -363,6 +371,7 @@ export function ExcelImport({ setValue, setSelectedFarmProduce, setSelectedClien
           // For regular categories, map to specific farm produce names
           const categoryToProduceMapping: Record<string, string> = {
             "chicken": "Chickens Broilers",
+            "chickens": "Chickens Broilers",
           }
 
           const searchTerm = categoryToProduceMapping[livestock.toLowerCase()] || livestock

--- a/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/[slug]/page.tsx
@@ -125,8 +125,8 @@ export default async function AgroChemicalGuidePage({ params }: GuidePageProps) 
             <SprayProgramBackLink />
 
             {/* Breadcrumb */}
-            <div className="border-b bg-muted/30">
-                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+            <div className="border-b">
+                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
                     <nav className="flex text-sm text-muted-foreground">
                         <Link href="/" className="hover:text-foreground">Home</Link>
                         <span className="mx-2">/</span>

--- a/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/page.tsx
+++ b/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/page.tsx
@@ -36,8 +36,8 @@ export default async function AgroChemicalCategoryPage({ params }: CategoryPageP
     return (
         <div className="min-h-screen bg-gradient-to-b from-background to-muted/20">
             {/* Breadcrumb */}
-            <div className="border-b bg-muted/30">
-                <div className="max-w-7xl mx-auto px-6 lg:px-8 py-4">
+            <div className="border-b">
+                <div className="max-w-7xl mx-auto px-6 lg:px-8 py-3">
                     <nav className="flex text-sm text-muted-foreground">
                         <Link href="/" className="hover:text-foreground">Home</Link>
                         <span className="mx-2">/</span>

--- a/apps/client-fnp/app/(landing)/agrochemical-guides/page.tsx
+++ b/apps/client-fnp/app/(landing)/agrochemical-guides/page.tsx
@@ -87,25 +87,6 @@ export default async function AgrochemicalGuidesPage() {
                 </div>
             </section>
 
-            {/* Quick Stats */}
-            <section className="border-y bg-card/50">
-                <div className="mx-auto max-w-7xl px-6 lg:px-8">
-                    <div className="grid grid-cols-3 divide-x">
-                        <div className="py-6 text-center">
-                            <div className="text-2xl sm:text-3xl font-bold text-primary">{categories.length || "10"}+</div>
-                            <div className="text-xs sm:text-sm text-muted-foreground mt-1">Product Categories</div>
-                        </div>
-                        <div className="py-6 text-center">
-                            <div className="text-2xl sm:text-3xl font-bold text-primary">{sprayPrograms.length || "0"}</div>
-                            <div className="text-xs sm:text-sm text-muted-foreground mt-1">Spray Programs</div>
-                        </div>
-                        <div className="py-6 text-center">
-                            <div className="text-2xl sm:text-3xl font-bold text-primary">Free</div>
-                            <div className="text-xs sm:text-sm text-muted-foreground mt-1">Always Free Access</div>
-                        </div>
-                    </div>
-                </div>
-            </section>
 
             {/* Spray Programs Section */}
             {sprayPrograms.length > 0 && (
@@ -137,7 +118,7 @@ export default async function AgrochemicalGuidesPage() {
                                 <Link
                                     key={program.id}
                                     href={`/spray-programs/${program.slug}`}
-                                    className="group rounded-lg border bg-card overflow-hidden hover:border-primary hover:shadow-md transition-all duration-300"
+                                    className="group rounded-xl border bg-card shadow-sm hover:shadow-md hover:border-primary/20 transition-all duration-200"
                                 >
                                     <div className="p-3">
                                         <h3 className="font-semibold text-sm mb-1 group-hover:text-primary transition-colors line-clamp-1">

--- a/apps/client-fnp/app/(landing)/animal-health-guides/[category]/AnimalHealthCategoryClient.tsx
+++ b/apps/client-fnp/app/(landing)/animal-health-guides/[category]/AnimalHealthCategoryClient.tsx
@@ -21,6 +21,7 @@ export function AnimalHealthCategoryClient({ category, categoryName, initialProd
         brand: parseAsArrayOf(parseAsString),
         target: parseAsArrayOf(parseAsString),
         active_ingredient: parseAsArrayOf(parseAsString),
+        used_on: parseAsArrayOf(parseAsString),
         p: parseAsInteger.withDefault(1),
     })
 
@@ -28,16 +29,18 @@ export function AnimalHealthCategoryClient({ category, categoryName, initialProd
         (queryState.brand && queryState.brand.length > 0) ||
         (queryState.target && queryState.target.length > 0) ||
         (queryState.active_ingredient && queryState.active_ingredient.length > 0) ||
+        (queryState.used_on && queryState.used_on.length > 0) ||
         queryState.p > 1
 
     const { data: productsData, isLoading: productsLoading } = useQuery({
-        queryKey: ["animal-health-category", category, queryState.p, queryState.brand, queryState.target, queryState.active_ingredient],
+        queryKey: ["animal-health-category", category, queryState.p, queryState.brand, queryState.target, queryState.active_ingredient, queryState.used_on],
         queryFn: () => queryAnimalHealthProductsByCategory({
             category,
             p: queryState.p,
             brand: queryState.brand || [],
             target: queryState.target || [],
             active_ingredient: queryState.active_ingredient || [],
+            used_on: queryState.used_on || [],
         }),
         refetchOnWindowFocus: false,
         placeholderData: !hasFilters ? { data: { data: initialProducts, total: initialTotal } } as any : undefined,

--- a/apps/client-fnp/app/(landing)/animal-health-guides/[category]/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/animal-health-guides/[category]/[slug]/page.tsx
@@ -212,8 +212,8 @@ export default async function AnimalHealthGuidePage({ params }: GuidePageProps) 
             />
 
             {/* Breadcrumb */}
-            <div className="border-b bg-muted/30">
-                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+            <div className="border-b">
+                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
                     <nav className="flex text-sm text-muted-foreground">
                         <Link href="/" className="hover:text-foreground">Home</Link>
                         <span className="mx-2">/</span>

--- a/apps/client-fnp/app/(landing)/animal-health-guides/[category]/page.tsx
+++ b/apps/client-fnp/app/(landing)/animal-health-guides/[category]/page.tsx
@@ -32,8 +32,8 @@ export default async function AnimalHealthCategoryPage({ params }: CategoryPageP
     return (
         <div className="min-h-screen bg-gradient-to-b from-background to-muted/20">
             {/* Breadcrumb */}
-            <div className="border-b bg-muted/30">
-                <div className="max-w-7xl mx-auto px-6 lg:px-8 py-4">
+            <div className="border-b">
+                <div className="max-w-7xl mx-auto px-6 lg:px-8 py-3">
                     <nav className="flex text-sm text-muted-foreground">
                         <Link href="/" className="hover:text-foreground">Home</Link>
                         <span className="mx-2">/</span>

--- a/apps/client-fnp/app/(landing)/buy-agrochemicals/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/buy-agrochemicals/[slug]/page.tsx
@@ -82,8 +82,8 @@ export default async function BuyAgroChemicalPage({ params }: BuyAgroChemicalPag
             )}
 
             {/* Breadcrumb */}
-            <div className="border-b bg-muted/30">
-                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+            <div className="border-b">
+                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
                     <nav className="flex text-sm text-muted-foreground">
                         <Link href="/" className="hover:text-foreground">Home</Link>
                         <span className="mx-2">/</span>

--- a/apps/client-fnp/app/(landing)/buy-feeds/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/buy-feeds/[slug]/page.tsx
@@ -92,8 +92,8 @@ export default async function BuyFeedPage({ params }: BuyFeedPageProps) {
             />
 
             {/* Breadcrumb */}
-            <div className="border-b bg-muted/30">
-                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+            <div className="border-b">
+                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
                     <nav className="flex text-sm text-muted-foreground">
                         <Link href="/" className="hover:text-foreground">Home</Link>
                         <span className="mx-2">/</span>

--- a/apps/client-fnp/app/(landing)/buyers/[product]/page.tsx
+++ b/apps/client-fnp/app/(landing)/buyers/[product]/page.tsx
@@ -6,6 +6,7 @@ import { AppURL, getBuyerSeo } from "@/lib/schemas";
 import { ClientFilterSidebar } from "@/components/generic/clientFilterSidebar"
 import { ActionsSidebar } from "@/components/generic/actions-sidebar"
 import { CrossSellBanner } from "@/components/monetization/cross-sell-banner"
+import { ProductResources } from "@/components/monetization/product-resources"
 import { RelatedMarkets } from "@/components/monetization/related-markets"
 
 
@@ -75,6 +76,7 @@ export default async function BuyersProductPage({ params }: BuyerProductPageProp
         </p>
 
         <CrossSellBanner product={product} context="buyer" />
+        <ProductResources product={product} />
 
         <div className="lg:flex lg:space-x-10">
           <div className="hidden lg:block lg:w-64 relative">

--- a/apps/client-fnp/app/(landing)/farmers/[product]/page.tsx
+++ b/apps/client-fnp/app/(landing)/farmers/[product]/page.tsx
@@ -6,6 +6,7 @@ import {AppURL, getFarmerSeo} from "@/lib/schemas";
 import { ClientFilterSidebar } from "@/components/generic/clientFilterSidebar"
 import { ActionsSidebar } from "@/components/generic/actions-sidebar"
 import { CrossSellBanner } from "@/components/monetization/cross-sell-banner"
+import { ProductResources } from "@/components/monetization/product-resources"
 import { RelatedMarkets } from "@/components/monetization/related-markets"
 
 
@@ -75,6 +76,7 @@ export default async function FarmersProductPage({ params }: FarmerProductPagePr
         </p>
 
         <CrossSellBanner product={product} context="farmer" />
+        <ProductResources product={product} />
 
         <div className="lg:flex lg:space-x-10">
           <div className="hidden lg:block lg:w-64 relative">

--- a/apps/client-fnp/app/(landing)/feeding-programs/[slug]/FeedingProgramDetailClient.tsx
+++ b/apps/client-fnp/app/(landing)/feeding-programs/[slug]/FeedingProgramDetailClient.tsx
@@ -12,9 +12,6 @@ import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
 
 const STAGE_STYLE = {
     dot: "bg-amber-600 dark:bg-amber-500",
-    bg: "bg-muted/40",
-    text: "text-foreground",
-    border: "border-border",
 }
 
 const PURPOSE_COLORS: Record<string, { bg: string; text: string; icon: any }> = {
@@ -44,7 +41,6 @@ export function FeedingProgramDetailClient({ program, slug }: FeedingProgramDeta
     const stageRefs = useRef<(HTMLDivElement | null)[]>([])
     const navRef = useRef<HTMLDivElement>(null)
 
-    // Extract unique brands from all recommendations
     const brands = useMemo(() => {
         if (!program?.stages) return []
         const brandMap = new Map<string, string>()
@@ -59,7 +55,6 @@ export function FeedingProgramDetailClient({ program, slug }: FeedingProgramDeta
         return Array.from(brandMap.values()).sort()
     }, [program?.stages])
 
-    // Filter stages' recommendations by selected brand
     const filteredStages = useMemo(() => {
         if (!program?.stages) return []
         if (!selectedBrand) return program.stages
@@ -108,20 +103,20 @@ export function FeedingProgramDetailClient({ program, slug }: FeedingProgramDeta
     return (
         <div className="min-h-screen bg-background">
             {/* Breadcrumb */}
-            <div className="border-b bg-muted/30">
-                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+            <div className="border-b">
+                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
                     <nav className="flex text-sm text-muted-foreground">
-                        <Link href="/" className="hover:text-foreground">Home</Link>
+                        <Link href="/" className="hover:text-foreground transition-colors">Home</Link>
                         <span className="mx-2">/</span>
-                        <Link href="/feeding-programs" className="hover:text-foreground">Feeding Programs</Link>
+                        <Link href="/feeding-programs" className="hover:text-foreground transition-colors">Feeding Programs</Link>
                         <span className="mx-2">/</span>
                         <span className="text-foreground">{capitalizeFirstLetter(program.name)}</span>
                     </nav>
                 </div>
             </div>
 
-            {/* Hero Header */}
-            <section className="relative overflow-hidden">
+            {/* Hero */}
+            <section className="border-b">
                 {program.cover_image?.img?.src ? (
                     <div className="relative h-56 sm:h-72 lg:h-80">
                         <Image
@@ -134,69 +129,67 @@ export function FeedingProgramDetailClient({ program, slug }: FeedingProgramDeta
                         />
                         <div className="absolute inset-0 bg-gradient-to-t from-background via-background/60 to-transparent" />
                         <div className="absolute bottom-0 left-0 right-0 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-8">
-                            <div className="flex items-center gap-3 mb-3">
+                            <div className="flex items-center gap-2 mb-3">
                                 {program.farm_produce_name && (
-                                    <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium bg-amber-100/90 text-amber-800 dark:bg-amber-900/60 dark:text-amber-300 backdrop-blur-sm">
+                                    <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-amber-100/90 text-amber-800 dark:bg-amber-900/60 dark:text-amber-300 backdrop-blur-sm">
                                         <Egg className="h-3 w-3" />
                                         {capitalizeFirstLetter(program.farm_produce_name)}
                                     </span>
                                 )}
-                                <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-white/90 text-foreground dark:bg-gray-900/60 dark:text-gray-200 backdrop-blur-sm">
-                                    {allStages.length} Feeding {allStages.length === 1 ? "Stage" : "Stages"}
+                                <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-white/90 text-foreground dark:bg-gray-900/60 dark:text-gray-200 backdrop-blur-sm">
+                                    {allStages.length} {allStages.length === 1 ? "Stage" : "Stages"}
                                 </span>
                             </div>
-                            <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold text-foreground">
+                            <h1 className="text-3xl sm:text-4xl font-bold font-heading tracking-tight">
                                 {capitalizeFirstLetter(program.name)}
                             </h1>
                             {program.description && (
-                                <p className="mt-3 text-base sm:text-lg text-muted-foreground max-w-2xl">
+                                <p className="mt-2 text-sm sm:text-base text-muted-foreground max-w-2xl">
                                     {program.description}
                                 </p>
                             )}
                         </div>
                     </div>
                 ) : (
-                    <div className="relative bg-gradient-to-br from-amber-50 to-orange-50 dark:from-amber-950/30 dark:to-orange-950/20 py-12 lg:py-16">
-                        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-                            <div className="flex items-center gap-3 mb-3">
-                                {program.farm_produce_name && (
-                                    <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
-                                        <Egg className="h-3 w-3" />
-                                        {capitalizeFirstLetter(program.farm_produce_name)}
-                                    </span>
-                                )}
-                                <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-muted text-muted-foreground">
-                                    {allStages.length} Feeding {allStages.length === 1 ? "Stage" : "Stages"}
+                    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-10 pb-8">
+                        <div className="flex items-center gap-2 mb-3">
+                            {program.farm_produce_name && (
+                                <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-600/10 dark:bg-amber-950/30 dark:text-amber-400">
+                                    <Egg className="h-3 w-3" />
+                                    {capitalizeFirstLetter(program.farm_produce_name)}
                                 </span>
-                            </div>
-                            <h1 className="text-3xl sm:text-4xl lg:text-5xl font-bold">
-                                {capitalizeFirstLetter(program.name)}
-                            </h1>
-                            {program.description && (
-                                <p className="mt-3 text-base sm:text-lg text-muted-foreground max-w-2xl">
-                                    {program.description}
-                                </p>
                             )}
+                            <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-muted text-muted-foreground">
+                                {allStages.length} {allStages.length === 1 ? "Stage" : "Stages"}
+                            </span>
                         </div>
+                        <h1 className="text-3xl sm:text-4xl font-bold font-heading tracking-tight">
+                            {capitalizeFirstLetter(program.name)}
+                        </h1>
+                        {program.description && (
+                            <p className="mt-2 text-sm text-muted-foreground max-w-2xl">
+                                {program.description}
+                            </p>
+                        )}
                     </div>
                 )}
             </section>
 
-            {/* Sticky Stage Navigator */}
+            {/* Sticky Stage Nav */}
             {allStages.length > 0 && (
-                <div ref={navRef} className="sticky top-16 z-20 bg-background/95 backdrop-blur-md border-b shadow-sm">
+                <div ref={navRef} className="sticky top-16 z-20 bg-background/95 backdrop-blur-md border-b">
                     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
                         <div className="flex gap-1 overflow-x-auto py-3 scrollbar-hide">
                             <button
                                 onClick={() => scrollToStage(0)}
-                                className={`flex-shrink-0 px-4 py-2 rounded-full text-sm font-medium transition-all ${
+                                className={`flex-shrink-0 px-3.5 py-1.5 rounded-full text-sm font-medium transition-all ${
                                     activeStage === 0
-                                        ? "bg-primary text-primary-foreground"
+                                        ? "bg-primary text-primary-foreground shadow-sm"
                                         : "text-muted-foreground hover:text-foreground hover:bg-muted"
                                 }`}
                             >
                                 <span className="flex items-center gap-2">
-                                    <span className={`w-2 h-2 rounded-full ${activeStage === 0 ? "bg-primary-foreground" : STAGE_STYLE.dot}`} />
+                                    <span className={`w-1.5 h-1.5 rounded-full ${activeStage === 0 ? "bg-primary-foreground" : STAGE_STYLE.dot}`} />
                                     Overview
                                 </span>
                             </button>
@@ -207,14 +200,14 @@ export function FeedingProgramDetailClient({ program, slug }: FeedingProgramDeta
                                     <button
                                         key={index}
                                         onClick={() => scrollToStage(tabIndex)}
-                                        className={`flex-shrink-0 px-4 py-2 rounded-full text-sm font-medium transition-all ${
+                                        className={`flex-shrink-0 px-3.5 py-1.5 rounded-full text-sm font-medium transition-all ${
                                             isActive
-                                                ? "bg-primary text-primary-foreground"
+                                                ? "bg-primary text-primary-foreground shadow-sm"
                                                 : "text-muted-foreground hover:text-foreground hover:bg-muted"
                                         }`}
                                     >
                                         <span className="flex items-center gap-2">
-                                            <span className={`w-2 h-2 rounded-full ${isActive ? "bg-primary-foreground" : STAGE_STYLE.dot}`} />
+                                            <span className={`w-1.5 h-1.5 rounded-full ${isActive ? "bg-primary-foreground" : STAGE_STYLE.dot}`} />
                                             {capitalizeFirstLetter(stage.name)}
                                         </span>
                                     </button>
@@ -225,7 +218,7 @@ export function FeedingProgramDetailClient({ program, slug }: FeedingProgramDeta
                 </div>
             )}
 
-            {/* Program Overview Chart */}
+            {/* Overview Table */}
             {stages.length > 0 && (() => {
                 const hasBrands = brands.length > 1
 
@@ -249,16 +242,16 @@ export function FeedingProgramDetailClient({ program, slug }: FeedingProgramDeta
                         className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-8"
                     >
                         <div className="flex items-center justify-between mb-4">
-                            <h2 className="text-lg font-semibold text-foreground">Program Overview</h2>
+                            <h2 className="text-lg font-semibold">Program Overview</h2>
                             {hasBrands && (
-                                <div className="flex items-center gap-2">
-                                    <span className="text-xs text-muted-foreground">Brand:</span>
+                                <div className="flex items-center gap-1.5">
+                                    <span className="text-xs text-muted-foreground mr-1">Brand:</span>
                                     <button
                                         onClick={() => setSelectedBrand(null)}
                                         className={`px-3 py-1 rounded-full text-xs font-medium transition-all ${
                                             !selectedBrand
-                                                ? "bg-foreground text-background"
-                                                : "bg-muted text-muted-foreground hover:text-foreground"
+                                                ? "bg-primary text-primary-foreground shadow-sm"
+                                                : "border bg-card text-muted-foreground hover:text-foreground hover:border-primary/20"
                                         }`}
                                     >
                                         All
@@ -269,8 +262,8 @@ export function FeedingProgramDetailClient({ program, slug }: FeedingProgramDeta
                                             onClick={() => setSelectedBrand(brand)}
                                             className={`px-3 py-1 rounded-full text-xs font-medium transition-all ${
                                                 selectedBrand === brand
-                                                    ? "bg-foreground text-background"
-                                                    : "bg-muted text-muted-foreground hover:text-foreground"
+                                                    ? "bg-primary text-primary-foreground shadow-sm"
+                                                    : "border bg-card text-muted-foreground hover:text-foreground hover:border-primary/20"
                                             }`}
                                         >
                                             {capitalizeFirstLetter(brand)}
@@ -279,33 +272,33 @@ export function FeedingProgramDetailClient({ program, slug }: FeedingProgramDeta
                                 </div>
                             )}
                         </div>
-                        <div className="rounded-xl border border-border overflow-hidden">
+                        <div className="rounded-xl border bg-card shadow-sm overflow-hidden">
                             <div className="overflow-x-auto">
-                                <table className="w-full border-collapse min-w-[640px]">
+                                <table className="w-full text-sm min-w-[640px]">
                                     <thead>
-                                        <tr className="bg-muted/60">
-                                            <th className="text-left text-xs font-semibold text-muted-foreground uppercase tracking-wide p-3 w-36 border-r border-border sticky left-0 bg-muted/60 z-10">
+                                        <tr className="bg-muted/50">
+                                            <th className="text-left text-[11px] font-medium text-muted-foreground uppercase tracking-wider px-4 py-3 w-36 sticky left-0 bg-muted/50 z-10">
                                                 Purpose
                                             </th>
                                             {stages.map((stage: any, idx: number) => (
-                                                <th key={idx} className="text-center p-3 border-r border-border last:border-r-0 min-w-[140px]">
-                                                    <div className="text-xs font-semibold text-foreground">{capitalizeFirstLetter(stage.name)}</div>
+                                                <th key={idx} className="text-center px-4 py-3 min-w-[140px]">
+                                                    <div className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">{capitalizeFirstLetter(stage.name)}</div>
                                                     {stage.timing_description && (
-                                                        <div className="text-[10px] text-muted-foreground font-normal mt-0.5">{stage.timing_description}</div>
+                                                        <div className="text-[10px] text-muted-foreground/70 font-normal mt-0.5">{stage.timing_description}</div>
                                                     )}
                                                 </th>
                                             ))}
                                         </tr>
                                     </thead>
-                                    <tbody className="divide-y divide-border">
+                                    <tbody className="divide-y">
                                         {purposes.map((purpose) => {
                                             const stageMap = purposeMap.get(purpose)!
                                             const style = getPurposeStyle(purpose)
                                             const Icon = style.icon
                                             return (
-                                                <tr key={purpose} className="hover:bg-muted/20 transition-colors">
-                                                    <td className="p-3 border-r border-border sticky left-0 bg-background z-10">
-                                                        <div className={`inline-flex items-center gap-1.5 px-2 py-1 rounded text-[11px] font-medium ${style.bg} ${style.text}`}>
+                                                <tr key={purpose} className="group/row hover:bg-muted/30 transition-colors">
+                                                    <td className="px-4 py-3 sticky left-0 bg-card group-hover/row:bg-muted/30 z-10 transition-colors">
+                                                        <div className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md text-[11px] font-medium ${style.bg} ${style.text}`}>
                                                             <Icon className="h-3 w-3" />
                                                             {purpose}
                                                         </div>
@@ -313,14 +306,14 @@ export function FeedingProgramDetailClient({ program, slug }: FeedingProgramDeta
                                                     {stages.map((_: any, stageIdx: number) => {
                                                         const recs = stageMap.get(stageIdx) || []
                                                         return (
-                                                            <td key={stageIdx} className="p-2 border-r border-border last:border-r-0 align-top">
+                                                            <td key={stageIdx} className="px-3 py-2.5 align-top">
                                                                 {recs.length > 0 ? (
                                                                     <div className="space-y-1.5">
                                                                         {recs.map((rec: any, i: number) => (
                                                                             <button
                                                                                 key={i}
                                                                                 onClick={() => setQuickViewRec(rec)}
-                                                                                className={`block w-full text-left p-2 rounded ${style.bg} cursor-pointer hover:ring-1 hover:ring-current transition-all`}
+                                                                                className={`block w-full text-left px-2.5 py-1.5 rounded-md ${style.bg} cursor-pointer hover:ring-1 hover:ring-current transition-all`}
                                                                             >
                                                                                 <div className={`text-xs font-medium ${style.text} leading-tight`}>
                                                                                     {capitalizeFirstLetter(rec.feed_product_name)}
@@ -355,8 +348,8 @@ export function FeedingProgramDetailClient({ program, slug }: FeedingProgramDeta
                 </div>
             )}
 
-            {/* Stage Sections */}
-            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-10">
+            {/* Stage Cards */}
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
                 {stages.map((stage: any, stageIndex: number) => {
                     const recommendations = stage.recommendations || []
 
@@ -364,12 +357,12 @@ export function FeedingProgramDetailClient({ program, slug }: FeedingProgramDeta
                         <div
                             key={stageIndex}
                             ref={(el) => { stageRefs.current[stageIndex + 1] = el }}
-                            className="rounded-xl border border-border overflow-hidden"
+                            className="rounded-xl border bg-card shadow-sm overflow-hidden"
                         >
-                            <div className="bg-muted/40 px-6 py-5">
+                            <div className="px-5 pt-5 pb-3">
                                 <div className="flex items-start justify-between flex-wrap gap-3">
                                     <div>
-                                        <h2 className="text-xl sm:text-2xl font-bold text-foreground">
+                                        <h2 className="text-lg font-bold font-heading tracking-tight">
                                             {capitalizeFirstLetter(stage.name)}
                                         </h2>
                                         {stage.description && (
@@ -379,7 +372,7 @@ export function FeedingProgramDetailClient({ program, slug }: FeedingProgramDeta
                                         )}
                                     </div>
                                     {stage.timing_description && (
-                                        <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-semibold bg-muted text-muted-foreground border border-border">
+                                        <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-muted text-muted-foreground">
                                             {stage.timing_description}
                                         </span>
                                     )}
@@ -387,17 +380,17 @@ export function FeedingProgramDetailClient({ program, slug }: FeedingProgramDeta
                             </div>
 
                             {recommendations.length > 0 ? (
-                                <div className="divide-y divide-border">
+                                <div className="divide-y">
                                     {recommendations.map((rec: any, recIndex: number) => {
                                         const purposeStyle = getPurposeStyle(rec.purpose)
                                         const PurposeIcon = purposeStyle.icon
 
                                         return (
-                                            <div key={recIndex} className="flex items-center gap-4 px-6 py-3 hover:bg-muted/30 transition-colors">
+                                            <div key={recIndex} className="flex items-center gap-4 px-5 py-3 hover:bg-muted/30 transition-colors group">
                                                 <div className="flex-1 min-w-0">
                                                     <button
                                                         onClick={() => setQuickViewRec(rec)}
-                                                        className="text-sm font-medium text-foreground hover:text-primary transition-colors text-left truncate block w-full cursor-pointer"
+                                                        className="text-sm font-medium text-foreground hover:text-primary transition-colors text-left truncate block w-full cursor-pointer group-hover:text-primary"
                                                     >
                                                         {capitalizeFirstLetter(rec.feed_product_name)}
                                                     </button>
@@ -405,7 +398,7 @@ export function FeedingProgramDetailClient({ program, slug }: FeedingProgramDeta
                                                         {rec.feed_product?.brand?.name && (
                                                             <span className="text-xs text-muted-foreground">{rec.feed_product.brand.name}</span>
                                                         )}
-                                                        <div className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium ${purposeStyle.bg} ${purposeStyle.text}`}>
+                                                        <div className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md text-[10px] font-medium ${purposeStyle.bg} ${purposeStyle.text}`}>
                                                             <PurposeIcon className="h-2.5 w-2.5" />
                                                             {rec.purpose}
                                                         </div>
@@ -415,9 +408,9 @@ export function FeedingProgramDetailClient({ program, slug }: FeedingProgramDeta
                                                 {rec.feed_product_slug && (
                                                     <Link
                                                         href={`/feeds/${rec.feed_product_slug}?ref=${slug}`}
-                                                        className="flex-shrink-0 text-xs font-medium text-primary hover:text-primary/80 transition-colors flex items-center gap-1"
+                                                        className="flex-shrink-0 text-xs font-medium text-muted-foreground hover:text-primary transition-colors flex items-center gap-1 opacity-0 group-hover:opacity-100"
                                                     >
-                                                        View Product
+                                                        View
                                                         <ChevronRight className="h-3 w-3" />
                                                     </Link>
                                                 )}
@@ -426,7 +419,7 @@ export function FeedingProgramDetailClient({ program, slug }: FeedingProgramDeta
                                     })}
                                 </div>
                             ) : (
-                                <div className="p-6 text-sm text-muted-foreground">
+                                <div className="px-5 pb-5 text-sm text-muted-foreground">
                                     {selectedBrand
                                         ? `No ${selectedBrand} recommendations for this stage.`
                                         : "No feed recommendations for this stage yet."}
@@ -437,12 +430,12 @@ export function FeedingProgramDetailClient({ program, slug }: FeedingProgramDeta
                 })}
 
                 {/* Disclaimer */}
-                <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-lg p-6">
+                <div className="rounded-xl border border-yellow-200 dark:border-yellow-800/30 bg-yellow-50 dark:bg-yellow-950/20 p-5">
                     <div className="flex items-start gap-3">
-                        <AlertTriangle className="w-6 h-6 text-yellow-600 dark:text-yellow-500 flex-shrink-0" />
+                        <AlertTriangle className="w-5 h-5 text-yellow-600 dark:text-yellow-500 flex-shrink-0 mt-0.5" />
                         <div>
-                            <h3 className="font-semibold mb-2 text-yellow-900 dark:text-yellow-100">Important Notice</h3>
-                            <p className="text-sm text-yellow-800 dark:text-yellow-200">
+                            <h3 className="text-sm font-semibold text-yellow-900 dark:text-yellow-100 mb-1">Important Notice</h3>
+                            <p className="text-xs text-yellow-800 dark:text-yellow-200 leading-relaxed">
                                 Always follow the manufacturer&apos;s feeding guidelines and recommended quantities. Feeding requirements may vary based on breed, climate, and individual animal condition. Consult a veterinarian or animal nutritionist for advice specific to your livestock operation.
                             </p>
                         </div>
@@ -457,44 +450,42 @@ export function FeedingProgramDetailClient({ program, slug }: FeedingProgramDeta
                         className="absolute inset-0 bg-black/50 backdrop-blur-sm"
                         onClick={() => setQuickViewRec(null)}
                     />
-                    <div className="relative bg-background rounded-xl border shadow-2xl max-w-md w-full">
+                    <div className="relative bg-card rounded-xl border shadow-lg max-w-md w-full">
                         <button
                             onClick={() => setQuickViewRec(null)}
-                            className="absolute right-3 top-3 z-10 p-1.5 rounded-full bg-muted hover:bg-muted/80 transition-colors"
+                            className="absolute right-3 top-3 z-10 p-1.5 rounded-md hover:bg-muted transition-colors"
                         >
-                            <X className="h-4 w-4" />
+                            <X className="h-4 w-4 text-muted-foreground" />
                         </button>
 
                         <div className="p-5 space-y-4">
-                            <div className="flex items-start gap-4">
-                                <div className="flex-1 min-w-0">
-                                    <h3 className="text-lg font-bold leading-tight pr-8">
-                                        {capitalizeFirstLetter(quickViewRec.feed_product_name)}
-                                    </h3>
-                                    {quickViewRec.feed_product?.show_price && quickViewRec.feed_product?.sale_price > 0 && (
-                                        <div className="mt-2">
-                                            <span className="text-lg font-bold text-foreground">${quickViewRec.feed_product.sale_price.toFixed(2)}</span>
-                                            {quickViewRec.feed_product.was_price > quickViewRec.feed_product.sale_price && (
-                                                <span className="text-sm text-muted-foreground line-through ml-2">${quickViewRec.feed_product.was_price.toFixed(2)}</span>
-                                            )}
+                            <div>
+                                <h3 className="text-base font-bold leading-tight pr-8">
+                                    {capitalizeFirstLetter(quickViewRec.feed_product_name)}
+                                </h3>
+                                {quickViewRec.feed_product?.show_price && quickViewRec.feed_product?.sale_price > 0 && (
+                                    <div className="mt-2">
+                                        <span className="text-lg font-bold text-foreground">${quickViewRec.feed_product.sale_price.toFixed(2)}</span>
+                                        {quickViewRec.feed_product.was_price > quickViewRec.feed_product.sale_price && (
+                                            <span className="text-sm text-muted-foreground line-through ml-2">${quickViewRec.feed_product.was_price.toFixed(2)}</span>
+                                        )}
+                                    </div>
+                                )}
+                                {quickViewRec.purpose && (() => {
+                                    const style = getPurposeStyle(quickViewRec.purpose)
+                                    const Icon = style.icon
+                                    return (
+                                        <div className={`inline-flex items-center gap-1 mt-2 px-2 py-0.5 rounded-md text-[11px] font-medium ${style.bg} ${style.text}`}>
+                                            <Icon className="h-3 w-3" />
+                                            {quickViewRec.purpose}
                                         </div>
-                                    )}
-                                    {quickViewRec.purpose && (() => {
-                                        const style = getPurposeStyle(quickViewRec.purpose)
-                                        const Icon = style.icon
-                                        return (
-                                            <div className={`inline-flex items-center gap-1 mt-2 px-2 py-0.5 rounded text-[11px] font-medium ${style.bg} ${style.text}`}>
-                                                <Icon className="h-3 w-3" />
-                                                {quickViewRec.purpose}
-                                            </div>
-                                        )
-                                    })()}
-                                </div>
+                                    )
+                                })()}
                             </div>
 
                             {quickViewRec.notes && (
-                                <div className="bg-muted/30 rounded-lg p-3 border">
-                                    <p className="text-sm text-foreground">{quickViewRec.notes}</p>
+                                <div className="rounded-lg bg-muted/50 p-3">
+                                    <p className="text-sm text-muted-foreground">{quickViewRec.notes}</p>
                                 </div>
                             )}
                         </div>
@@ -503,7 +494,7 @@ export function FeedingProgramDetailClient({ program, slug }: FeedingProgramDeta
                             <div className="px-5 pb-5">
                                 <Link
                                     href={`/feeds/${quickViewRec.feed_product_slug}?ref=${slug}`}
-                                    className="flex items-center justify-center gap-2 w-full py-2 rounded-md text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+                                    className="flex items-center justify-center gap-2 w-full py-2.5 rounded-lg text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
                                     onClick={() => setQuickViewRec(null)}
                                 >
                                     View Full Product

--- a/apps/client-fnp/app/(landing)/feeding-programs/page.tsx
+++ b/apps/client-fnp/app/(landing)/feeding-programs/page.tsx
@@ -1,7 +1,6 @@
-import Link from "next/link"
-import { Egg, Layers, ChevronRight } from "lucide-react"
+import { Egg } from "lucide-react"
 import { queryPublishedFeedingPrograms } from "@/lib/query"
-import { capitalizeFirstLetter } from "@/lib/utilities"
+import { FeedingProgramsGrid } from "@/components/structures/feeding-programs-grid"
 
 export default async function FeedingProgramsPage() {
     let programs: any[] = []
@@ -23,7 +22,7 @@ export default async function FeedingProgramsPage() {
                 </div>
             </section>
             <section className="mx-auto max-w-7xl px-6 lg:px-8 py-8">
-                {programs.length === 0 && (
+                {programs.length === 0 ? (
                     <div className="text-center py-16">
                         <div className="mx-auto w-16 h-16 bg-muted rounded-full flex items-center justify-center mb-4">
                             <Egg className="w-8 h-8 text-muted-foreground" />
@@ -31,30 +30,8 @@ export default async function FeedingProgramsPage() {
                         <h2 className="text-lg font-semibold mb-1">No Feeding Programs Yet</h2>
                         <p className="text-sm text-muted-foreground max-w-md mx-auto">We're working on creating comprehensive feeding programs. Check back soon.</p>
                     </div>
-                )}
-                {programs.length > 0 && (
-                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                        {programs.map((program: any) => (
-                            <Link key={program.id} href={`/feeding-programs/${program.slug}`} className="group rounded-xl border bg-card overflow-hidden hover:shadow-md hover:border-primary/20 transition-all">
-                                <div className="p-4">
-                                    <h2 className="text-sm font-bold font-heading mb-1 group-hover:text-primary transition-colors">{capitalizeFirstLetter(program.name)}</h2>
-                                    {program.farm_produce_name && (
-                                        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-600/10 dark:bg-amber-950/30 dark:text-amber-400 mb-2">{capitalizeFirstLetter(program.farm_produce_name)}</span>
-                                    )}
-                                    {program.description && (
-                                        <p className="text-xs text-muted-foreground line-clamp-2 mb-3">{program.description}</p>
-                                    )}
-                                    <div className="flex items-center justify-between">
-                                        <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
-                                            <Layers className="h-3 w-3" />
-                                            <span>{program.stages?.length || 0} stages</span>
-                                        </div>
-                                        <ChevronRight className="h-3.5 w-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
-                                    </div>
-                                </div>
-                            </Link>
-                        ))}
-                    </div>
+                ) : (
+                    <FeedingProgramsGrid programs={programs} />
                 )}
             </section>
         </main>

--- a/apps/client-fnp/app/(landing)/feeds/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/feeds/[slug]/page.tsx
@@ -85,8 +85,8 @@ export default async function FeedDetailPage({ params }: FeedDetailPageProps) {
             />
 
             {/* Breadcrumb */}
-            <div className="border-b bg-muted/30">
-                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+            <div className="border-b">
+                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
                     <FeedBreadcrumb productName={product.name} />
                 </div>
             </div>

--- a/apps/client-fnp/app/(landing)/prices/[slug]/[produce]/page.tsx
+++ b/apps/client-fnp/app/(landing)/prices/[slug]/[produce]/page.tsx
@@ -1,0 +1,185 @@
+import { PriceDetailsGrid } from "@/components/structures/price-details-grid"
+import { RelatedPricesSidebar } from "@/components/structures/related-prices-sidebar"
+import { ContactBuyerButton } from "@/components/structures/contact-buyer-button"
+import { formatDate, capitalizeFirstLetter } from "@/lib/utilities"
+import { AppURL } from "@/lib/schemas"
+import axios from "axios"
+import { notFound } from "next/navigation"
+import Link from "next/link"
+import { Calendar, Building2, ArrowLeft } from "lucide-react"
+import { auth } from "@/auth"
+import type { Metadata } from "next"
+
+const validProduce = ["beef", "lamb", "mutton", "goat", "chicken", "pork", "slaughter"]
+
+interface ProducePageProps {
+  params: Promise<{
+    slug: string
+    produce: string
+  }>
+}
+
+async function getPriceListBySlug(slug: string) {
+  try {
+    const baseURL = process.env.NEXT_PUBLIC_BASE_URL || process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3744"
+    const response = await axios.get(`${baseURL}/v1/prices/all?p=1&limit=100`)
+    const priceLists = response.data?.data || []
+
+    const priceList = priceLists.find((pl: any) => {
+      const plDate = new Date(pl.effectiveDate).toISOString().split('T')[0]
+      const plSlug = `${pl.client_name.toLowerCase().replace(/\s+/g, '-')}-${plDate}`
+      return plSlug === slug
+    })
+
+    return { priceList: priceList || null, allPrices: priceLists }
+  } catch (error) {
+    return { priceList: null, allPrices: [] }
+  }
+}
+
+export async function generateMetadata({ params }: ProducePageProps): Promise<Metadata> {
+  const { slug, produce } = await params
+
+  if (!validProduce.includes(produce)) {
+    return { title: 'Not Found | farmnport.com' }
+  }
+
+  const { priceList } = await getPriceListBySlug(slug)
+
+  if (!priceList || !priceList[produce]) {
+    return { title: 'Price List Not Found | farmnport.com' }
+  }
+
+  const name = capitalizeFirstLetter(priceList.client_name)
+  const produceName = capitalizeFirstLetter(produce)
+  const date = formatDate(priceList.effectiveDate.toString())
+
+  return {
+    title: `${produceName} Prices — ${name} ${date} | farmnport.com`,
+    description: `${name} ${produceName.toLowerCase()} price list effective ${date}. View current ${produceName.toLowerCase()} market rates by grade — delivered and collected prices.`,
+    alternates: {
+      canonical: `${AppURL}/prices/${slug}/${produce}`,
+    },
+    openGraph: {
+      title: `${produceName} Prices — ${name} ${date}`,
+      description: `${name} ${produceName.toLowerCase()} price list effective ${date}. View current market rates on Farmnport.`,
+      url: `${AppURL}/prices/${slug}/${produce}`,
+      siteName: 'farmnport',
+      type: 'website',
+    },
+  }
+}
+
+export default async function ProduceDetailPage({ params }: ProducePageProps) {
+  const { slug, produce } = await params
+
+  if (!validProduce.includes(produce)) {
+    notFound()
+  }
+
+  const { priceList, allPrices } = await getPriceListBySlug(slug)
+  const session = await auth()
+
+  if (!priceList || !priceList[produce]) {
+    notFound()
+  }
+
+  const formattedDate = formatDate(priceList.effectiveDate.toString())
+  const produceName = capitalizeFirstLetter(produce)
+
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@type": "Product",
+    "name": `${produceName} — ${capitalizeFirstLetter(priceList.client_name)}`,
+    "description": `${produceName} price list from ${capitalizeFirstLetter(priceList.client_name)} effective ${formattedDate}`,
+    "brand": {
+      "@type": "Organization",
+      "name": priceList.client_name
+    },
+    "offers": {
+      "@type": "AggregateOffer",
+      "priceCurrency": "USD",
+      "availability": "https://schema.org/InStock",
+      "validFrom": priceList.effectiveDate,
+    },
+  }
+
+  return (
+    <main>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+
+      <div className="mx-auto max-w-7xl px-6 lg:px-8 py-12 min-h-[70lvh]">
+        <Link
+          href={`/prices/produce/${produce}`}
+          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Back to {produceName} Prices
+        </Link>
+
+        <div className="mb-8">
+          <div className="flex items-center gap-3 mb-4">
+            <h1 className="text-4xl font-bold font-heading">
+              {produceName} Prices — {capitalizeFirstLetter(priceList.client_name)}
+            </h1>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-4 text-sm">
+            <div className="flex items-center gap-2">
+              <Building2 className="h-4 w-4 text-muted-foreground" />
+              <span className="text-muted-foreground">Buyer:</span>
+              <Link href={`/buyer/${priceList.client_name.toLowerCase().replace(/\s+/g, '-')}`} className="font-medium text-primary hover:underline">
+                {capitalizeFirstLetter(priceList.client_name)}
+              </Link>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <Calendar className="h-4 w-4 text-muted-foreground" />
+              <span className="text-muted-foreground">Effective:</span>
+              <span className="font-medium text-card-foreground">{formattedDate}</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="lg:flex lg:items-start lg:gap-8">
+          <div className="flex-1">
+            <div className="mb-8 bg-card border rounded-xl p-6">
+              <h2 className="text-xl font-semibold mb-3">
+                Contact {capitalizeFirstLetter(priceList.client_name)} Directly
+              </h2>
+              <p className="text-sm text-muted-foreground leading-relaxed mb-4">
+                Want to sell your {produceName.toLowerCase()} to {capitalizeFirstLetter(priceList.client_name)}? We can connect you directly with the buyer responsible for {produceName.toLowerCase()} procurement.
+              </p>
+              <ContactBuyerButton
+                user={session?.user}
+                clientName={priceList.client_name}
+                clientId={priceList.client_id}
+              />
+            </div>
+
+            <PriceDetailsGrid priceList={priceList} produce={produce} />
+          </div>
+
+          <aside className="hidden lg:block lg:w-72 lg:flex-shrink-0 sticky top-20 self-start">
+            <RelatedPricesSidebar
+              currentClientName={priceList.client_name}
+              currentPriceId={priceList.id}
+              allPrices={allPrices}
+            />
+          </aside>
+        </div>
+
+        <div className="mt-8 lg:hidden">
+          <RelatedPricesSidebar
+            currentClientName={priceList.client_name}
+            currentPriceId={priceList.id}
+            allPrices={allPrices}
+          />
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/apps/client-fnp/app/(landing)/prices/cdm/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/prices/cdm/[slug]/page.tsx
@@ -93,46 +93,45 @@ export default async function CdmPriceDetailPage({ params }: CdmDetailPageProps)
         dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
       />
 
-      <div className="mx-auto max-w-7xl px-6 lg:px-8 py-12 min-h-[70lvh]">
-        {/* Back link */}
-        <Link
-          href="/prices/cdm"
-          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6"
-        >
-          <ArrowLeft className="h-3.5 w-3.5" />
-          Back to CDM Prices
-        </Link>
-
-        {/* Header */}
-        <div className="mb-8">
-          <div className="flex items-center gap-3 mb-4">
-            <h1 className="text-3xl font-bold font-heading">
-              {capitalizeFirstLetter(price.client_name)}
-            </h1>
-            <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider bg-muted px-2.5 py-1 rounded">
-              CDM
-            </span>
+      <section className="border-b">
+        <div className="mx-auto max-w-7xl px-6 lg:px-8 pt-6 pb-8">
+          <Link
+            href="/prices/cdm"
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-4"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Back to CDM Prices
+          </Link>
+          <div className="flex items-center gap-3">
+            <div>
+              <p className="text-xs font-semibold text-primary tracking-wide uppercase">Cold Dress Mass Pricing</p>
+              <h1 className="mt-1 text-3xl font-bold font-heading tracking-tight">
+                {capitalizeFirstLetter(price.client_name)}
+              </h1>
+            </div>
           </div>
-
-          <div className="flex items-center gap-2 text-sm">
-            <Calendar className="h-4 w-4 text-muted-foreground" />
-            <span className="text-muted-foreground">Effective:</span>
-            <span className="font-medium text-foreground">{formattedDate}</span>
+          <div className="flex items-center gap-2 mt-2 text-sm text-muted-foreground">
+            <Calendar className="h-4 w-4" />
+            <span>Effective {formattedDate}</span>
           </div>
         </div>
+      </section>
 
-        <div className="lg:flex lg:items-start lg:gap-8">
-          <div className="flex-1">
+      <section className="mx-auto max-w-7xl px-6 lg:px-8 py-8 min-h-[50lvh]">
+        <div className="lg:grid lg:grid-cols-[1fr_260px] lg:gap-8">
+          <div className="min-w-0">
             <CdmPriceCard price={price} hideHeader />
           </div>
 
-          <aside className="hidden lg:block lg:w-72 lg:flex-shrink-0 sticky top-20 self-start">
-            <RelatedCdmPricesSidebar
-              currentClientName={price.client_name}
-              currentPriceId={price.id}
-              allPrices={allPrices}
-            />
-          </aside>
+          <div className="hidden lg:block">
+            <div className="sticky top-20">
+              <RelatedCdmPricesSidebar
+                currentClientName={price.client_name}
+                currentPriceId={price.id}
+                allPrices={allPrices}
+              />
+            </div>
+          </div>
         </div>
 
         {/* Mobile: Related prices at bottom */}
@@ -143,7 +142,7 @@ export default async function CdmPriceDetailPage({ params }: CdmDetailPageProps)
             allPrices={allPrices}
           />
         </div>
-      </div>
+      </section>
     </main>
   )
 }

--- a/apps/client-fnp/app/(landing)/prices/page.tsx
+++ b/apps/client-fnp/app/(landing)/prices/page.tsx
@@ -1,5 +1,6 @@
 import { PriceCardsView } from "@/components/structures/price-cards-view"
 import { CdmPriceCardsView } from "@/components/structures/cdm-price-cards-view"
+import { ProduceCategoriesView } from "@/components/structures/produce-categories-view"
 import Link from "next/link"
 import { ArrowRight, Scale, Beef } from "lucide-react"
 
@@ -18,27 +19,6 @@ export const metadata = {
   },
 }
 
-const categories = [
-  {
-    title: "Liveweight Prices",
-    tag: "LWT",
-    description: "Per kg delivered rates for cattle, sheep, goats and pigs — by grade, teeth category and weight range.",
-    href: "/prices/lwt",
-    icon: Scale,
-    gradient: "from-emerald-500 to-teal-600",
-    iconBg: "bg-emerald-500",
-  },
-  {
-    title: "Cold Dress Mass",
-    tag: "CDM",
-    description: "Carcass grade pricing from abattoirs — commercial, economy and manufacturing grades, ex leakage.",
-    href: "/prices/cdm",
-    icon: Beef,
-    gradient: "from-blue-500 to-indigo-600",
-    iconBg: "bg-blue-500",
-  },
-]
-
 export default async function PricesPage() {
   return (
     <main>
@@ -55,74 +35,50 @@ export default async function PricesPage() {
         </div>
       </section>
 
-      {/* Categories */}
+      {/* Prices by Produce */}
       <section className="mx-auto max-w-7xl px-6 lg:px-8 py-8">
-        <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-4">Browse by type</h2>
-
-        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {categories.map((cat) => {
-            const Icon = cat.icon
-            return (
-              <Link key={cat.href} href={cat.href} className="group block">
-                <div className="relative h-full rounded-xl border bg-card p-4 hover:shadow-md hover:border-primary/20 transition-all">
-                  <div className="flex items-center gap-3 mb-2">
-                    <div className={`flex items-center justify-center h-8 w-8 rounded-lg bg-gradient-to-br ${cat.gradient}`}>
-                      <Icon className="h-4 w-4 text-white" />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <h3 className="text-sm font-bold font-heading group-hover:text-primary transition-colors">
-                        {cat.title}
-                      </h3>
-                      <span className="text-[9px] font-bold text-muted-foreground uppercase tracking-widest">
-                        {cat.tag}
-                      </span>
-                    </div>
-                    <ArrowRight className="h-3.5 w-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
-                  </div>
-                  <p className="text-xs text-muted-foreground leading-relaxed">
-                    {cat.description}
-                  </p>
-                </div>
-              </Link>
-            )
-          })}
-
-          <div className="relative h-full rounded-xl border border-dashed bg-muted/20 p-4 flex flex-col items-center justify-center text-center">
-            <p className="text-xs font-semibold text-muted-foreground">More coming soon</p>
-            <p className="mt-0.5 text-[11px] text-muted-foreground">
-              Grains, vegetables, dairy and more
-            </p>
-          </div>
-        </div>
+        <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-4">Prices by produce</h2>
+        <ProduceCategoriesView />
       </section>
 
-      {/* Latest Prices */}
-      <section className="border-t bg-muted/20">
+      {/* Price List Categories */}
+      <section className="border-t">
         <div className="mx-auto max-w-7xl px-6 lg:px-8 py-8">
-          <h2 className="text-lg font-bold font-heading mb-5">Latest Prices</h2>
-
-          <div className="grid md:grid-cols-2 gap-6">
-            <div>
-              <div className="flex items-center gap-2 mb-3">
-                <div className="flex items-center justify-center h-6 w-6 rounded-md bg-gradient-to-br from-emerald-500 to-teal-600">
-                  <Scale className="h-3 w-3 text-white" />
+          <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-4">Price lists by type</h2>
+          <div className="grid md:grid-cols-2 gap-4">
+            <div className="group rounded-xl border bg-card shadow-sm hover:shadow-md hover:border-primary/20 transition-all duration-200">
+              <div className="flex items-center justify-between px-4 pt-4 pb-2">
+                <div className="flex items-center gap-2">
+                  <div className="flex items-center justify-center h-5 w-5 rounded-md bg-gradient-to-br from-emerald-500 to-teal-600">
+                    <Scale className="h-2.5 w-2.5 text-white" />
+                  </div>
+                  <h3 className="text-sm font-bold tracking-tight">Liveweight Prices</h3>
                 </div>
-                <h3 className="text-xs font-bold uppercase tracking-wide text-muted-foreground">Liveweight</h3>
+                <Link href="/prices/lwt" className="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground hover:text-primary transition-colors">
+                  View all
+                  <ArrowRight className="h-3 w-3 opacity-0 -translate-x-1 group-hover:opacity-100 group-hover:translate-x-0 transition-all" />
+                </Link>
               </div>
-              <div className="rounded-lg border bg-card px-3">
-                <PriceCardsView limit={4} viewAllHref="/prices/lwt" />
+              <div className="px-3 pb-1">
+                <PriceCardsView limit={4} />
               </div>
             </div>
 
-            <div>
-              <div className="flex items-center gap-2 mb-3">
-                <div className="flex items-center justify-center h-6 w-6 rounded-md bg-gradient-to-br from-blue-500 to-indigo-600">
-                  <Beef className="h-3 w-3 text-white" />
+            <div className="group rounded-xl border bg-card shadow-sm hover:shadow-md hover:border-primary/20 transition-all duration-200">
+              <div className="flex items-center justify-between px-4 pt-4 pb-2">
+                <div className="flex items-center gap-2">
+                  <div className="flex items-center justify-center h-5 w-5 rounded-md bg-gradient-to-br from-blue-500 to-indigo-600">
+                    <Beef className="h-2.5 w-2.5 text-white" />
+                  </div>
+                  <h3 className="text-sm font-bold tracking-tight">Cold Dress Mass Prices</h3>
                 </div>
-                <h3 className="text-xs font-bold uppercase tracking-wide text-muted-foreground">Cold Dress Mass</h3>
+                <Link href="/prices/cdm" className="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground hover:text-primary transition-colors">
+                  View all
+                  <ArrowRight className="h-3 w-3 opacity-0 -translate-x-1 group-hover:opacity-100 group-hover:translate-x-0 transition-all" />
+                </Link>
               </div>
-              <div className="rounded-lg border bg-card px-3">
-                <CdmPriceCardsView limit={4} viewAllHref="/prices/cdm" />
+              <div className="px-3 pb-1">
+                <CdmPriceCardsView limit={4} />
               </div>
             </div>
           </div>

--- a/apps/client-fnp/app/(landing)/prices/produce/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/prices/produce/[slug]/page.tsx
@@ -1,0 +1,136 @@
+import { ProducePriceCardsView } from "@/components/structures/produce-price-cards-view"
+import { ActionsSidebar } from "@/components/generic/actions-sidebar"
+import Link from "next/link"
+import { ArrowLeft } from "lucide-react"
+import type { Metadata } from "next"
+import { capitalizeFirstLetter } from "@/lib/utilities"
+
+interface ProducePageProps {
+  params: Promise<{ slug: string }>
+}
+
+const produceCategories = [
+  { name: "Beef", slug: "beef", color: "bg-red-500" },
+  { name: "Lamb", slug: "lamb", color: "bg-amber-500" },
+  { name: "Mutton", slug: "mutton", color: "bg-orange-500" },
+  { name: "Goat", slug: "goat", color: "bg-lime-600" },
+  { name: "Chicken", slug: "chicken", color: "bg-yellow-500" },
+  { name: "Pork", slug: "pork", color: "bg-pink-500" },
+]
+
+export async function generateMetadata({ params }: ProducePageProps): Promise<Metadata> {
+  const { slug } = await params
+  const produceName = capitalizeFirstLetter(slug.replace(/-/g, ' '))
+
+  return {
+    title: `${produceName} Prices Zimbabwe – Current Market Rates | farmnport.com`,
+    description: `Browse current ${produceName.toLowerCase()} prices from buyers across Zimbabwe. Compare rates, view buyer profiles, and sell your ${produceName.toLowerCase()} at competitive prices.`,
+    alternates: {
+      canonical: `/prices/produce/${slug}`,
+    },
+    openGraph: {
+      title: `${produceName} Prices Zimbabwe – Current Market Rates`,
+      description: `Browse current ${produceName.toLowerCase()} prices from buyers across Zimbabwe.`,
+      url: `/prices/produce/${slug}`,
+      siteName: 'farmnport',
+      type: 'website',
+    },
+  }
+}
+
+export default async function ProducePricePage({ params }: ProducePageProps) {
+  const { slug } = await params
+  const produceName = capitalizeFirstLetter(slug.replace(/-/g, ' '))
+
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    "name": `${produceName} Prices in Zimbabwe`,
+    "description": `Current ${produceName.toLowerCase()} market prices from buyers across Zimbabwe`,
+    "url": `https://farmnport.com/prices/produce/${slug}`,
+  }
+
+  return (
+    <main>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+
+      <section className="border-b">
+        <div className="mx-auto max-w-7xl px-6 lg:px-8 pt-6 pb-8">
+          <Link
+            href="/prices"
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-4"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Back to Market Prices
+          </Link>
+          <p className="text-xs font-semibold text-primary tracking-wide uppercase">Prices by Produce</p>
+          <h1 className="mt-1 text-3xl font-bold font-heading tracking-tight">
+            {produceName} Prices
+          </h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Current {produceName.toLowerCase()} market prices from buyers across Zimbabwe.
+          </p>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-6 lg:px-8 py-8 min-h-[50lvh]">
+        {/* Mobile produce pills */}
+        <div className="lg:hidden flex flex-wrap gap-1.5 mb-6">
+          {produceCategories.map((cat) => (
+            <Link
+              key={cat.slug}
+              href={`/prices/produce/${cat.slug}`}
+              className={`px-3 py-1.5 rounded-full text-xs font-medium transition-all ${
+                cat.slug === slug
+                  ? "bg-primary text-primary-foreground shadow-sm"
+                  : "border bg-card text-muted-foreground hover:text-foreground hover:border-primary/20"
+              }`}
+            >
+              {cat.name}
+            </Link>
+          ))}
+        </div>
+
+        <div className="lg:grid lg:grid-cols-[180px_1fr_220px] lg:gap-8">
+          {/* Left — produce nav */}
+          <nav className="hidden lg:block">
+            <div className="sticky top-20">
+              <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider mb-3">Produce</p>
+              <div className="space-y-0.5">
+                {produceCategories.map((cat) => (
+                  <Link
+                    key={cat.slug}
+                    href={`/prices/produce/${cat.slug}`}
+                    className={`flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm transition-colors ${
+                      cat.slug === slug
+                        ? "bg-primary/10 text-primary font-semibold"
+                        : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
+                    }`}
+                  >
+                    <div className={`h-2 w-2 rounded-full ${cat.color}`} />
+                    {cat.name}
+                  </Link>
+                ))}
+              </div>
+            </div>
+          </nav>
+
+          {/* Center — price cards */}
+          <div className="min-w-0">
+            <ProducePriceCardsView produceSlug={slug} />
+          </div>
+
+          {/* Right — sidebar */}
+          <div className="hidden lg:block">
+            <div className="sticky top-20">
+              <ActionsSidebar type="buyers" product={slug} />
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/apps/client-fnp/app/(landing)/prices/produce/page.tsx
+++ b/apps/client-fnp/app/(landing)/prices/produce/page.tsx
@@ -1,0 +1,87 @@
+import { ProducePriceCardsView } from "@/components/structures/produce-price-cards-view"
+import { ProduceFilter } from "@/components/structures/produce-filter"
+import Link from "next/link"
+import { ChevronLeft } from "lucide-react"
+import type { Metadata } from "next"
+
+export const metadata: Metadata = {
+  title: 'Prices by Produce – Beef, Lamb, Chicken & More | farmnport.com',
+  description: 'Browse current agricultural produce prices across Zimbabwe. Filter by beef, lamb, mutton, goat, chicken, and pork. Compare rates from verified buyers.',
+  alternates: {
+    canonical: '/prices/produce',
+  },
+  openGraph: {
+    title: 'Prices by Produce – Beef, Lamb, Chicken & More',
+    description: 'Browse current agricultural produce prices across Zimbabwe. Filter by produce type.',
+    url: '/prices/produce',
+    siteName: 'farmnport',
+    type: 'website',
+  },
+}
+
+const produceCategories = [
+  { name: "Beef", slug: "beef" },
+  { name: "Lamb", slug: "lamb" },
+  { name: "Mutton", slug: "mutton" },
+  { name: "Goat", slug: "goat" },
+  { name: "Chicken", slug: "chicken" },
+  { name: "Pork", slug: "pork" },
+]
+
+interface ProducePageProps {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}
+
+export default async function ProduceIndexPage({ searchParams }: ProducePageProps) {
+  const params = await searchParams
+  const activeFilter = typeof params.filter === "string" ? params.filter : ""
+
+  const filtered = activeFilter
+    ? produceCategories.filter((p) => p.slug === activeFilter)
+    : produceCategories
+
+  return (
+    <main>
+      <div className="mx-auto max-w-7xl px-6 lg:px-8 min-h-[70lvh]">
+        <div className="pt-6 pb-4">
+          <Link
+            href="/prices"
+            className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ChevronLeft className="h-3.5 w-3.5" />
+            All prices
+          </Link>
+        </div>
+
+        <h1 className="text-3xl font-bold font-heading pb-2">
+          Prices by Produce
+        </h1>
+        <p className="text-muted-foreground mb-6">
+          Current produce prices from buyers across Zimbabwe, in USD.
+        </p>
+
+        <ProduceFilter
+          categories={produceCategories}
+          activeFilter={activeFilter}
+        />
+
+        <div className="mt-6 space-y-8">
+          {filtered.map((produce) => (
+            <section key={produce.slug}>
+              <div className="flex items-center justify-between mb-3">
+                <h2 className="text-lg font-semibold font-heading">{produce.name}</h2>
+                <Link
+                  href={`/prices/produce/${produce.slug}`}
+                  className="text-sm font-medium text-primary hover:underline"
+                >
+                  View all {produce.name.toLowerCase()} prices
+                </Link>
+              </div>
+              <ProducePriceCardsView produceSlug={produce.slug} limit={4} />
+            </section>
+          ))}
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/apps/client-fnp/app/(landing)/spray-programs/SprayProgramsClient.tsx
+++ b/apps/client-fnp/app/(landing)/spray-programs/SprayProgramsClient.tsx
@@ -2,28 +2,83 @@
 
 import { useMemo, useState } from "react"
 import Link from "next/link"
-import { Layers, ChevronRight, Search, X } from "lucide-react"
+import { Layers, ChevronRight, Search, X, Filter } from "lucide-react"
 import { capitalizeFirstLetter } from "@/lib/utilities"
+import { useQueryState, parseAsString } from "nuqs"
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet"
+import { Button } from "@/components/ui/button"
+import { useMediaQuery } from "@/hooks/use-media-query"
 
 interface SprayProgramsClientProps {
     programs: any[]
 }
 
-export function SprayProgramsClient({ programs }: SprayProgramsClientProps) {
-    const [filter, setFilter] = useState<string | null>(null)
-    const [search, setSearch] = useState("")
+function FilterNav({ cropGroups, counts, active, onSelect }: {
+    cropGroups: string[]
+    counts: Record<string, number>
+    active: string | null
+    onSelect: (g: string | null) => void
+}) {
+    const total = Object.values(counts).reduce((a, b) => a + b, 0)
 
-    // Extract unique crop groups for filter
+    return (
+        <div>
+            <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider mb-3">Crop Group</p>
+            <div className="space-y-0.5">
+                <button
+                    onClick={() => onSelect(null)}
+                    className={`w-full flex items-center justify-between px-3 py-2 rounded-lg text-sm transition-colors ${
+                        active === null
+                            ? "bg-primary/10 text-primary font-semibold"
+                            : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
+                    }`}
+                >
+                    <span>All</span>
+                    <span className="text-xs text-muted-foreground">{total}</span>
+                </button>
+                {cropGroups.map((name) => (
+                    <button
+                        key={name}
+                        onClick={() => onSelect(name)}
+                        className={`w-full flex items-center justify-between px-3 py-2 rounded-lg text-sm transition-colors ${
+                            active === name
+                                ? "bg-primary/10 text-primary font-semibold"
+                                : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
+                        }`}
+                    >
+                        <span>{capitalizeFirstLetter(name)}</span>
+                        <span className="text-xs text-muted-foreground">{counts[name] || 0}</span>
+                    </button>
+                ))}
+            </div>
+        </div>
+    )
+}
+
+export function SprayProgramsClient({ programs }: SprayProgramsClientProps) {
+    const [group, setGroup] = useQueryState("group", parseAsString)
+    const [search, setSearch] = useState("")
+    const isDesktop = useMediaQuery("(min-width: 1024px)")
+
     const cropGroups = useMemo(() => {
         const names = new Set<string>()
         for (const p of programs) {
-            if (p.crop_group_name) names.add(p.crop_group_name)
+            if (p.crop_group_name) names.add(p.crop_group_name.toLowerCase())
         }
         return Array.from(names).sort()
     }, [programs])
 
+    const counts = useMemo(() => {
+        const c: Record<string, number> = {}
+        for (const p of programs) {
+            const g = (p.crop_group_name || "other").toLowerCase()
+            c[g] = (c[g] || 0) + 1
+        }
+        return c
+    }, [programs])
+
     const filtered = programs.filter((p: any) => {
-        if (filter && p.crop_group_name !== filter) return false
+        if (group && (p.crop_group_name || "").toLowerCase() !== group) return false
         if (search) {
             const q = search.toLowerCase()
             const name = (p.name || "").toLowerCase()
@@ -34,123 +89,116 @@ export function SprayProgramsClient({ programs }: SprayProgramsClientProps) {
         return true
     })
 
+    const handleSelect = (g: string | null) => {
+        setGroup(g)
+        window.scrollTo({ top: 0, behavior: "smooth" })
+    }
+
     return (
-        <>
-            {/* Filter bar */}
-            {cropGroups.length > 0 && (
-                <div className="border-b bg-muted/30">
-                    <div className="mx-auto max-w-7xl px-6 lg:px-8 py-3">
-                        <div className="flex flex-wrap gap-1.5">
-                            <button
-                                onClick={() => setFilter(null)}
-                                className={`px-3 py-1.5 rounded-full text-xs font-medium transition-all ${
-                                    !filter
-                                        ? "bg-primary text-primary-foreground"
-                                        : "bg-muted text-muted-foreground hover:text-foreground hover:bg-muted/80"
-                                }`}
-                            >
-                                All
-                            </button>
-                            {cropGroups.map((name) => (
+        <section className="mx-auto max-w-7xl px-6 lg:px-8 py-8">
+            {programs.length === 0 ? (
+                <div className="text-center py-16">
+                    <h2 className="text-lg font-semibold mb-1">No Spray Programs Yet</h2>
+                    <p className="text-sm text-muted-foreground max-w-md mx-auto">
+                        We&apos;re working on creating comprehensive spray programs. Check back soon.
+                    </p>
+                </div>
+            ) : (
+                <div className="lg:grid lg:grid-cols-[180px_1fr] lg:gap-8">
+                    {/* Sidebar */}
+                    {isDesktop ? (
+                        <nav className="hidden lg:block">
+                            <div className="sticky top-20">
+                                <FilterNav cropGroups={cropGroups} counts={counts} active={group} onSelect={handleSelect} />
+                            </div>
+                        </nav>
+                    ) : (
+                        <Sheet>
+                            <SheetTrigger asChild>
+                                <Button variant="outline" className="w-full mb-4">
+                                    <Filter className="mr-2 h-4 w-4" />
+                                    Filter by Crop Group
+                                </Button>
+                            </SheetTrigger>
+                            <SheetContent side="left" className="w-[280px] overflow-y-auto">
+                                <SheetHeader className="mb-4">
+                                    <SheetTitle>Filter Programs</SheetTitle>
+                                </SheetHeader>
+                                <FilterNav cropGroups={cropGroups} counts={counts} active={group} onSelect={handleSelect} />
+                            </SheetContent>
+                        </Sheet>
+                    )}
+
+                    {/* Content */}
+                    <div className="min-w-0">
+                        {/* Search */}
+                        <div className="relative max-w-sm mb-6">
+                            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                            <input
+                                type="text"
+                                value={search}
+                                onChange={(e) => setSearch(e.target.value)}
+                                placeholder="Search spray programs..."
+                                className="w-full pl-9 pr-9 py-1.5 text-sm border rounded-lg bg-background focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all"
+                            />
+                            {search && (
                                 <button
-                                    key={name}
-                                    onClick={() => setFilter(name)}
-                                    className={`px-3 py-1.5 rounded-full text-xs font-medium transition-all ${
-                                        filter === name
-                                            ? "bg-primary text-primary-foreground"
-                                            : "bg-muted text-muted-foreground hover:text-foreground hover:bg-muted/80"
-                                    }`}
+                                    onClick={() => setSearch("")}
+                                    className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
                                 >
-                                    {capitalizeFirstLetter(name)}
+                                    <X className="h-4 w-4" />
                                 </button>
-                            ))}
+                            )}
                         </div>
+
+                        {/* Grid */}
+                        {filtered.length > 0 ? (
+                            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                                {filtered.map((program: any) => (
+                                    <Link
+                                        key={program.id}
+                                        href={`/spray-programs/${program.slug}`}
+                                        className="group rounded-xl border bg-card overflow-hidden hover:shadow-md hover:border-primary/20 transition-all"
+                                    >
+                                        <div className="p-4">
+                                            <h2 className="text-sm font-bold font-heading mb-1 group-hover:text-primary transition-colors">
+                                                {capitalizeFirstLetter(program.name)}
+                                            </h2>
+
+                                            {program.farm_produce_name && (
+                                                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-600/10 dark:bg-amber-950/30 dark:text-amber-400 mb-2">
+                                                    {capitalizeFirstLetter(program.farm_produce_name)}
+                                                </span>
+                                            )}
+
+                                            {program.description && (
+                                                <p className="text-xs text-muted-foreground line-clamp-2 mb-3">
+                                                    {program.description}
+                                                </p>
+                                            )}
+
+                                            <div className="flex items-center justify-between">
+                                                <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                                                    <Layers className="h-3 w-3" />
+                                                    <span>{program.stages?.length || 0} stages</span>
+                                                </div>
+                                                <ChevronRight className="h-3.5 w-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+                                            </div>
+                                        </div>
+                                    </Link>
+                                ))}
+                            </div>
+                        ) : (
+                            <div className="text-center py-16">
+                                <h2 className="text-lg font-semibold mb-1">No programs found</h2>
+                                <p className="text-sm text-muted-foreground">
+                                    No spray programs match {search ? `"${search}"` : "the selected filter"}.
+                                </p>
+                            </div>
+                        )}
                     </div>
                 </div>
             )}
-
-            <section className="mx-auto max-w-7xl px-6 lg:px-8 py-8">
-                {/* Search */}
-                {programs.length > 0 && (
-                    <div className="relative mb-6 max-w-md">
-                        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-                        <input
-                            type="text"
-                            value={search}
-                            onChange={(e) => setSearch(e.target.value)}
-                            placeholder="Search spray programs..."
-                            className="w-full pl-9 pr-9 py-2 text-sm border rounded-lg bg-background focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all"
-                        />
-                        {search && (
-                            <button
-                                onClick={() => setSearch("")}
-                                className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                            >
-                                <X className="h-4 w-4" />
-                            </button>
-                        )}
-                    </div>
-                )}
-
-                {/* Empty State */}
-                {programs.length === 0 && (
-                    <div className="text-center py-16">
-                        <h2 className="text-lg font-semibold mb-1">No Spray Programs Yet</h2>
-                        <p className="text-sm text-muted-foreground max-w-md mx-auto">
-                            We&apos;re working on creating comprehensive spray programs. Check back soon.
-                        </p>
-                    </div>
-                )}
-
-                {/* Programs Grid */}
-                {filtered.length > 0 && (
-                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                        {filtered.map((program: any) => (
-                            <Link
-                                key={program.id}
-                                href={`/spray-programs/${program.slug}`}
-                                className="group rounded-xl border bg-card overflow-hidden hover:shadow-md hover:border-primary/20 transition-all"
-                            >
-                                <div className="p-4">
-                                    <h2 className="text-sm font-bold font-heading mb-1 group-hover:text-primary transition-colors">
-                                        {capitalizeFirstLetter(program.name)}
-                                    </h2>
-
-                                    {program.farm_produce_name && (
-                                        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-600/10 dark:bg-amber-950/30 dark:text-amber-400 mb-2">
-                                            {capitalizeFirstLetter(program.farm_produce_name)}
-                                        </span>
-                                    )}
-
-                                    {program.description && (
-                                        <p className="text-xs text-muted-foreground line-clamp-2 mb-3">
-                                            {program.description}
-                                        </p>
-                                    )}
-
-                                    <div className="flex items-center justify-between">
-                                        <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
-                                            <Layers className="h-3 w-3" />
-                                            <span>{program.stages?.length || 0} stages</span>
-                                        </div>
-                                        <ChevronRight className="h-3.5 w-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
-                                    </div>
-                                </div>
-                            </Link>
-                        ))}
-                    </div>
-                )}
-
-                {/* No results */}
-                {filtered.length === 0 && programs.length > 0 && (
-                    <div className="text-center py-16">
-                        <h2 className="text-lg font-semibold mb-1">No programs found</h2>
-                        <p className="text-sm text-muted-foreground">
-                            No spray programs match {search ? `"${search}"` : "the selected filter"}.
-                        </p>
-                    </div>
-                )}
-            </section>
-        </>
+        </section>
     )
 }

--- a/apps/client-fnp/app/(landing)/spray-programs/[slug]/SprayProgramDetailClient.tsx
+++ b/apps/client-fnp/app/(landing)/spray-programs/[slug]/SprayProgramDetailClient.tsx
@@ -101,8 +101,8 @@ export function SprayProgramDetailClient({ program, slug }: SprayProgramDetailCl
     return (
         <div className="min-h-screen bg-background">
             {/* Breadcrumb */}
-            <div className="border-b bg-muted/30">
-                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+            <div className="border-b">
+                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
                     <nav className="flex text-sm text-muted-foreground">
                         <Link href="/" className="hover:text-foreground">Home</Link>
                         <span className="mx-2">/</span>

--- a/apps/client-fnp/app/layout.tsx
+++ b/apps/client-fnp/app/layout.tsx
@@ -3,6 +3,7 @@ import localFont from "next/font/local"
 
 import { GoogleTagManager } from '@next/third-parties/google'
 import { Analytics } from "@vercel/analytics/react"
+import Script from "next/script"
 
 import { QueryProvider } from "@/components/providers/QueryProvider"
 import { ThemeProvider } from "@/components/providers/ThemeProvider"
@@ -78,6 +79,31 @@ export default async function RootLayout({ children }: RootLayoutProps) {
             <QueryProvider>
               <NuqsAdapter>
                 {children}
+                <Script
+                  id="facebook-sdk-init"
+                  strategy="lazyOnload"
+                  dangerouslySetInnerHTML={{
+                    __html: `
+                      window.fbAsyncInit = function() {
+                        FB.init({
+                          appId      : '512373632579287',
+                          cookie     : true,
+                          xfbml      : true,
+                          version    : 'v22.0'
+                        });
+                        FB.AppEvents.logPageView();
+                      };
+
+                      (function(d, s, id){
+                        var js, fjs = d.getElementsByTagName(s)[0];
+                        if (d.getElementById(id)) {return;}
+                        js = d.createElement(s); js.id = id;
+                        js.src = "https://connect.facebook.net/en_US/sdk.js";
+                        fjs.parentNode.insertBefore(js, fjs);
+                      }(document, 'script', 'facebook-jssdk'));
+                    `,
+                  }}
+                />
                 <GoogleTagManager gtmId={GTM_ID} />
                 <Toaster />
                 {NEXT_ENV !== 'production' && <SpeedInsights />}

--- a/apps/client-fnp/components/generic/actions-sidebar.tsx
+++ b/apps/client-fnp/components/generic/actions-sidebar.tsx
@@ -26,19 +26,19 @@ const productActions: Record<string, ActionItem[]> = {
     {
       title: "Order New Chicks Online",
       description: "Source day-old chicks and point-of-lay hens from trusted hatcheries across Zimbabwe.",
-      cta: "Browse Chick Suppliers",
-      href: "/buyers/chicken",
+      cta: "Join Waiting List",
+      href: "/waiting-list",
       event: "ActionOrderChicks",
       bg: "bg-emerald-50 dark:bg-emerald-950/30",
       border: "border-emerald-200 dark:border-emerald-800/50",
       button: "bg-emerald-600 hover:bg-emerald-700",
     },
     {
-      title: "Poultry Health Guides",
-      description: "Vaccines, antibiotics & nutrition guides to keep your flock healthy and productive.",
-      cta: "View Guides",
-      href: "/agrochemical-guides/all",
-      event: "ActionPoultryGuides",
+      title: "Poultry Feed Programs",
+      description: "Broiler, layer and free-range feeding programs to maximise growth and production.",
+      cta: "View Feed Programs",
+      href: "/feeding-programs",
+      event: "ActionPoultryFeedPrograms",
       bg: "bg-sky-50 dark:bg-sky-950/30",
       border: "border-sky-200 dark:border-sky-800/50",
       button: "bg-sky-600 hover:bg-sky-700",
@@ -109,7 +109,7 @@ export function ActionsSidebar({type = "buyers", product, showPremiumCTA = true}
         </div>
       ))}
 
-      {showPremiumCTA && (
+      {/* {showPremiumCTA && (
         <div className="bg-primary/5 border-2 border-primary/20 rounded-lg p-6">
           <h3 className="text-lg font-semibold mb-2">Unlock Premium Features</h3>
           <p className="text-sm text-muted-foreground mb-4">
@@ -122,7 +122,7 @@ export function ActionsSidebar({type = "buyers", product, showPremiumCTA = true}
             Subscribe
           </Link>
         </div>
-      )}
+      )} */}
     </aside>
   )
 }

--- a/apps/client-fnp/components/generic/pagination.tsx
+++ b/apps/client-fnp/components/generic/pagination.tsx
@@ -28,6 +28,14 @@ export function Pagination({
     const router = useRouter()
     const pathname = usePathname()
     const [isPending, startTransition] = React.useTransition()
+    const prevPage = React.useRef(page)
+
+    React.useEffect(() => {
+        if (prevPage.current !== page) {
+            window.scrollTo({ top: 0, behavior: "smooth" })
+            prevPage.current = page
+        }
+    }, [page])
 
     // Memoize pagination range to avoid unnecessary re-renders
     const paginationRange = React.useMemo(() => {
@@ -78,7 +86,8 @@ export function Pagination({
                                 page: Number(page) - 1,
                                 per_page: per_page ?? null,
                                 sort: sort ?? null,
-                            })}`
+                            })}`,
+                            { scroll: false }
                         )
                     })
                 }}
@@ -110,7 +119,8 @@ export function Pagination({
                                 router.push(
                                     `${pathname}?${createQueryString({
                                         page: pageNumber
-                                    })}`
+                                    })}`,
+                                    { scroll: false }
                                 )
                             })
                         }}
@@ -130,7 +140,8 @@ export function Pagination({
                         router.push(
                             `${pathname}?${createQueryString({
                                 page: Number(page) + 1
-                            })}`
+                            })}`,
+                            { scroll: false }
                         )
                     })
                 }}

--- a/apps/client-fnp/components/layouts/client.tsx
+++ b/apps/client-fnp/components/layouts/client.tsx
@@ -16,6 +16,7 @@ import { Button } from "@/components/ui/button"
 import { Contacts } from "@/components/layouts/contacts"
 import { BuyerContacts } from "@/components/structures/buyer-contacts"
 import { CdmPriceCard } from "@/components/structures/cdm-price-card"
+import { ProductResources } from "@/components/monetization/product-resources"
 
 
 interface ClientPageProps {
@@ -265,7 +266,7 @@ export function Client({ slug, user }: ClientPageProps) {
                 <p className="text-xs text-lime-700 dark:text-lime-500 mb-4">
                   Note: Always contact {name} directly to verify payment terms.
                 </p>
-                {pricingLoading ? (
+                {/* {pricingLoading ? (
                   <div className="flex items-center gap-3 py-4 border-t">
                     <Icons.spinner className="h-5 w-5 animate-spin text-primary" />
                     <p className="text-sm text-muted-foreground">Loading pricing data...</p>
@@ -293,7 +294,7 @@ export function Client({ slug, user }: ClientPageProps) {
                   <p className="text-sm text-muted-foreground py-4 border-t">
                     This buyer hasn&apos;t shared pricing information yet. Check back later or contact them directly for pricing details.
                   </p>
-                )}
+                )} */}
               </div>
             )}
 
@@ -305,6 +306,7 @@ export function Client({ slug, user }: ClientPageProps) {
                 ))}
               </div>
             )}
+
 
           </div>
 

--- a/apps/client-fnp/components/layouts/logged-in-dashboard.tsx
+++ b/apps/client-fnp/components/layouts/logged-in-dashboard.tsx
@@ -2,9 +2,41 @@
 
 import Link from "next/link"
 import { useQuery } from "@tanstack/react-query"
+import { sendGTMEvent } from "@next/third-parties/google"
+import { ArrowRight, ChevronRight, FlaskConical, Layers } from "lucide-react"
 import { AuthenticatedUser } from "@/lib/schemas"
-import { TrendingUp, Users, ShoppingBag, BookOpen } from "lucide-react"
-import { queryDashboardAggregates } from "@/lib/query"
+import { queryDashboardAggregates, queryAnimalHealthCategories, queryPublishedFeedingPrograms } from "@/lib/query"
+import { capitalizeFirstLetter, unSlug } from "@/lib/utilities"
+import { Badge } from "@/components/ui/badge"
+
+// Prefix-based matching for animal produce slugs (e.g. "chickens-broilers", "chicken-meat", "chicken-eggs")
+const ANIMAL_PREFIXES = [
+  "chicken", "cattle", "beef", "pork", "pig",
+  "goat", "sheep", "lamb", "mutton",
+  "duck", "turkey", "rabbit", "ostrich",
+  "tilapia", "trout", "catfish"
+]
+
+function isAnimalProduce(slug: string): boolean {
+  const lower = slug.toLowerCase()
+  return ANIMAL_PREFIXES.some(p => lower === p || lower.startsWith(p))
+}
+
+// Map produce slug prefixes to the used_on value for animal health filtering
+function normalizeAnimal(slug: string): string {
+  const lower = slug.toLowerCase()
+  if (lower.startsWith("chicken")) return "chicken"
+  if (lower.startsWith("cattle") || lower.startsWith("beef")) return "cattle"
+  if (lower.startsWith("pork") || lower.startsWith("pig")) return "pigs"
+  if (lower.startsWith("sheep") || lower.startsWith("lamb") || lower.startsWith("mutton")) return "sheep"
+  if (lower.startsWith("goat")) return "goats"
+  if (lower.startsWith("duck")) return "ducks"
+  if (lower.startsWith("turkey")) return "turkeys"
+  if (lower.startsWith("rabbit")) return "rabbits"
+  if (lower.startsWith("ostrich")) return "ostriches"
+  return lower
+}
+
 
 interface LoggedInDashboardProps {
   user: AuthenticatedUser
@@ -21,25 +53,53 @@ export function LoggedInDashboard({ user }: LoggedInDashboardProps) {
   })
 
   const counterpartyCount = aggregates?.data?.counterparty_count || 0
-  const pricesCount = aggregates?.data?.prices_count || 0
-  const guidesCount = aggregates?.data?.guides_count || 0
   const mainProduceSlug = aggregates?.data?.main_produce_slug || ""
-  const counterpartyByProduce = aggregates?.data?.counterparty_by_produce || []
-  const counterpartyByCategory = aggregates?.data?.counterparty_by_category || []
+  const displayName = mainProduceSlug ? capitalizeFirstLetter(unSlug(mainProduceSlug)) : ""
+  const isAnimal = isAnimalProduce(mainProduceSlug)
+  const animal = isAnimal ? normalizeAnimal(mainProduceSlug) : ""
 
-  // Determine label based on user type - farmers see buyers, buyers see farmers
+  // User profile data from enriched response
+  const mainProduce = aggregates?.data?.main_produce
+  const otherProduce: any[] = aggregates?.data?.other_produce || []
+  const primaryCategory = aggregates?.data?.primary_category
+
+  // Collect all animal produce for matching
+  const allProduceSlugs: string[] = []
+  if (mainProduceSlug) allProduceSlugs.push(mainProduceSlug)
+  for (const p of otherProduce) {
+    if (p.slug && !allProduceSlugs.includes(p.slug)) allProduceSlugs.push(p.slug)
+  }
+  const uniqueAnimals = [...new Set(allProduceSlugs.filter(isAnimalProduce).map(normalizeAnimal))]
+  const otherAnimals = uniqueAnimals.filter(a => a !== animal)
+
   const counterpartyLabel = isBuyer ? "Farmers" : "Buyers"
   const counterpartyRoute = isBuyer ? "/farmers" : "/buyers"
 
-  // For similar users (same type)
-  const similarUserLabel = isBuyer ? "Buyers" : "Farmers"
-  const similarUserRoute = isBuyer ? "/buyers" : "/farmers"
+  const { data: categoriesData } = useQuery({
+    queryKey: ["animal-health-categories", animal],
+    queryFn: () => queryAnimalHealthCategories(animal),
+    enabled: isAnimal && !isLoading && !!animal,
+    refetchOnWindowFocus: false,
+  })
 
+  const categories = categoriesData?.data?.data || []
+
+  // Fetch feeding programs matched to user's animals
+  const { data: feedingProgramsData } = useQuery({
+    queryKey: ["dashboard-feeding-programs"],
+    queryFn: () => queryPublishedFeedingPrograms(),
+    enabled: uniqueAnimals.length > 0 && !isLoading,
+    refetchOnWindowFocus: false,
+  })
+  const allFeedingPrograms = feedingProgramsData?.data?.data || []
+  const matchedFeedingPrograms = allFeedingPrograms.filter((p: any) => {
+    const programAnimal = p.farm_produce_name?.toLowerCase()
+    return uniqueAnimals.some(a => a === programAnimal)
+  })
 
   return (
     <main className="min-h-screen bg-gradient-to-b from-background to-muted/20">
       <div className="mx-auto max-w-7xl px-6 lg:px-8 py-12">
-        {/* Welcome Section */}
         <div className="mb-8">
           <h1 className="text-4xl font-bold tracking-tight font-heading mb-2">
             Welcome back, {user?.username}!
@@ -47,117 +107,170 @@ export function LoggedInDashboard({ user }: LoggedInDashboardProps) {
           <p className="text-lg text-muted-foreground">
             Here&apos;s how you can manage your {businessType} today
           </p>
-        </div>
-
-        {/* Quick Stats Grid */}
-        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4 mb-8">
-          <StatCard
-            title="Market Prices"
-            value={isLoading ? "..." : `${pricesCount.toLocaleString()}`}
-            icon={<TrendingUp className="w-6 h-6" />}
-            href="/prices"
-            description="Check latest market prices"
-          />
-          <StatCard
-            title={counterpartyLabel}
-            value={isLoading ? "..." : `${counterpartyCount.toLocaleString()}`}
-            icon={<Users className="w-6 h-6" />}
-            href={counterpartyRoute}
-            description={`Connect with verified ${counterpartyLabel.toLowerCase()}`}
-          />
-
-          {/* Similar Users Card */}
-          {!isLoading && (counterpartyByCategory.length > 0 || counterpartyByProduce.length > 0) && (
-            <div className="bg-card border rounded-lg p-6 hover:border-primary/50 hover:shadow-md transition-all flex flex-col">
-              <div className="mb-4">
-                <h3 className="text-sm font-medium text-muted-foreground">Similar {similarUserLabel}</h3>
-              </div>
-
-              <div className="space-y-2">
-                {/* Category */}
-                {counterpartyByCategory.length > 0 && counterpartyByCategory.map((item: any, index: number) => (
-                  <Link
-                    key={`category-${index}`}
-                    href={`${similarUserRoute}?category=${item.name.toLowerCase()}`}
-                    className="w-full group text-left bg-muted/30 hover:bg-primary/10 active:bg-primary/20 rounded-lg p-3 transition-all border border-transparent hover:border-primary/20 block"
-                  >
-                    <div className="flex items-center justify-between">
-                      <span className="text-xs font-medium text-muted-foreground group-hover:text-primary transition-colors">
-                        {item.name}
-                      </span>
-                      <span className="text-2xl font-bold text-foreground group-hover:text-primary transition-colors">{item.count.toLocaleString()}</span>
-                    </div>
-                  </Link>
-                ))}
-
-                {/* Produce */}
-                {counterpartyByProduce.length > 0 && counterpartyByProduce.map((item: any, index: number) => (
-                  <Link
-                    key={`produce-${index}`}
-                    href={`${similarUserRoute}?produce=${item.name.toLowerCase()}`}
-                    className="w-full group text-left bg-muted/30 hover:bg-primary/10 active:bg-primary/20 rounded-lg p-3 transition-all border border-transparent hover:border-primary/20 block"
-                  >
-                    <div className="flex items-center justify-between">
-                      <span className="text-xs font-medium text-muted-foreground group-hover:text-primary transition-colors">
-                        {item.name}
-                      </span>
-                      <span className="text-2xl font-bold text-foreground group-hover:text-primary transition-colors">{item.count.toLocaleString()}</span>
-                    </div>
-                  </Link>
-                ))}
-              </div>
+          {!isLoading && (primaryCategory || mainProduce) && (
+            <div className="flex flex-wrap items-center gap-2 mt-4">
+              {primaryCategory && (
+                <Badge variant="secondary" className="bg-primary/10 text-primary">
+                  {capitalizeFirstLetter(primaryCategory.name)}
+                </Badge>
+              )}
+              {mainProduce && (
+                <Badge variant="secondary" className="bg-amber-50 text-amber-700 dark:bg-amber-900/20 dark:text-amber-400">
+                  {capitalizeFirstLetter(mainProduce.name)}
+                </Badge>
+              )}
+              {otherProduce.map((p: any) => (
+                <Badge key={p.slug} variant="outline">
+                  {capitalizeFirstLetter(p.name)}
+                </Badge>
+              ))}
             </div>
           )}
-
-          <StatCard
-            title="Guides"
-            value={isLoading ? "..." : guidesCount === 0 ? "Browse All" : `${guidesCount.toLocaleString()}`}
-            icon={<BookOpen className="w-6 h-6" />}
-            href={guidesCount === 0 ? "/agrochemical-guides/all" : `/agrochemical-guides/all?used_on=${mainProduceSlug}`}
-            description={guidesCount === 0 ? "See all agrochemical guides" : "Expert agrochemical info"}
-          />
         </div>
 
-        {/* Shop CTA */}
-        <Link href="/waiting-list-shop">
-          <div className="bg-card border rounded-lg p-6 hover:border-primary/50 hover:shadow-md transition-all cursor-pointer mb-8">
-            <div className="flex items-center gap-4">
-              <div className="p-3 bg-primary/10 rounded-lg text-primary">
-                <ShoppingBag className="w-8 h-8" />
-              </div>
-              <div>
-                <h3 className="text-xl font-semibold mb-1">Shop - Coming Soon</h3>
-                <p className="text-sm text-muted-foreground">Quality farm inputs delivered to your door</p>
-              </div>
-            </div>
+        {!isLoading && mainProduceSlug && (
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-10">
+            {/* Ready to Sell */}
+            <section>
+              <h2 className="text-2xl font-bold tracking-tight font-heading mb-4">Ready to Sell</h2>
+              <Link href={`${counterpartyRoute}/${mainProduceSlug}`} className="block">
+                <div className="bg-gradient-to-r from-orange-50 to-orange-100 dark:from-orange-900/20 dark:to-orange-800/20 border border-orange-200 dark:border-orange-800/30 rounded-lg p-6 hover:shadow-md transition-all">
+                  <div className="flex items-center gap-4">
+                    <div className="flex-1">
+                      <h3 className="text-lg font-semibold">Find {counterpartyLabel} for {displayName}</h3>
+                      <p className="text-sm text-muted-foreground">
+                        {counterpartyCount > 0
+                          ? `${counterpartyCount.toLocaleString()} ${counterpartyLabel.toLowerCase()} available to possibly buy your produce`
+                          : `Browse ${counterpartyLabel.toLowerCase()} on the platform`}
+                      </p>
+                    </div>
+                    <ArrowRight className="w-5 h-5 text-muted-foreground" />
+                  </div>
+                </div>
+              </Link>
+            </section>
+
+            {/* Animal Health Categories */}
+            {isAnimal && (
+              <section>
+                <h2 className="text-2xl font-bold tracking-tight font-heading mb-4">
+                  Animal Health for Your {displayName} Business
+                </h2>
+                {categories.length > 0 ? (
+                  <div className="grid grid-cols-2 gap-2">
+                    {categories.map((cat: any) => (
+                      <Link
+                        key={cat.id}
+                        href={`/animal-health-guides/${cat.slug}?used_on=${animal}`}
+                        className="flex items-center justify-between rounded-lg border bg-card p-3 hover:border-primary/50 hover:shadow-sm transition group"
+                        onClick={() => sendGTMEvent({ event: "click", value: `DashboardHealthCategory_${cat.slug}` })}
+                      >
+                        <span className="text-sm font-medium truncate">{capitalizeFirstLetter(cat.name)}</span>
+                        <div className="flex items-center gap-1 flex-none">
+                          {cat.product_count > 0 && (
+                            <span className="text-xs text-muted-foreground">{cat.product_count}</span>
+                          )}
+                          <ChevronRight className="h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+                        </div>
+                      </Link>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="rounded-lg border border-dashed border-muted-foreground/30 bg-muted/30 p-6 text-center">
+                    <FlaskConical className="h-8 w-8 mx-auto text-muted-foreground/50 mb-3" />
+                    <p className="text-sm font-medium text-muted-foreground">
+                      We&apos;re building {displayName.toLowerCase()} health product data
+                    </p>
+                    <p className="text-xs text-muted-foreground/70 mt-1">
+                      Vaccines, supplements, and more — coming soon
+                    </p>
+                  </div>
+                )}
+              </section>
+            )}
           </div>
-        </Link>
+        )}
+
+        {/* Feeding Programs matched to user's livestock */}
+        {!isLoading && matchedFeedingPrograms.length > 0 && (
+          <section className="mb-10">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-2xl font-bold tracking-tight font-heading">
+                Feeding Programs for Your Livestock
+              </h2>
+              <Link href="/feeding-programs" className="text-sm text-primary hover:underline flex items-center gap-1">
+                View all <ChevronRight className="h-3.5 w-3.5" />
+              </Link>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {matchedFeedingPrograms.slice(0, 6).map((program: any) => (
+                <Link
+                  key={program.id}
+                  href={`/feeding-programs/${program.slug}`}
+                  className="group rounded-lg border bg-card p-4 hover:shadow-md hover:border-primary/20 transition-all"
+                  onClick={() => sendGTMEvent({ event: "click", value: `DashboardFeedProgram_${program.slug}` })}
+                >
+                  <h3 className="text-sm font-bold font-heading mb-1 group-hover:text-primary transition-colors">
+                    {capitalizeFirstLetter(program.name)}
+                  </h3>
+                  {program.farm_produce_name && (
+                    <Badge variant="secondary" className="bg-amber-50 text-amber-700 dark:bg-amber-900/20 dark:text-amber-400 text-[10px] mb-2">
+                      {capitalizeFirstLetter(program.farm_produce_name)}
+                    </Badge>
+                  )}
+                  <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                    <Layers className="h-3 w-3" />
+                    <span>{program.stages?.length || 0} stage feeding program</span>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Resources for other animals in user's produce list */}
+        {!isLoading && otherAnimals.length > 0 && (
+          <section className="mb-10">
+            {otherAnimals.map(otherAnimal => {
+              const display = capitalizeFirstLetter(otherAnimal)
+              return (
+                <div key={otherAnimal} className="mb-6">
+                  <h3 className="text-lg font-bold tracking-tight font-heading mb-3">
+                    {display} Resources
+                  </h3>
+                  <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+                    <Link
+                      href={`/animal-health-guides/vaccines?used_on=${otherAnimal}`}
+                      className="flex items-center gap-3 rounded-lg border bg-card p-3 hover:border-primary/50 hover:shadow-sm transition group"
+                      onClick={() => sendGTMEvent({ event: "click", value: `DashboardVaccines_${otherAnimal}` })}
+                    >
+                      <span className="text-sm font-medium group-hover:text-primary transition-colors">{display} Vaccines</span>
+                      <ChevronRight className="h-4 w-4 text-muted-foreground ml-auto opacity-0 group-hover:opacity-100 transition-opacity" />
+                    </Link>
+                    <Link
+                      href={`/animal-health-guides/nutrition-supplements?used_on=${otherAnimal}`}
+                      className="flex items-center gap-3 rounded-lg border bg-card p-3 hover:border-primary/50 hover:shadow-sm transition group"
+                      onClick={() => sendGTMEvent({ event: "click", value: `DashboardNutrition_${otherAnimal}` })}
+                    >
+                      <span className="text-sm font-medium group-hover:text-primary transition-colors">{display} Nutrition</span>
+                      <ChevronRight className="h-4 w-4 text-muted-foreground ml-auto opacity-0 group-hover:opacity-100 transition-opacity" />
+                    </Link>
+                    <Link
+                      href={`/feeding-programs?animal=${otherAnimal}`}
+                      className="flex items-center gap-3 rounded-lg border bg-card p-3 hover:border-primary/50 hover:shadow-sm transition group"
+                      onClick={() => sendGTMEvent({ event: "click", value: `DashboardFeedingPrograms_${otherAnimal}` })}
+                    >
+                      <span className="text-sm font-medium group-hover:text-primary transition-colors">{display} Feeding Programs</span>
+                      <ChevronRight className="h-4 w-4 text-muted-foreground ml-auto opacity-0 group-hover:opacity-100 transition-opacity" />
+                    </Link>
+                  </div>
+                </div>
+              )
+            })}
+          </section>
+        )}
+
       </div>
     </main>
-  )
-}
-
-interface StatCardProps {
-  title: string
-  value: string
-  icon: React.ReactNode
-  href: string
-  description: string
-}
-
-function StatCard({ title, value, icon, href, description }: StatCardProps) {
-  return (
-    <Link href={href} className="h-full">
-      <div className="bg-card border rounded-lg p-6 hover:border-primary/50 hover:shadow-md transition-all cursor-pointer h-full flex flex-col">
-        <div className="flex items-center justify-between mb-4">
-          <div className="p-2 bg-primary/10 rounded-lg text-primary">
-            {icon}
-          </div>
-        </div>
-        <h3 className="text-sm font-medium text-muted-foreground mb-3 leading-snug">{title}</h3>
-        <p className="text-2xl font-bold mb-3 leading-tight">{value}</p>
-        <p className="text-xs text-muted-foreground leading-normal">{description}</p>
-      </div>
-    </Link>
   )
 }

--- a/apps/client-fnp/components/layouts/logged-out-landing.tsx
+++ b/apps/client-fnp/components/layouts/logged-out-landing.tsx
@@ -151,11 +151,34 @@ function ArrowDownIcon(props: React.ComponentPropsWithoutRef<"svg">) {
 }
 
 function Featured() {
-    const categories = [
+    const resources = [
         {
-            name: "Pricing",
-            description: "Pricing data and market insights",
+            name: "Feeding Programs",
+            description: "Structured feeding schedules for optimal livestock growth at every stage.",
+            href: "/feeding-programs",
+            event: "LandingFeedingPrograms",
+            icon: (
+                <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" />
+                </svg>
+            ),
+        },
+        {
+            name: "Animal Health Guides",
+            description: "Vaccines, antibiotics, dips and nutrition supplements for your livestock.",
+            href: "/animal-health-guides/all",
+            event: "LandingAnimalHealth",
+            icon: (
+                <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0112 15a9.065 9.065 0 00-6.23.693L5 14.5m14.8.8l1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0112 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5" />
+                </svg>
+            ),
+        },
+        {
+            name: "Market Prices",
+            description: "Real-time livestock pricing data to plan your sales and maximize profit.",
             href: "/prices",
+            event: "LandingMarketPrices",
             icon: (
                 <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
                     <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 18.75a60.07 60.07 0 0115.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 013 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 00-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 01-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 003 15h-.75M15 10.5a3 3 0 11-6 0 3 3 0 016 0zm3 0h.008v.008H18V10.5zm-12 0h.008v.008H6V10.5z" />
@@ -163,22 +186,13 @@ function Featured() {
             ),
         },
         {
-            name: "Shop",
-            description: "Quality inputs for your farm",
-            href: "/waiting-list-shop",
-            icon: (
-                <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 00-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 00-16.536-1.84M7.5 14.25L5.106 5.272M6 20.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm12.75 0a.75.75 0 11-1.5 0 .75.75 0 011.5 0z" />
-                </svg>
-            ),
-        },
-        {
-            name: "Chemical Guides",
-            description: "Expert agrochemical information",
+            name: "Agrochemical Guides",
+            description: "Crop protection products, herbicides, fungicides and insecticides.",
             href: "/agrochemical-guides",
+            event: "LandingAgrochemicalGuides",
             icon: (
                 <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0112 15a9.065 9.065 0 00-6.23.693L5 14.5m14.8.8l1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0112 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5" />
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
                 </svg>
             ),
         },
@@ -187,39 +201,31 @@ function Featured() {
     return (
         <section className="bg-background py-12 lg:py-16">
             <div className="mx-auto max-w-7xl px-6 lg:px-8">
-                <div className="grid gap-8 lg:grid-cols-12 lg:gap-12 xl:gap-16">
-                    <div className="content-center lg:col-span-6 order-1 lg:order-2">
-                        <h2 className="mb-4 text-4xl font-bold leading-none tracking-tight sm:text-5xl font-heading">
-                            Your Complete Farm Hub
-                        </h2>
-                        <p className="mb-6 max-w-2xl text-lg text-muted-foreground md:mb-8">
-                            Search active ingredients, discover how pesticides and herbicides work, find what targets specific pests and diseases, then shop for the right products. Find reputable and verified buyers for your produce and get real-time market prices to plan your harvest sales.
-                        </p>
-                    </div>
-                    <div className="lg:col-span-6 order-2 lg:order-1">
-                        <div className="grid gap-4 sm:grid-cols-1">
-                            {categories.map((category) => (
-                                <Link
-                                    key={category.name}
-                                    href={category.href}
-                                    className="group flex items-start gap-4 rounded-lg border bg-card text-card-foreground p-4 shadow-sm transition hover:border-orange-500 hover:shadow-md"
-                                    onClick={() => sendGTMEvent({ event: "click", value: `CategoryCard${category.name.replace(/\s+/g, '')}` })}
-                                >
-                                    <div className="relative mt-1 flex h-10 w-10 flex-none items-center justify-center rounded-full shadow-md shadow-zinc-800/5 ring-1 ring-zinc-900/5 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0 group-hover:bg-orange-600 group-hover:text-white dark:group-hover:bg-orange-500">
-                                        {category.icon}
-                                    </div>
-                                    <div>
-                                        <h3 className="mb-1 text-lg font-semibold">
-                                            {category.name}
-                                        </h3>
-                                        <p className="text-sm text-muted-foreground">
-                                            {category.description}
-                                        </p>
-                                    </div>
-                                </Link>
-                            ))}
-                        </div>
-                    </div>
+                <div className="mx-auto max-w-2xl lg:mx-0">
+                    <h2 className="mb-4 text-4xl font-bold leading-none tracking-tight sm:text-5xl font-heading">
+                        Your Complete Farm Hub
+                    </h2>
+                    <p className="mb-6 max-w-2xl text-lg text-muted-foreground md:mb-8">
+                        Access feeding programs, animal health guides, market prices and crop protection information to grow your farm.
+                    </p>
+                </div>
+                <div className="mt-10 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4 lg:mt-12">
+                    {resources.map((resource) => (
+                        <Link
+                            key={resource.name}
+                            href={resource.href}
+                            className="group flex items-start gap-4 rounded-lg border bg-card text-card-foreground p-5 shadow-sm transition hover:border-orange-500 hover:shadow-md"
+                            onClick={() => sendGTMEvent({ event: "click", value: resource.event })}
+                        >
+                            <div className="relative mt-1 flex h-10 w-10 flex-none items-center justify-center rounded-full shadow-md shadow-zinc-800/5 ring-1 ring-zinc-900/5 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0 group-hover:bg-orange-600 group-hover:text-white dark:group-hover:bg-orange-500 transition-colors">
+                                {resource.icon}
+                            </div>
+                            <div>
+                                <h3 className="text-sm font-semibold">{resource.name}</h3>
+                                <p className="text-xs text-muted-foreground mt-1">{resource.description}</p>
+                            </div>
+                        </Link>
+                    ))}
                 </div>
             </div>
         </section>
@@ -289,3 +295,4 @@ function FeaturedPopularSection() {
         </div>
     )
 }
+

--- a/apps/client-fnp/components/monetization/product-resources.tsx
+++ b/apps/client-fnp/components/monetization/product-resources.tsx
@@ -1,0 +1,134 @@
+"use client"
+
+import Link from "next/link"
+import { useQuery } from "@tanstack/react-query"
+import { sendGTMEvent } from "@next/third-parties/google"
+import { Layers } from "lucide-react"
+import { queryPublishedFeedingPrograms } from "@/lib/query"
+import { capitalizeFirstLetter } from "@/lib/utilities"
+
+interface ProductResourcesProps {
+    product: string
+}
+
+// Prefix-based matching for animal produce slugs (e.g. "chickens-broilers", "chicken-meat")
+const ANIMAL_PREFIXES = [
+    "chicken", "cattle", "beef", "pork", "pig",
+    "goat", "sheep", "lamb", "mutton",
+    "duck", "turkey", "rabbit", "ostrich",
+    "tilapia", "trout", "catfish"
+]
+
+function isAnimalProduce(slug: string): boolean {
+    const lower = slug.toLowerCase()
+    return ANIMAL_PREFIXES.some(p => lower === p || lower.startsWith(p))
+}
+
+function normalizeAnimal(slug: string): string {
+    const lower = slug.toLowerCase()
+    if (lower.startsWith("chicken")) return "chicken"
+    if (lower.startsWith("cattle") || lower.startsWith("beef")) return "cattle"
+    if (lower.startsWith("pork") || lower.startsWith("pig")) return "pigs"
+    if (lower.startsWith("sheep") || lower.startsWith("lamb") || lower.startsWith("mutton")) return "sheep"
+    if (lower.startsWith("goat")) return "goats"
+    if (lower.startsWith("duck")) return "ducks"
+    if (lower.startsWith("turkey")) return "turkeys"
+    if (lower.startsWith("rabbit")) return "rabbits"
+    if (lower.startsWith("ostrich")) return "ostriches"
+    return lower
+}
+
+export function ProductResources({ product }: ProductResourcesProps) {
+    const lower = product.toLowerCase()
+
+    const isAnimal = isAnimalProduce(lower)
+
+    const { data, isLoading } = useQuery({
+        queryKey: ["feeding-programs-cross-sell"],
+        queryFn: () => queryPublishedFeedingPrograms(),
+        enabled: isAnimal,
+        refetchOnWindowFocus: false,
+    })
+
+    if (!isAnimal) return null
+
+    const allPrograms = data?.data?.data || []
+    const animal = normalizeAnimal(lower)
+    const matchingPrograms = allPrograms.filter(
+        (p: any) => p.farm_produce_name?.toLowerCase() === animal
+    ).slice(0, 3)
+
+    const displayName = capitalizeFirstLetter(product)
+
+    // Static resource cards with filtered URLs
+    const staticCards = [
+        {
+            title: `${displayName} Vaccines`,
+            description: "Vaccination schedules & guides",
+            href: `/animal-health-guides/vaccines?used_on=${animal}`,
+            event: `CrossSellVaccines_${lower}`,
+            icon: (
+                <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0112 15a9.065 9.065 0 00-6.23.693L5 14.5m14.8.8l1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0112 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5" />
+                </svg>
+            ),
+        },
+        {
+            title: `${displayName} Nutrition`,
+            description: "Supplements & nutrition guides",
+            href: `/animal-health-guides/nutrition-supplements?used_on=${animal}`,
+            event: `CrossSellNutrition_${lower}`,
+            icon: (
+                <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z" />
+                </svg>
+            ),
+        },
+    ]
+
+    const hasContent = matchingPrograms.length > 0 || staticCards.length > 0
+
+    if (!hasContent && !isLoading) return null
+
+    return (
+        <div className="mb-6">
+            <h3 className="text-sm font-semibold text-muted-foreground mb-3">
+                Resources for {displayName} Farming
+            </h3>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                {matchingPrograms.map((program: any) => (
+                    <Link
+                        key={program.id}
+                        href={`/feeding-programs/${program.slug}`}
+                        className="flex items-center gap-3 rounded-lg border bg-card p-3 transition hover:border-primary/50 hover:shadow-sm group"
+                        onClick={() => sendGTMEvent({ event: "click", value: `CrossSellFeedProgram_${program.slug}` })}
+                    >
+                        <div className="flex h-9 w-9 flex-none items-center justify-center rounded-full bg-muted text-muted-foreground group-hover:bg-primary group-hover:text-white transition-colors">
+                            <Layers className="h-5 w-5" />
+                        </div>
+                        <div className="min-w-0">
+                            <p className="text-sm font-medium truncate">{capitalizeFirstLetter(program.name)}</p>
+                            <p className="text-xs text-muted-foreground">{program.stages?.length || 0} stage feeding program</p>
+                        </div>
+                    </Link>
+                ))}
+                {staticCards.map((card) => (
+                    <Link
+                        key={card.title}
+                        href={card.href}
+                        className="flex items-center gap-3 rounded-lg border bg-card p-3 transition hover:border-primary/50 hover:shadow-sm group"
+                        onClick={() => sendGTMEvent({ event: "click", value: card.event })}
+                    >
+                        <div className="flex h-9 w-9 flex-none items-center justify-center rounded-full bg-muted text-muted-foreground group-hover:bg-primary group-hover:text-white transition-colors">
+                            {card.icon}
+                        </div>
+                        <div className="min-w-0">
+                            <p className="text-sm font-medium truncate">{card.title}</p>
+                            <p className="text-xs text-muted-foreground">{card.description}</p>
+                        </div>
+                    </Link>
+                ))}
+            </div>
+        </div>
+    )
+}

--- a/apps/client-fnp/components/structures/cdm-price-card.tsx
+++ b/apps/client-fnp/components/structures/cdm-price-card.tsx
@@ -70,7 +70,7 @@ export function CdmPriceCard({ price, hideHeader }: CdmPriceCardProps) {
     <div className="space-y-6">
       {/* Header */}
       {!hideHeader && (
-        <div className="rounded-lg border bg-card px-5 py-4">
+        <div className="rounded-xl border bg-card shadow-sm px-5 py-4">
           <div className="flex items-start justify-between">
             <div>
               <h3 className="text-lg font-semibold text-foreground">
@@ -81,7 +81,7 @@ export function CdmPriceCard({ price, hideHeader }: CdmPriceCardProps) {
                 <span>Cold Dress Mass Pricing</span>
               </div>
             </div>
-            <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider bg-muted px-2 py-1 rounded">
+            <span className="text-[10px] font-semibold text-primary uppercase tracking-wider bg-primary/10 px-2 py-1 rounded-md">
               CDM
             </span>
           </div>
@@ -96,8 +96,8 @@ export function CdmPriceCard({ price, hideHeader }: CdmPriceCardProps) {
       )}
 
       {/* Carcass Grades */}
-      <div className="rounded-lg border bg-card overflow-hidden">
-        <div className="px-5 py-2.5 bg-muted/30 border-b">
+      <div className="rounded-xl border bg-card shadow-sm">
+        <div className="px-5 py-2.5 border-b">
           <h4 className="text-sm font-semibold text-foreground">
             Carcass Grades (per kg)
           </h4>
@@ -158,8 +158,8 @@ export function CdmPriceCard({ price, hideHeader }: CdmPriceCardProps) {
             // Classification-only (no prices) — table with Weight + Status
             if (!hasAnyPrice && hasAnyNote) {
               return (
-                <div key={teeth} className="rounded-lg border bg-card overflow-hidden">
-                  <div className="px-5 py-2.5 bg-muted/30 border-b flex items-center gap-3">
+                <div key={teeth} className="rounded-xl border bg-card shadow-sm">
+                  <div className="px-5 py-2.5 border-b flex items-center gap-3">
                     <h5 className="text-sm font-semibold text-foreground">{info.name}</h5>
                     <span className={cn(info.color, "rounded-md px-2 py-0.5 text-[10px] font-bold ring-1 ring-inset")}>
                       {teeth}
@@ -211,8 +211,8 @@ export function CdmPriceCard({ price, hideHeader }: CdmPriceCardProps) {
 
             // Has prices — full table
             return (
-              <div key={teeth} className="rounded-lg border bg-card overflow-hidden">
-                <div className="px-5 py-2.5 bg-muted/30 border-b flex items-center gap-3">
+              <div key={teeth} className="rounded-xl border bg-card shadow-sm">
+                <div className="px-5 py-2.5 border-b flex items-center gap-3">
                   <h5 className="text-sm font-semibold text-foreground">{info.name}</h5>
                   <span className={cn(info.color, "rounded-md px-2 py-0.5 text-[10px] font-bold ring-1 ring-inset")}>
                     {teeth}
@@ -283,7 +283,7 @@ export function CdmPriceCard({ price, hideHeader }: CdmPriceCardProps) {
 
       {/* Notes */}
       {price.notes && price.notes.length > 0 && (
-        <div className="rounded-lg border bg-card px-5 py-4">
+        <div className="rounded-xl border bg-card shadow-sm px-5 py-4">
           <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">Important Notes</h4>
           <div className="space-y-2">
             {price.notes.map((note, i) => (

--- a/apps/client-fnp/components/structures/cdm-price-summary-card.tsx
+++ b/apps/client-fnp/components/structures/cdm-price-summary-card.tsx
@@ -15,10 +15,22 @@ export function CdmPriceSummaryCard({ price }: CdmPriceSummaryCardProps) {
   const nameSlug = slug(price.client_name)
   const priceSlug = `${nameSlug}-${dateSlug}`
 
+  const teethCategories = price.liveweight
+    ? [...new Set(price.liveweight.map((lw) => lw.teeth).filter(Boolean))]
+    : []
+
+  const teethColors: Record<string, string> = {
+    "MT": "bg-emerald-50 text-emerald-700 ring-emerald-600/10 dark:bg-emerald-950/30 dark:text-emerald-400",
+    "2T": "bg-blue-50 text-blue-700 ring-blue-600/10 dark:bg-blue-950/30 dark:text-blue-400",
+    "4T": "bg-violet-50 text-violet-700 ring-violet-600/10 dark:bg-violet-950/30 dark:text-violet-400",
+    "6T": "bg-amber-50 text-amber-700 ring-amber-600/10 dark:bg-amber-950/30 dark:text-amber-400",
+    "8T": "bg-orange-50 text-orange-700 ring-orange-600/10 dark:bg-orange-950/30 dark:text-orange-400",
+  }
+
   return (
     <Link href={`/prices/cdm/${priceSlug}`} className="block group">
       <div className="flex items-center justify-between gap-3 py-3 px-1 hover:bg-muted/30 transition-colors">
-        <div className="min-w-0">
+        <div className="min-w-0 flex-1">
           <h3 className="text-sm font-semibold text-foreground truncate group-hover:text-primary transition-colors">
             {capitalizeFirstLetter(price.client_name)}
           </h3>
@@ -26,6 +38,15 @@ export function CdmPriceSummaryCard({ price }: CdmPriceSummaryCardProps) {
             <Calendar className="h-3 w-3 shrink-0" />
             <span>{formattedDate}</span>
           </div>
+          {teethCategories.length > 0 && (
+            <div className="flex gap-1 mt-1.5">
+              {teethCategories.map((t) => (
+                <span key={t} className={`inline-flex items-center rounded-md px-1.5 py-0.5 text-[10px] font-medium ring-1 ring-inset ${teethColors[t] || "bg-slate-50 text-slate-700 ring-slate-600/10 dark:bg-slate-950/30 dark:text-slate-400"}`}>
+                  {t}
+                </span>
+              ))}
+            </div>
+          )}
         </div>
         <ArrowRight className="h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 group-hover:translate-x-0.5 transition-all shrink-0" />
       </div>

--- a/apps/client-fnp/components/structures/feeding-programs-grid.tsx
+++ b/apps/client-fnp/components/structures/feeding-programs-grid.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import Link from "next/link"
+import { Layers, ChevronRight, Filter } from "lucide-react"
+import { capitalizeFirstLetter } from "@/lib/utilities"
+import { useQueryState, parseAsString } from "nuqs"
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet"
+import { Button } from "@/components/ui/button"
+import { useMediaQuery } from "@/hooks/use-media-query"
+
+function getAnimalGroup(farmProduceName: string): string {
+  const name = farmProduceName.toLowerCase()
+  if (name.startsWith("chicken")) return "chickens"
+  if (name.startsWith("cattle") || name.startsWith("beef")) return "cattle"
+  if (name.startsWith("pig") || name.startsWith("pork")) return "pigs"
+  if (name.startsWith("sheep") || name.startsWith("lamb")) return "sheep"
+  if (name.startsWith("goat")) return "goats"
+  if (name.startsWith("duck")) return "ducks"
+  if (name.startsWith("turkey")) return "turkeys"
+  return farmProduceName.split("(")[0].trim().toLowerCase()
+}
+
+interface FeedingProgramsGridProps {
+  programs: any[]
+}
+
+function FilterNav({ groups, counts, active, onSelect }: {
+  groups: string[]
+  counts: Record<string, number>
+  active: string | null
+  onSelect: (g: string | null) => void
+}) {
+  return (
+    <div>
+      <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider mb-3">Livestock Type</p>
+      <div className="space-y-0.5">
+        <button
+          onClick={() => onSelect(null)}
+          className={`w-full flex items-center justify-between px-3 py-2 rounded-lg text-sm transition-colors ${
+            active === null
+              ? "bg-primary/10 text-primary font-semibold"
+              : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
+          }`}
+        >
+          <span>All</span>
+          <span className="text-xs text-muted-foreground">{Object.values(counts).reduce((a, b) => a + b, 0)}</span>
+        </button>
+        {groups.map((group) => (
+          <button
+            key={group}
+            onClick={() => onSelect(group)}
+            className={`w-full flex items-center justify-between px-3 py-2 rounded-lg text-sm transition-colors ${
+              active === group
+                ? "bg-primary/10 text-primary font-semibold"
+                : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
+            }`}
+          >
+            <span>{capitalizeFirstLetter(group)}</span>
+            <span className="text-xs text-muted-foreground">{counts[group] || 0}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function FeedingProgramsGrid({ programs }: FeedingProgramsGridProps) {
+  const [animal, setAnimal] = useQueryState("animal", parseAsString)
+  const isDesktop = useMediaQuery("(min-width: 1024px)")
+
+  const groups: string[] = []
+  const counts: Record<string, number> = {}
+  for (const p of programs) {
+    const g = getAnimalGroup(p.farm_produce_name || "")
+    if (!groups.includes(g)) groups.push(g)
+    counts[g] = (counts[g] || 0) + 1
+  }
+
+  const filtered = animal
+    ? programs.filter((p: any) => getAnimalGroup(p.farm_produce_name || "") === animal)
+    : programs
+
+  const handleSelect = (g: string | null) => {
+    setAnimal(g)
+    window.scrollTo({ top: 0, behavior: "smooth" })
+  }
+
+  return (
+    <div className="lg:grid lg:grid-cols-[180px_1fr] lg:gap-8">
+      {/* Desktop sidebar */}
+      {isDesktop ? (
+        <nav className="hidden lg:block">
+          <div className="sticky top-20">
+            <FilterNav groups={groups} counts={counts} active={animal} onSelect={handleSelect} />
+          </div>
+        </nav>
+      ) : (
+        <Sheet>
+          <SheetTrigger asChild>
+            <Button variant="outline" className="w-full mb-4">
+              <Filter className="mr-2 h-4 w-4" />
+              Filter by Livestock
+            </Button>
+          </SheetTrigger>
+          <SheetContent side="left" className="w-[280px] overflow-y-auto">
+            <SheetHeader className="mb-4">
+              <SheetTitle>Filter Programs</SheetTitle>
+            </SheetHeader>
+            <FilterNav groups={groups} counts={counts} active={animal} onSelect={handleSelect} />
+          </SheetContent>
+        </Sheet>
+      )}
+
+      {/* Grid */}
+      <div className="min-w-0">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {filtered.map((program: any) => (
+            <Link key={program.id} href={`/feeding-programs/${program.slug}`} className="group rounded-xl border bg-card overflow-hidden hover:shadow-md hover:border-primary/20 transition-all">
+              <div className="p-4">
+                <h2 className="text-sm font-bold font-heading mb-1 group-hover:text-primary transition-colors">{capitalizeFirstLetter(program.name)}</h2>
+                {program.farm_produce_name && (
+                  <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-600/10 dark:bg-amber-950/30 dark:text-amber-400 mb-2">{capitalizeFirstLetter(program.farm_produce_name)}</span>
+                )}
+                {program.description && (
+                  <p className="text-xs text-muted-foreground line-clamp-2 mb-3">{program.description}</p>
+                )}
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                    <Layers className="h-3 w-3" />
+                    <span>{program.stages?.length || 0} stages</span>
+                  </div>
+                  <ChevronRight className="h-3.5 w-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/client-fnp/components/structures/price-card.tsx
+++ b/apps/client-fnp/components/structures/price-card.tsx
@@ -60,10 +60,8 @@ export function PriceCard({ priceList }: PriceCardProps) {
   const categories = pricingTypes[priceList.client_specialization] || []
 
   return (
-    <div className="group relative rounded-2xl border bg-card shadow-sm transition-all duration-300 hover:shadow-md hover:border-primary/30 overflow-hidden">
-      <div className="h-1 bg-gradient-to-r from-blue-500 via-purple-500 to-pink-500" />
-
-      <div className="p-6 border-b bg-muted/20">
+    <div className="group relative rounded-xl border bg-card shadow-sm transition-all duration-200 hover:shadow-md hover:border-primary/20">
+      <div className="p-6">
         <div className="flex items-start justify-between mb-3">
           <div className="flex-1">
             <h3 className="text-2xl font-bold font-heading text-card-foreground mb-2">
@@ -107,16 +105,16 @@ export function PriceCard({ priceList }: PriceCardProps) {
           if (gradeEntries.length === 0) return null
 
           return (
-            <div key={typeIndex} className="rounded-xl border bg-card/50 overflow-hidden">
-              <div className="px-4 py-3 bg-muted/30 border-b">
-                <h4 className="text-base font-semibold text-card-foreground">
-                  {capitalizeFirstLetter(pricingType)}
+            <div key={typeIndex} className="rounded-xl border bg-card/50">
+              <div className="px-4 pt-3 pb-1">
+                <h4 className="text-sm font-bold tracking-tight">
+                  {capitalizeFirstLetter(pricingType)} Prices
                 </h4>
               </div>
 
               <div className="overflow-x-auto">
                 <table className="min-w-full divide-y divide-border">
-                  <thead className="bg-muted/20">
+                  <thead>
                     <tr>
                       <th className="px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
                         Grade
@@ -173,7 +171,7 @@ export function PriceCard({ priceList }: PriceCardProps) {
         })}
       </div>
 
-      <div className="px-6 py-4 bg-muted/20 border-t">
+      <div className="px-6 py-4 border-t">
         <Link href={`/prices/${priceList.id}`}>
           <Button variant="ghost" className="w-full group/btn" size="sm">
             <span>View Detailed Breakdown</span>

--- a/apps/client-fnp/components/structures/price-details-grid.tsx
+++ b/apps/client-fnp/components/structures/price-details-grid.tsx
@@ -29,6 +29,7 @@ interface PriceListData {
 
 interface PriceDetailsGridProps {
   priceList: PriceListData
+  produce?: string
 }
 
 type ProducerPriceListKeys = "beef" | "lamb" | "mutton" | "goat" | "chicken" | "pork" | "slaughter"
@@ -47,15 +48,37 @@ const pricingTypes: Record<string, ProducerPriceListKeys[]> = {
   livestock: ["beef", "lamb", "mutton", "goat", "chicken", "pork", "slaughter"],
 }
 
+const gradeLabels: Record<string, string> = {
+  super: "Super",
+  choice: "Choice",
+  commercial: "Commercial",
+  economy: "Economy",
+  manufacturing: "Manufacturing",
+  condemned: "Condemned",
+  superPremium: "Super Premium",
+  standard: "Standard",
+  ordinary: "Ordinary",
+  inferior: "Inferior",
+  a_grade_over_1_75: "A Grade Over 1.75 kgs",
+  a_grade_1_55_1_75: "A Grade 1.55 – 1.75 kgs",
+  a_grade_under_1_55: "A Grade Under 1.55 kgs",
+  off_layers: "Off Layers",
+  cattle: "Cattle",
+  sheep: "Sheep",
+  pigs: "Pigs",
+  chicken: "Chicken",
+}
+
 const formatGradeName = (key: string): string => {
-  if (key === "superPremium") return "Super Premium"
+  if (gradeLabels[key]) return gradeLabels[key]
   return key.split("_").map((word) => capitalizeFirstLetter(word)).join(" ")
 }
 
-export function PriceDetailsGrid({ priceList }: PriceDetailsGridProps) {
+export function PriceDetailsGrid({ priceList, produce }: PriceDetailsGridProps) {
   const categories = pricingTypes[priceList.client_specialization] || []
 
   const renderableCategories = categories.filter((pricingType) => {
+    if (produce && pricingType !== produce) return false
     if (priceList[pricingType] === undefined) return false
     const categoryData = priceList[pricingType]
     const gradeEntries = Object.entries(categoryData).filter(
@@ -75,10 +98,10 @@ export function PriceDetailsGrid({ priceList }: PriceDetailsGridProps) {
         return (
           <div key={renderIndex}>
           {renderIndex > 0 && renderIndex % 2 === 0 && <AdSenseInFeed />}
-          <div className="rounded-lg border bg-card overflow-hidden">
-            <div className="px-5 py-3 border-b bg-muted/30">
-              <h3 className="text-sm font-semibold text-foreground uppercase tracking-wide">
-                {capitalizeFirstLetter(pricingType)}
+          <div className="rounded-xl border bg-card shadow-sm">
+            <div className="px-5 pt-4 pb-2">
+              <h3 className="text-sm font-bold tracking-tight">
+                {capitalizeFirstLetter(pricingType)} Prices
               </h3>
             </div>
 

--- a/apps/client-fnp/components/structures/produce-categories-view.tsx
+++ b/apps/client-fnp/components/structures/produce-categories-view.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import Link from "next/link"
+import { ArrowRight } from "lucide-react"
+import { ProducePriceCardsView } from "@/components/structures/produce-price-cards-view"
+
+const produceCategories = [
+  { name: "Beef", slug: "beef", color: "bg-red-500" },
+  { name: "Lamb", slug: "lamb", color: "bg-amber-500" },
+  { name: "Mutton", slug: "mutton", color: "bg-orange-500" },
+  { name: "Goat", slug: "goat", color: "bg-lime-600" },
+  { name: "Chicken", slug: "chicken", color: "bg-yellow-500" },
+  { name: "Pork", slug: "pork", color: "bg-pink-500" },
+]
+
+export function ProduceCategoriesView() {
+  return (
+    <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+      {produceCategories.map((produce) => (
+        <div
+          key={produce.slug}
+          className="group rounded-xl border bg-card shadow-sm hover:shadow-md hover:border-primary/20 transition-all duration-200"
+        >
+          <div className="flex items-center justify-between px-4 pt-4 pb-2">
+            <div className="flex items-center gap-2">
+              <div className={`h-2.5 w-2.5 rounded-full ${produce.color}`} />
+              <h3 className="text-sm font-bold tracking-tight">{produce.name} Prices</h3>
+            </div>
+            <Link
+              href={`/prices/produce/${produce.slug}`}
+              className="inline-flex items-center gap-1 text-xs font-medium text-muted-foreground hover:text-primary transition-colors"
+            >
+              View all
+              <ArrowRight className="h-3 w-3 opacity-0 -translate-x-1 group-hover:opacity-100 group-hover:translate-x-0 transition-all" />
+            </Link>
+          </div>
+          <div className="px-3 pb-1">
+            <ProducePriceCardsView produceSlug={produce.slug} limit={3} />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/apps/client-fnp/components/structures/produce-filter.tsx
+++ b/apps/client-fnp/components/structures/produce-filter.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { useRouter, useSearchParams } from "next/navigation"
+import { Button } from "@/components/ui/button"
+
+interface ProduceFilterProps {
+  categories: { name: string; slug: string }[]
+  activeFilter: string
+}
+
+export function ProduceFilter({ categories, activeFilter }: ProduceFilterProps) {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  function handleFilter(slug: string) {
+    const params = new URLSearchParams(searchParams.toString())
+    if (slug === activeFilter) {
+      params.delete("filter")
+    } else {
+      params.set("filter", slug)
+    }
+    const qs = params.toString()
+    router.push(`/prices/produce${qs ? `?${qs}` : ""}`)
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Button
+        variant={!activeFilter ? "default" : "outline"}
+        size="sm"
+        onClick={() => {
+          router.push("/prices/produce")
+        }}
+      >
+        All
+      </Button>
+      {categories.map((cat) => (
+        <Button
+          key={cat.slug}
+          variant={activeFilter === cat.slug ? "default" : "outline"}
+          size="sm"
+          onClick={() => handleFilter(cat.slug)}
+        >
+          {cat.name}
+        </Button>
+      ))}
+    </div>
+  )
+}

--- a/apps/client-fnp/components/structures/produce-price-cards-view.tsx
+++ b/apps/client-fnp/components/structures/produce-price-cards-view.tsx
@@ -1,0 +1,275 @@
+"use client"
+
+import { Fragment, useState } from "react"
+import { useQuery } from "@tanstack/react-query"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { ChevronLeft, ChevronRight, Calendar, ArrowRight } from "lucide-react"
+import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
+import { queryPricesByProduce } from "@/lib/query"
+import { formatDate, capitalizeFirstLetter, centsToDollars } from "@/lib/utilities"
+
+function parsePriceData(priceData: any) {
+  if (!priceData || !Array.isArray(priceData) || priceData.length === 0) return null
+  const grade = priceData[0]
+  if (!grade?.Value || !Array.isArray(grade.Value)) return null
+  const code = grade.Value.find((v: any) => v.Key === "code")?.Value
+  const pricingArr = grade.Value.find((v: any) => v.Key === "pricing")?.Value
+  let delivered = 0
+  let collected = 0
+  if (Array.isArray(pricingArr)) {
+    delivered = pricingArr.find((v: any) => v.Key === "delivered")?.Value || 0
+    collected = pricingArr.find((v: any) => v.Key === "collected")?.Value || 0
+  }
+  return { code, delivered, collected }
+}
+
+function priceDetailHref(relation: any) {
+  const nameSlug = relation.client_name.toLowerCase().replace(/\s+/g, '-')
+  const dateSlug = new Date(relation.effective_date).toISOString().split('T')[0]
+  const produce = relation.produce_category?.toLowerCase() || ''
+  return `/prices/${nameSlug}-${dateSlug}/${produce}`
+}
+
+interface ProducePriceCardsViewProps {
+  produceSlug: string
+  limit?: number
+  viewAllHref?: string
+}
+
+export function ProducePriceCardsView({ produceSlug, limit, viewAllHref }: ProducePriceCardsViewProps) {
+  const [currentPage, setCurrentPage] = useState(1)
+
+  const { isError, isLoading, data } = useQuery({
+    queryKey: ["prices-by-produce", produceSlug, currentPage, limit],
+    queryFn: () => queryPricesByProduce(produceSlug, { p: currentPage, ...(limit ? { limit } : {}) }),
+    refetchOnWindowFocus: false,
+  })
+
+  const priceRelations = data?.data?.data || []
+  const total = data?.data?.total || 0
+  const totalPages = Math.ceil(total / (limit || 20))
+
+  if (isError) {
+    return (
+      <div className="text-center py-4 px-4">
+        <p className="text-sm font-medium mb-1">Error loading prices</p>
+        <p className="text-xs text-muted-foreground">Please try refreshing the page</p>
+      </div>
+    )
+  }
+
+  if (isLoading) {
+    if (limit) {
+      return (
+        <div className="divide-y">
+          {[...Array(limit)].map((_, i) => (
+            <div key={i} className="py-3 px-1">
+              <div className="h-[52px] bg-muted/20 rounded-lg animate-pulse" />
+            </div>
+          ))}
+        </div>
+      )
+    }
+    return (
+      <div className="space-y-4">
+        <div className="h-5 w-32 bg-muted/20 rounded animate-pulse" />
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {[...Array(9)].map((_, i) => (
+            <div key={i} className="rounded-xl border bg-card shadow-sm p-4 space-y-3">
+              <div className="h-4 w-3/4 bg-muted/20 rounded animate-pulse" />
+              <div className="h-3 w-1/2 bg-muted/20 rounded animate-pulse" />
+              <div className="border-t pt-3 space-y-2">
+                <div className="h-3 bg-muted/20 rounded animate-pulse" />
+                <div className="h-3 w-2/3 bg-muted/20 rounded animate-pulse" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (priceRelations.length === 0) {
+    return (
+      <div className="text-center py-4 px-4">
+        <p className="text-sm font-medium mb-1">No prices found for {capitalizeFirstLetter(produceSlug)}</p>
+        <p className="text-xs text-muted-foreground">Check back later for updated prices</p>
+      </div>
+    )
+  }
+
+  // Preview mode — compact divider list, deduplicated by effective date
+  if (limit) {
+    const uniqueRelations = priceRelations.filter((relation: any, index: number, arr: any[]) =>
+      arr.findIndex((r: any) => r.effective_date === relation.effective_date && r.client_name === relation.client_name) === index
+    )
+
+    return (
+      <div>
+        <div className="divide-y">
+          {uniqueRelations.slice(0, limit).map((relation: any) => (
+            <Link
+              key={relation.id}
+              href={priceDetailHref(relation)}
+              className="flex items-center justify-between gap-3 py-3 px-1 hover:bg-muted/30 transition-colors group"
+            >
+              <div className="min-w-0 flex-1">
+                <h3 className="text-sm font-semibold text-foreground truncate group-hover:text-primary transition-colors">
+                  {capitalizeFirstLetter(relation.client_name)}
+                </h3>
+                <div className="flex items-center gap-1.5 mt-0.5 text-xs text-muted-foreground">
+                  <Calendar className="h-3 w-3 shrink-0" />
+                  <span>{formatDate(relation.effective_date)}</span>
+                  {(() => {
+                    const pd = parsePriceData(relation.price_data)
+                    if (!pd) return null
+                    return (
+                      <>
+                        {pd.code && (
+                          <>
+                            <span className="text-border">|</span>
+                            <span>{pd.code}</span>
+                          </>
+                        )}
+                        {pd.delivered > 0 && (
+                          <>
+                            <span className="text-border">|</span>
+                            <span className="font-medium text-foreground">{centsToDollars(pd.delivered)}{relation.unit ? ` per ${relation.unit}` : ''}</span>
+                          </>
+                        )}
+                      </>
+                    )
+                  })()}
+                </div>
+              </div>
+              <ArrowRight className="h-4 w-4 text-muted-foreground opacity-0 group-hover:opacity-100 group-hover:translate-x-0.5 transition-all shrink-0" />
+            </Link>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  // Full paginated mode — 3-column card grid
+  return (
+    <div className="space-y-6">
+      <p className="text-sm text-muted-foreground">
+        {total} {capitalizeFirstLetter(produceSlug)} Price{total !== 1 ? "s" : ""}
+      </p>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {priceRelations.map((relation: any, index: number) => {
+          const pd = parsePriceData(relation.price_data)
+          return (
+            <Fragment key={relation.id}>
+              {index > 0 && index % 9 === 0 && <AdSenseInFeed />}
+              <Link
+                href={priceDetailHref(relation)}
+                className="group rounded-xl border bg-card shadow-sm hover:shadow-md hover:border-primary/20 transition-all duration-200 p-4 flex flex-col"
+              >
+                <div className="flex items-start justify-between gap-2 mb-3">
+                  <h3 className="text-sm font-bold text-foreground group-hover:text-primary transition-colors leading-tight">
+                    {capitalizeFirstLetter(relation.client_name)}
+                  </h3>
+                  {pd?.code && (
+                    <span className="shrink-0 text-[10px] font-mono text-muted-foreground bg-muted px-1.5 py-0.5 rounded">
+                      {pd.code}
+                    </span>
+                  )}
+                </div>
+
+                <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-3">
+                  <Calendar className="h-3 w-3 shrink-0" />
+                  <span>{formatDate(relation.effective_date)}</span>
+                </div>
+
+                {pd && (pd.delivered > 0 || pd.collected > 0) && (
+                  <div className="mt-auto space-y-1.5 border-t pt-3">
+                    {pd.delivered > 0 && (
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs text-muted-foreground">Delivered</span>
+                        <span className="text-sm font-semibold tabular-nums">{centsToDollars(pd.delivered)}{relation.unit ? <span className="text-xs font-normal text-muted-foreground">/{relation.unit}</span> : null}</span>
+                      </div>
+                    )}
+                    {pd.collected > 0 && (
+                      <div className="flex items-center justify-between">
+                        <span className="text-xs text-muted-foreground">Collected</span>
+                        <span className="text-sm tabular-nums text-muted-foreground">{centsToDollars(pd.collected)}{relation.unit ? <span className="text-xs font-normal">/{relation.unit}</span> : null}</span>
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                <div className="flex items-center gap-1 mt-3 text-xs font-medium text-primary opacity-0 group-hover:opacity-100 transition-opacity">
+                  View details
+                  <ArrowRight className="h-3 w-3" />
+                </div>
+              </Link>
+            </Fragment>
+          )
+        })}
+      </div>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between pt-4 border-t">
+          <p className="text-xs text-muted-foreground">
+            Page {currentPage} of {totalPages}
+          </p>
+          <div className="flex items-center gap-1">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setCurrentPage(p => Math.max(1, p - 1))
+                window.scrollTo({ top: 0, behavior: "smooth" })
+              }}
+              disabled={currentPage === 1}
+              className="h-8 w-8 p-0"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
+              let pageNumber: number
+              if (totalPages <= 5) {
+                pageNumber = i + 1
+              } else if (currentPage <= 3) {
+                pageNumber = i + 1
+              } else if (currentPage >= totalPages - 2) {
+                pageNumber = totalPages - 4 + i
+              } else {
+                pageNumber = currentPage - 2 + i
+              }
+              return (
+                <Button
+                  key={pageNumber}
+                  variant={currentPage === pageNumber ? "default" : "ghost"}
+                  size="sm"
+                  onClick={() => {
+                    setCurrentPage(pageNumber)
+                    window.scrollTo({ top: 0, behavior: "smooth" })
+                  }}
+                  className="h-8 w-8 p-0 text-xs"
+                >
+                  {pageNumber}
+                </Button>
+              )
+            })}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setCurrentPage(p => Math.min(totalPages, p + 1))
+                window.scrollTo({ top: 0, behavior: "smooth" })
+              }}
+              disabled={currentPage === totalPages}
+              className="h-8 w-8 p-0"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/client-fnp/components/structures/related-cdm-prices-sidebar.tsx
+++ b/apps/client-fnp/components/structures/related-cdm-prices-sidebar.tsx
@@ -42,7 +42,7 @@ export function RelatedCdmPricesSidebar({ currentClientName, currentPriceId, all
           <div className="space-y-3">
             {sameClientPrices.map((price) => (
               <Link key={price.id} href={`/prices/cdm/${getCdmSlug(price)}`} className="block">
-                <div className="rounded-lg border bg-card p-3 hover:bg-muted/50 transition-colors">
+                <div className="rounded-xl border bg-card p-3 shadow-sm hover:shadow-md hover:border-primary/20 transition-all duration-200">
                   <div className="flex items-center gap-2 text-xs text-muted-foreground">
                     <Calendar className="h-3 w-3" />
                     <span>{formatDate(price.effectiveDate)}</span>
@@ -62,7 +62,7 @@ export function RelatedCdmPricesSidebar({ currentClientName, currentPriceId, all
           <div className="space-y-3">
             {otherClientPrices.map((price) => (
               <Link key={price.id} href={`/prices/cdm/${getCdmSlug(price)}`} className="block">
-                <div className="rounded-lg border bg-card p-3 hover:bg-muted/50 transition-colors">
+                <div className="rounded-xl border bg-card p-3 shadow-sm hover:shadow-md hover:border-primary/20 transition-all duration-200">
                   <p className="text-sm font-medium text-foreground mb-1">
                     {capitalizeFirstLetter(price.client_name)}
                   </p>

--- a/apps/client-fnp/lib/query.ts
+++ b/apps/client-fnp/lib/query.ts
@@ -160,8 +160,16 @@ export function queryPriceFilterAggregates() {
   return api.get(url)
 }
 
-export function queryPricesByProduce(produceSlug: string) {
-  const url = `${BaseURL}/prices/produce/${produceSlug}`
+export function queryPricesByProduce(produceSlug: string, pagination?: PaginationModel) {
+  const params = new URLSearchParams()
+  if (pagination?.p !== undefined && pagination.p >= 2) {
+    params.set("p", String(pagination.p))
+  }
+  if (pagination?.limit) {
+    params.set("limit", String(pagination.limit))
+  }
+  const qs = params.toString()
+  const url = `${BaseURL}/prices/produce/${produceSlug}${qs ? `?${qs}` : ""}`
   return api.get(url)
 }
 
@@ -323,8 +331,13 @@ export function querySprayProgramBySlug(slug: string) {
 }
 
 // Animal Health
-export function queryAnimalHealthCategories() {
-  const url = `${BaseURL}/animalhealthcategories/`
+export function queryAnimalHealthCategories(usedOn?: string) {
+  const params = new URLSearchParams()
+  if (usedOn) {
+    params.set('used_on', usedOn)
+  }
+  const qs = params.toString()
+  const url = `${BaseURL}/animalhealthcategories/${qs ? `?${qs}` : ''}`
   return api.get(url)
 }
 
@@ -354,7 +367,7 @@ export function queryAllAnimalHealthProducts(pagination?: PaginationModel & { br
   return api.get(url)
 }
 
-export function queryAnimalHealthProductsByCategory(options: { category: string } & PaginationModel & { brand?: string[], target?: string[], active_ingredient?: string[] }) {
+export function queryAnimalHealthProductsByCategory(options: { category: string } & PaginationModel & { brand?: string[], target?: string[], active_ingredient?: string[], used_on?: string[] }) {
   const params = new URLSearchParams()
 
   if (options.p !== undefined && options.p >= 2) {
@@ -369,6 +382,9 @@ export function queryAnimalHealthProductsByCategory(options: { category: string 
   }
   if (options.active_ingredient && options.active_ingredient.length > 0) {
     options.active_ingredient.forEach(ai => params.append('active_ingredient', ai))
+  }
+  if (options.used_on && options.used_on.length > 0) {
+    options.used_on.forEach(u => params.append('used_on', u))
   }
 
   const queryString = params.toString()

--- a/apps/client-fnp/next.config.js
+++ b/apps/client-fnp/next.config.js
@@ -3,6 +3,7 @@ const nextConfig = {
   /* config options here */
   output: "standalone",
   images: {
+    dangerouslyAllowLocalIP: true,
     remotePatterns: [
       {
         protocol: 'https',

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- Personalize logged-in dashboard with user produce badges, matched feeding programs, animal health categories, and other animal resource links
- Add ProductResources cross-sell component across agrochemical, animal health, feed, and spray program pages
- Add produce-based price browsing pages and produce filter/categories components
- Refactor feeding programs and spray programs pages with improved filtering and grid layouts
- Add AdSense integration to root layout
- Clean up agrochemical guides landing and buyer detail pages

## Test Plan
- [ ] Login as different users and verify dashboard shows correct produce, category, feeding programs
- [ ] Verify ProductResources component appears on product detail pages
- [ ] Test produce price browsing at /prices/produce
- [ ] Verify spray programs and feeding programs filtering works
- [ ] Check AdSense script loads correctly