### PR TITLE
Disable paywall on production

### DIFF
--- a/apps/client-fnp/.env.production
+++ b/apps/client-fnp/.env.production
@@ -1,6 +1,7 @@
 NEXT_PUBLIC_APP_URL=https://farmnport.com
 NEXT_PUBLIC_BASE_URL=https://farmnport.com
 NEXT_PUBLIC_GTM_ID=GTM-TS7XJ4J
+NEXT_PUBLIC_ENABLE_PAYWALL=false
 NEXT_TELEMETRY_DEBUG=0
 NEXTAUTH_URL=https://farmnport.com
 NEXT_ENV=production


### PR DESCRIPTION
## Summary
- Set `NEXT_PUBLIC_ENABLE_PAYWALL=false` in `.env.production`
- Buyer contacts visible to all users without subscription
- Pricing and subscription pages redirect to `/buyers`