### PR TITLE
Add empty states and remove related markets

### DIFF
--- a/apps/client-fnp/app/(landing)/buyers/[product]/page.tsx
+++ b/apps/client-fnp/app/(landing)/buyers/[product]/page.tsx
@@ -7,7 +7,6 @@ import { ClientFilterSidebar } from "@/components/generic/clientFilterSidebar"
 import { ActionsSidebar } from "@/components/generic/actions-sidebar"
 import { CrossSellBanner } from "@/components/monetization/cross-sell-banner"
 import { ProductResources } from "@/components/monetization/product-resources"
-import { RelatedMarkets } from "@/components/monetization/related-markets"
 
 
 type Props = {
@@ -95,7 +94,6 @@ export default async function BuyersProductPage({ params }: BuyerProductPageProp
           </div>
         </div>
 
-        <RelatedMarkets currentProduct={product} context="buyer" />
       </div>
     </main>
   )

--- a/apps/client-fnp/app/(landing)/farmers/[product]/page.tsx
+++ b/apps/client-fnp/app/(landing)/farmers/[product]/page.tsx
@@ -7,7 +7,6 @@ import { ClientFilterSidebar } from "@/components/generic/clientFilterSidebar"
 import { ActionsSidebar } from "@/components/generic/actions-sidebar"
 import { CrossSellBanner } from "@/components/monetization/cross-sell-banner"
 import { ProductResources } from "@/components/monetization/product-resources"
-import { RelatedMarkets } from "@/components/monetization/related-markets"
 
 
 type Props = {
@@ -95,7 +94,6 @@ export default async function FarmersProductPage({ params }: FarmerProductPagePr
           </div>
         </div>
 
-        <RelatedMarkets currentProduct={product} context="farmer" />
       </div>
     </main>
   )

--- a/apps/client-fnp/app/(landing)/prices/page.tsx
+++ b/apps/client-fnp/app/(landing)/prices/page.tsx
@@ -24,27 +24,27 @@ export default async function PricesPage() {
     <main>
       {/* Hero */}
       <section className="border-b">
-        <div className="mx-auto max-w-7xl px-6 lg:px-8 pt-10 pb-8">
+        <div className="mx-auto max-w-7xl px-6 lg:px-8 pt-12 pb-10">
           <p className="text-xs font-semibold text-primary tracking-wide uppercase">Market Intelligence</p>
-          <h1 className="mt-1 text-3xl font-bold font-heading tracking-tight">
+          <h1 className="mt-1 text-4xl font-bold font-heading tracking-tight">
             Market Prices
           </h1>
-          <p className="mt-2 text-sm text-muted-foreground">
+          <p className="mt-3 text-base text-muted-foreground max-w-2xl">
             Transparent pricing from verified buyers across Zimbabwe.
           </p>
         </div>
       </section>
 
       {/* Prices by Produce */}
-      <section className="mx-auto max-w-7xl px-6 lg:px-8 py-8">
-        <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-4">Prices by produce</h2>
+      <section className="mx-auto max-w-7xl px-6 lg:px-8 py-10">
+        <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-6">Prices by produce</h2>
         <ProduceCategoriesView />
       </section>
 
       {/* Price List Categories */}
       <section className="border-t">
-        <div className="mx-auto max-w-7xl px-6 lg:px-8 py-8">
-          <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-4">Price lists by type</h2>
+        <div className="mx-auto max-w-7xl px-6 lg:px-8 py-10">
+          <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-6">Price lists by type</h2>
           <div className="grid md:grid-cols-2 gap-4">
             <div className="group rounded-xl border bg-card shadow-sm hover:shadow-md hover:border-primary/20 transition-all duration-200">
               <div className="flex items-center justify-between px-4 pt-4 pb-2">
@@ -87,11 +87,18 @@ export default async function PricesPage() {
 
       {/* SEO Content */}
       <section className="border-t">
-        <div className="mx-auto max-w-7xl px-6 lg:px-8 py-8">
-          <h2 className="text-base font-bold font-heading mb-2">About Agricultural Pricing in Zimbabwe</h2>
-          <p className="text-xs text-muted-foreground">
-            Transparent market prices from verified buyers across Zimbabwe.
-          </p>
+        <div className="mx-auto max-w-7xl px-6 lg:px-8 py-10">
+          <h2 className="text-base font-bold font-heading mb-3">About Agricultural Pricing in Zimbabwe</h2>
+          <div className="space-y-2 text-sm text-muted-foreground max-w-3xl">
+            <p>
+              Compare current agricultural prices from verified buyers across Zimbabwe. Prices are updated weekly and cover liveweight cattle, cold dress mass, beef, lamb, mutton, goat, chicken, and pork.
+            </p>
+            <ul className="list-disc list-inside space-y-1">
+              <li>Side-by-side price comparison from multiple buyers</li>
+              <li>Delivered and collected pricing for each grade</li>
+              <li>Liveweight and cold dress mass price lists</li>
+            </ul>
+          </div>
         </div>
       </section>
     </main>

--- a/apps/client-fnp/components/layouts/buyers.tsx
+++ b/apps/client-fnp/components/layouts/buyers.tsx
@@ -4,7 +4,7 @@ import {useCallback} from "react"
 import {usePathname, useRouter, useSearchParams} from "next/navigation"
 import {useQuery} from "@tanstack/react-query"
 import Link from "next/link"
-import {Search} from "lucide-react"
+import {Search, Users} from "lucide-react"
 
 import {Pagination} from "@/components/generic/pagination"
 import {Icons} from "@/components/icons/lucide"
@@ -75,6 +75,24 @@ export function Buyers({user, queryBy}: BuyersPageProps) {
     return null
   }
 
+  if (buyers.length === 0) {
+    const produceName = queryBy ? capitalizeFirstLetter(plural(queryBy)) : "Produce"
+    return (
+      <section className="mt-[21px]">
+        <div className="flex flex-col items-center justify-center py-16 px-6 text-center border rounded-lg bg-muted/30">
+          <Users className="h-12 w-12 text-muted-foreground/40 mb-4" />
+          <h3 className="text-lg font-semibold mb-1">No {produceName} Buyers Yet</h3>
+          <p className="text-sm text-muted-foreground max-w-md">
+            There are currently no registered {queryBy ? plural(queryBy) : ""} buyers on the platform.
+            Check back soon as new buyers join regularly.
+          </p>
+          <Link href="/buyers" className="mt-4 text-sm text-primary hover:underline">
+            Browse all buyers
+          </Link>
+        </div>
+      </section>
+    )
+  }
 
   return (
     <section className="space-y-8 mt-[21px]">

--- a/apps/client-fnp/components/layouts/farmers.tsx
+++ b/apps/client-fnp/components/layouts/farmers.tsx
@@ -4,7 +4,7 @@ import {useCallback} from "react"
 import {usePathname, useRouter, useSearchParams} from "next/navigation"
 import {useQuery} from "@tanstack/react-query"
 import Link from "next/link"
-import {Search} from "lucide-react"
+import {Search, Users} from "lucide-react"
 
 import {Pagination} from "@/components/generic/pagination"
 import {Icons} from "@/components/icons/lucide"
@@ -73,6 +73,24 @@ export function Farmers({user, queryBy}: FarmersPageProps) {
     return null
   }
 
+  if (farmers.length === 0) {
+    const produceName = queryBy ? capitalizeFirstLetter(plural(queryBy)) : "Produce"
+    return (
+      <section className="mt-[21px]">
+        <div className="flex flex-col items-center justify-center py-16 px-6 text-center border rounded-lg bg-muted/30">
+          <Users className="h-12 w-12 text-muted-foreground/40 mb-4" />
+          <h3 className="text-lg font-semibold mb-1">No {produceName} Farmers Yet</h3>
+          <p className="text-sm text-muted-foreground max-w-md">
+            There are currently no registered {queryBy ? plural(queryBy) : ""} farmers on the platform.
+            Check back soon as new farmers join regularly.
+          </p>
+          <Link href="/farmers" className="mt-4 text-sm text-primary hover:underline">
+            Browse all farmers
+          </Link>
+        </div>
+      </section>
+    )
+  }
 
   return (
     <section className="space-y-8 mt-[21px]">

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- Add empty state UI for buyers/farmers pages when no results found for a product
- Remove RelatedMarkets component from buyers/farmers product pages
- Improve prices page spacing, typography, and SEO content

## Test Plan
- [ ] Visit /buyers/chilli - should show empty state
- [ ] Visit /farmers/chilli - should show empty state
- [ ] Visit /prices - verify improved layout