### PR TITLE
Add menu catalog with multi-location, category notes, and sizes UI

### DIFF
--- a/apps/admin-fnp/app/dashboard/restaurants/menu-item-categories/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-item-categories/[slug]/edit/page.tsx
@@ -1,0 +1,173 @@
+"use client"
+
+import { useEffect } from "react"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useMutation, useQuery } from "@tanstack/react-query"
+import { useForm } from "react-hook-form"
+import { useRouter, useParams } from "next/navigation"
+
+import { queryMenuItemCategory, updateMenuItemCategory } from "@/lib/query"
+import { MenuItemCategory } from "@/lib/schemas"
+import { Icons } from "@/components/icons/lucide"
+import { toast } from "@/components/ui/use-toast"
+import { handleApiError } from "@/lib/error-handler"
+import { Placeholder } from "@/components/state/placeholder"
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+
+import * as z from "zod"
+
+const EditFormSchema = z.object({
+    name: z.string().min(1, "Name is required").max(120),
+})
+
+type EditFormModel = z.infer<typeof EditFormSchema>
+
+export default function EditMenuItemCategoryPage() {
+    const router = useRouter()
+    const params = useParams()
+    const categoryId = params.slug as string
+
+    const { data, isLoading, isError } = useQuery({
+        queryKey: ["menu-item-category", categoryId],
+        queryFn: () => queryMenuItemCategory(categoryId),
+        refetchOnWindowFocus: false,
+    })
+
+    const category = data?.data as MenuItemCategory
+
+    const form = useForm<EditFormModel>({
+        defaultValues: {
+            name: "",
+        },
+        resolver: zodResolver(EditFormSchema),
+    })
+
+    useEffect(() => {
+        if (category) {
+            form.reset({
+                name: category.name || "",
+            })
+        }
+    }, [category, form])
+
+    const { mutate, isPending } = useMutation({
+        mutationFn: updateMenuItemCategory,
+        onSuccess: () => {
+            toast({
+                description: "Category updated successfully",
+            })
+            router.push("/dashboard/restaurants/menu-item-categories")
+        },
+        onError: (error) => {
+            handleApiError(error, {
+                context: "category update"
+            })
+        },
+    })
+
+    async function onSubmit(data: EditFormModel) {
+        mutate({
+            id: categoryId,
+            ...data,
+        })
+    }
+
+    if (isLoading) {
+        return (
+            <Placeholder>
+                <Placeholder.Title>Loading Category</Placeholder.Title>
+            </Placeholder>
+        )
+    }
+
+    if (isError) {
+        return (
+            <Placeholder>
+                <Placeholder.Icon name="close" />
+                <Placeholder.Title>Error Loading Category</Placeholder.Title>
+            </Placeholder>
+        )
+    }
+
+    return (
+        <div className="space-y-10">
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+                        Edit Category
+                    </h1>
+                    <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                        Update menu item category details.
+                    </p>
+                </div>
+            </div>
+
+            <Form {...form}>
+                <form onSubmit={form.handleSubmit(onSubmit)}>
+                    <div className="space-y-12">
+                        <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
+                            <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                                Category Information
+                            </h2>
+
+                            <div className="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+                                <div className="sm:col-span-4 px-1">
+                                    <label
+                                        htmlFor="name"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Category Name
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="name"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Input
+                                                            id="name"
+                                                            placeholder="Enter category name"
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="mt-6 flex items-center justify-end gap-x-6">
+                        <button
+                            type="button"
+                            onClick={() => router.push("/dashboard/restaurants/menu-item-categories")}
+                            className="text-sm/6 font-semibold text-gray-900 dark:text-white"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={isPending}
+                            className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
+                        >
+                            {isPending && <Icons.spinner className="w-4 h-4 mr-2 animate-spin" />}
+                            Update
+                        </button>
+                    </div>
+                </form>
+            </Form>
+        </div>
+    )
+}

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-item-categories/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-item-categories/[slug]/edit/page.tsx
@@ -145,6 +145,7 @@ export default function EditMenuItemCategoryPage() {
                                         />
                                     </div>
                                 </div>
+
                             </div>
                         </div>
                     </div>

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-item-categories/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-item-categories/new/page.tsx
@@ -110,6 +110,7 @@ export default function NewMenuItemCategoryPage() {
                                         />
                                     </div>
                                 </div>
+
                             </div>
                         </div>
                     </div>

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-item-categories/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-item-categories/new/page.tsx
@@ -1,0 +1,138 @@
+"use client"
+
+import Link from "next/link"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useMutation } from "@tanstack/react-query"
+import { useForm } from "react-hook-form"
+import { useRouter } from "next/navigation"
+
+import { addMenuItemCategory } from "@/lib/query"
+import { FormMenuItemCategorySchema, FormMenuItemCategoryModel } from "@/lib/schemas"
+import { cn } from "@/lib/utilities"
+import { buttonVariants } from "@/components/ui/button"
+import { Icons } from "@/components/icons/lucide"
+import { toast } from "@/components/ui/use-toast"
+import { handleApiError } from "@/lib/error-handler"
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+
+export default function NewMenuItemCategoryPage() {
+    const router = useRouter()
+
+    const form = useForm<FormMenuItemCategoryModel>({
+        defaultValues: {
+            name: "",
+        },
+        resolver: zodResolver(FormMenuItemCategorySchema),
+    })
+
+    const { mutate, isPending } = useMutation({
+        mutationFn: addMenuItemCategory,
+        onSuccess: () => {
+            toast({
+                description: "Category added successfully",
+            })
+            router.push("/dashboard/restaurants/menu-item-categories")
+        },
+        onError: (error) => {
+            handleApiError(error, {
+                context: "category creation"
+            })
+        },
+    })
+
+    async function onSubmit(data: FormMenuItemCategoryModel) {
+        mutate(data)
+    }
+
+    return (
+        <div className="space-y-10">
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+                        Add Menu Item Category
+                    </h1>
+                    <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                        Create a new menu item category.
+                    </p>
+                </div>
+                <Link
+                    href="/dashboard/restaurants/menu-item-categories"
+                    className={cn(buttonVariants({ variant: "ghost" }))}
+                >
+                    <Icons.close className="w-4 h-4 mr-2" />
+                    Close
+                </Link>
+            </div>
+
+            <Form {...form}>
+                <form onSubmit={form.handleSubmit(onSubmit)}>
+                    <div className="space-y-12">
+                        <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
+                            <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                                Category Information
+                            </h2>
+                            <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                                e.g. Starters, Mains, Desserts, Drinks, Sides
+                            </p>
+
+                            <div className="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+                                <div className="sm:col-span-4 px-1">
+                                    <label
+                                        htmlFor="name"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Category Name
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="name"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Input
+                                                            id="name"
+                                                            placeholder="Enter category name"
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="mt-6 flex items-center justify-end gap-x-6">
+                        <button
+                            type="button"
+                            onClick={() => router.push("/dashboard/restaurants/menu-item-categories")}
+                            className="text-sm/6 font-semibold text-gray-900 dark:text-white"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={isPending}
+                            className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
+                        >
+                            {isPending && <Icons.spinner className="w-4 h-4 mr-2 animate-spin" />}
+                            Save
+                        </button>
+                    </div>
+                </form>
+            </Form>
+        </div>
+    )
+}

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-item-categories/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-item-categories/page.tsx
@@ -1,0 +1,15 @@
+import { DashboardHeader } from "@/components/state/dashboardHeader"
+import { DashboardShell } from "@/components/state/dashboardShell"
+import { MenuItemCategoriesTable } from "@/components/structures/tables/menu-item-categories"
+
+export default async function MenuItemCategoriesPage() {
+  return (
+    <DashboardShell>
+      <DashboardHeader
+        heading="Menu Item Categories"
+        text="Manage menu item categories."
+      ></DashboardHeader>
+      <MenuItemCategoriesTable />
+    </DashboardShell>
+  )
+}

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-item-components/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-item-components/[slug]/edit/page.tsx
@@ -1,0 +1,224 @@
+"use client"
+
+import { useEffect } from "react"
+import Link from "next/link"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useMutation, useQuery } from "@tanstack/react-query"
+import { useForm } from "react-hook-form"
+import { useRouter, useParams } from "next/navigation"
+
+import { queryMenuItemComponent, updateMenuItemComponent } from "@/lib/query"
+import { MenuItemComponent } from "@/lib/schemas"
+import { cn } from "@/lib/utilities"
+import { buttonVariants } from "@/components/ui/button"
+import { Icons } from "@/components/icons/lucide"
+import { toast } from "@/components/ui/use-toast"
+import { handleApiError } from "@/lib/error-handler"
+import { Placeholder } from "@/components/state/placeholder"
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select"
+
+import * as z from "zod"
+
+const EditFormSchema = z.object({
+    name: z.string().min(1, "Name is required").max(120),
+    status: z.enum(["active", "inactive"]),
+})
+
+type EditFormModel = z.infer<typeof EditFormSchema>
+
+export default function EditMenuItemComponentPage() {
+    const router = useRouter()
+    const params = useParams()
+    const componentId = params.slug as string
+
+    const { data, isLoading, isError } = useQuery({
+        queryKey: ["menu-item-component", componentId],
+        queryFn: () => queryMenuItemComponent(componentId),
+        refetchOnWindowFocus: false,
+    })
+
+    const component = data?.data as MenuItemComponent
+
+    const form = useForm<EditFormModel>({
+        defaultValues: {
+            name: "",
+            status: "active",
+        },
+        resolver: zodResolver(EditFormSchema),
+    })
+
+    useEffect(() => {
+        if (component) {
+            form.reset({
+                name: component.name || "",
+                status: (component.status as "active" | "inactive") || "active",
+            })
+        }
+    }, [component, form])
+
+    const { mutate, isPending } = useMutation({
+        mutationFn: updateMenuItemComponent,
+        onSuccess: () => {
+            toast({
+                description: "Component updated successfully",
+            })
+            router.push("/dashboard/restaurants/menu-item-components")
+        },
+        onError: (error) => {
+            handleApiError(error, {
+                context: "component update"
+            })
+        },
+    })
+
+    async function onSubmit(data: EditFormModel) {
+        mutate({
+            id: componentId,
+            ...data,
+        })
+    }
+
+    if (isLoading) {
+        return (
+            <Placeholder>
+                <Placeholder.Title>Loading Component</Placeholder.Title>
+            </Placeholder>
+        )
+    }
+
+    if (isError) {
+        return (
+            <Placeholder>
+                <Placeholder.Icon name="close" />
+                <Placeholder.Title>Error Loading Component</Placeholder.Title>
+            </Placeholder>
+        )
+    }
+
+    return (
+        <div className="space-y-10">
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+                        Edit Component
+                    </h1>
+                    <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                        Update menu item component details.
+                    </p>
+                </div>
+                <Link
+                    href="/dashboard/restaurants/menu-item-components"
+                    className={cn(buttonVariants({ variant: "ghost" }))}
+                >
+                    <Icons.close className="w-4 h-4 mr-2" />
+                    Close
+                </Link>
+            </div>
+
+            <Form {...form}>
+                <form onSubmit={form.handleSubmit(onSubmit)}>
+                    <div className="space-y-12">
+                        <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
+                            <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                                Component Information
+                            </h2>
+
+                            <div className="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+                                <div className="sm:col-span-4 px-1">
+                                    <label
+                                        htmlFor="name"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Component Name
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="name"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Input
+                                                            id="name"
+                                                            placeholder="Enter component name"
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                </div>
+
+                                <div className="sm:col-span-4 px-1">
+                                    <label
+                                        htmlFor="status"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Status
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="status"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <Select onValueChange={field.onChange} value={field.value}>
+                                                        <FormControl>
+                                                            <SelectTrigger className="w-full">
+                                                                <SelectValue placeholder="Select status" />
+                                                            </SelectTrigger>
+                                                        </FormControl>
+                                                        <SelectContent>
+                                                            <SelectItem value="active">Active</SelectItem>
+                                                            <SelectItem value="inactive">Inactive</SelectItem>
+                                                        </SelectContent>
+                                                    </Select>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="mt-6 flex items-center justify-end gap-x-6">
+                        <button
+                            type="button"
+                            onClick={() => router.push("/dashboard/restaurants/menu-item-components")}
+                            className="text-sm/6 font-semibold text-gray-900 dark:text-white"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={isPending}
+                            className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
+                        >
+                            {isPending && <Icons.spinner className="w-4 h-4 mr-2 animate-spin" />}
+                            Update
+                        </button>
+                    </div>
+                </form>
+            </Form>
+        </div>
+    )
+}

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-item-components/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-item-components/[slug]/edit/page.tsx
@@ -23,19 +23,10 @@ import {
     FormMessage,
 } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
-import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from "@/components/ui/select"
-
 import * as z from "zod"
 
 const EditFormSchema = z.object({
     name: z.string().min(1, "Name is required").max(120),
-    status: z.enum(["active", "inactive"]),
 })
 
 type EditFormModel = z.infer<typeof EditFormSchema>
@@ -56,7 +47,6 @@ export default function EditMenuItemComponentPage() {
     const form = useForm<EditFormModel>({
         defaultValues: {
             name: "",
-            status: "active",
         },
         resolver: zodResolver(EditFormSchema),
     })
@@ -65,7 +55,6 @@ export default function EditMenuItemComponentPage() {
         if (component) {
             form.reset({
                 name: component.name || "",
-                status: (component.status as "active" | "inactive") || "active",
             })
         }
     }, [component, form])
@@ -166,36 +155,6 @@ export default function EditMenuItemComponentPage() {
                                     </div>
                                 </div>
 
-                                <div className="sm:col-span-4 px-1">
-                                    <label
-                                        htmlFor="status"
-                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
-                                    >
-                                        Status
-                                    </label>
-                                    <div className="mt-2">
-                                        <FormField
-                                            control={form.control}
-                                            name="status"
-                                            render={({ field }) => (
-                                                <FormItem>
-                                                    <Select onValueChange={field.onChange} value={field.value}>
-                                                        <FormControl>
-                                                            <SelectTrigger className="w-full">
-                                                                <SelectValue placeholder="Select status" />
-                                                            </SelectTrigger>
-                                                        </FormControl>
-                                                        <SelectContent>
-                                                            <SelectItem value="active">Active</SelectItem>
-                                                            <SelectItem value="inactive">Inactive</SelectItem>
-                                                        </SelectContent>
-                                                    </Select>
-                                                    <FormMessage />
-                                                </FormItem>
-                                            )}
-                                        />
-                                    </div>
-                                </div>
                             </div>
                         </div>
                     </div>

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-item-components/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-item-components/new/page.tsx
@@ -21,13 +21,6 @@ import {
     FormMessage,
 } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
-import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from "@/components/ui/select"
 
 export default function NewMenuItemComponentPage() {
     const router = useRouter()
@@ -35,7 +28,6 @@ export default function NewMenuItemComponentPage() {
     const form = useForm<FormMenuItemComponentModel>({
         defaultValues: {
             name: "",
-            status: "active",
         },
         resolver: zodResolver(FormMenuItemComponentSchema),
     })
@@ -119,36 +111,6 @@ export default function NewMenuItemComponentPage() {
                                     </div>
                                 </div>
 
-                                <div className="sm:col-span-4 px-1">
-                                    <label
-                                        htmlFor="status"
-                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
-                                    >
-                                        Status
-                                    </label>
-                                    <div className="mt-2">
-                                        <FormField
-                                            control={form.control}
-                                            name="status"
-                                            render={({ field }) => (
-                                                <FormItem>
-                                                    <Select onValueChange={field.onChange} defaultValue={field.value}>
-                                                        <FormControl>
-                                                            <SelectTrigger className="w-full">
-                                                                <SelectValue placeholder="Select status" />
-                                                            </SelectTrigger>
-                                                        </FormControl>
-                                                        <SelectContent>
-                                                            <SelectItem value="active">Active</SelectItem>
-                                                            <SelectItem value="inactive">Inactive</SelectItem>
-                                                        </SelectContent>
-                                                    </Select>
-                                                    <FormMessage />
-                                                </FormItem>
-                                            )}
-                                        />
-                                    </div>
-                                </div>
                             </div>
                         </div>
                     </div>

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-item-components/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-item-components/new/page.tsx
@@ -1,0 +1,177 @@
+"use client"
+
+import Link from "next/link"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useMutation } from "@tanstack/react-query"
+import { useForm } from "react-hook-form"
+import { useRouter } from "next/navigation"
+
+import { addMenuItemComponent } from "@/lib/query"
+import { FormMenuItemComponentSchema, FormMenuItemComponentModel } from "@/lib/schemas"
+import { cn } from "@/lib/utilities"
+import { buttonVariants } from "@/components/ui/button"
+import { Icons } from "@/components/icons/lucide"
+import { toast } from "@/components/ui/use-toast"
+import { handleApiError } from "@/lib/error-handler"
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select"
+
+export default function NewMenuItemComponentPage() {
+    const router = useRouter()
+
+    const form = useForm<FormMenuItemComponentModel>({
+        defaultValues: {
+            name: "",
+            status: "active",
+        },
+        resolver: zodResolver(FormMenuItemComponentSchema),
+    })
+
+    const { mutate, isPending } = useMutation({
+        mutationFn: addMenuItemComponent,
+        onSuccess: () => {
+            toast({
+                description: "Component added successfully",
+            })
+            router.push("/dashboard/restaurants/menu-item-components")
+        },
+        onError: (error) => {
+            handleApiError(error, {
+                context: "component creation"
+            })
+        },
+    })
+
+    async function onSubmit(data: FormMenuItemComponentModel) {
+        mutate(data)
+    }
+
+    return (
+        <div className="space-y-10">
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+                        Add Menu Item Component
+                    </h1>
+                    <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                        Create a new component (building block of a dish).
+                    </p>
+                </div>
+                <Link
+                    href="/dashboard/restaurants/menu-item-components"
+                    className={cn(buttonVariants({ variant: "ghost" }))}
+                >
+                    <Icons.close className="w-4 h-4 mr-2" />
+                    Close
+                </Link>
+            </div>
+
+            <Form {...form}>
+                <form onSubmit={form.handleSubmit(onSubmit)}>
+                    <div className="space-y-12">
+                        <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
+                            <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                                Component Information
+                            </h2>
+                            <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                                e.g. Chips, Eggs, Steak, Rice, Sadza, Coleslaw
+                            </p>
+
+                            <div className="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+                                <div className="sm:col-span-4 px-1">
+                                    <label
+                                        htmlFor="name"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Component Name
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="name"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Input
+                                                            id="name"
+                                                            placeholder="Enter component name"
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                </div>
+
+                                <div className="sm:col-span-4 px-1">
+                                    <label
+                                        htmlFor="status"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Status
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="status"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <Select onValueChange={field.onChange} defaultValue={field.value}>
+                                                        <FormControl>
+                                                            <SelectTrigger className="w-full">
+                                                                <SelectValue placeholder="Select status" />
+                                                            </SelectTrigger>
+                                                        </FormControl>
+                                                        <SelectContent>
+                                                            <SelectItem value="active">Active</SelectItem>
+                                                            <SelectItem value="inactive">Inactive</SelectItem>
+                                                        </SelectContent>
+                                                    </Select>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="mt-6 flex items-center justify-end gap-x-6">
+                        <button
+                            type="button"
+                            onClick={() => router.push("/dashboard/restaurants/menu-item-components")}
+                            className="text-sm/6 font-semibold text-gray-900 dark:text-white"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={isPending}
+                            className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
+                        >
+                            {isPending && <Icons.spinner className="w-4 h-4 mr-2 animate-spin" />}
+                            Save
+                        </button>
+                    </div>
+                </form>
+            </Form>
+        </div>
+    )
+}

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-item-components/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-item-components/page.tsx
@@ -1,0 +1,15 @@
+import { DashboardHeader } from "@/components/state/dashboardHeader"
+import { DashboardShell } from "@/components/state/dashboardShell"
+import { MenuItemComponentsTable } from "@/components/structures/tables/menu-item-components"
+
+export default async function MenuItemComponentsPage() {
+  return (
+    <DashboardShell>
+      <DashboardHeader
+        heading="Menu Item Components"
+        text="Manage menu item components (building blocks of dishes)."
+      ></DashboardHeader>
+      <MenuItemComponentsTable />
+    </DashboardShell>
+  )
+}

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-items/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-items/[slug]/edit/page.tsx
@@ -1,0 +1,407 @@
+"use client"
+
+import { useState, useRef, useEffect } from "react"
+import Link from "next/link"
+import { useMutation, useQuery } from "@tanstack/react-query"
+import { useRouter, useParams } from "next/navigation"
+import { useDebounce } from "use-debounce"
+
+import { queryMenuItem, updateMenuItem, queryMenuItemCategories, queryMenuItemComponents } from "@/lib/query"
+import { MenuItem, MenuItemCategory, MenuItemComponent, CompositionEntry } from "@/lib/schemas"
+import { cn, dollarsToCents, centsToDollarsFormInputs } from "@/lib/utilities"
+import { buttonVariants } from "@/components/ui/button"
+import { Button } from "@/components/ui/button"
+import { Icons } from "@/components/icons/lucide"
+import { toast } from "@/components/ui/use-toast"
+import { handleApiError, handleFetchError } from "@/lib/error-handler"
+import { Placeholder } from "@/components/state/placeholder"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select"
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from "@/components/ui/popover"
+import {
+    Command,
+    CommandEmpty,
+    CommandInput,
+    CommandItem,
+    CommandList,
+} from "@/components/ui/command"
+
+export default function EditMenuItemPage() {
+    const router = useRouter()
+    const params = useParams()
+    const menuItemId = params.slug as string
+
+    const [name, setName] = useState("")
+    const [description, setDescription] = useState("")
+    const [priceCents, setPriceCents] = useState("")
+    const [categoryId, setCategoryId] = useState("")
+    const [status, setStatus] = useState("active")
+    const [selectedComponents, setSelectedComponents] = useState<CompositionEntry[]>([])
+    const [searchComponent, setSearchComponent] = useState("")
+    const [openComponents, setOpenComponents] = useState(false)
+    const [initialized, setInitialized] = useState(false)
+
+    const [debouncedComponentQuery] = useDebounce(searchComponent, 1000)
+
+    // Fetch the menu item
+    const { data: menuItemData, isLoading, isError } = useQuery({
+        queryKey: ["menu-item", menuItemId],
+        queryFn: () => queryMenuItem(menuItemId),
+        refetchOnWindowFocus: false,
+    })
+
+    const menuItem = menuItemData?.data as MenuItem
+
+    // Populate form when data loads
+    useEffect(() => {
+        if (menuItem && !initialized) {
+            setName(menuItem.name || "")
+            setDescription(menuItem.description || "")
+            setPriceCents(String(centsToDollarsFormInputs(menuItem.price_cents || 0)))
+            setCategoryId(menuItem.category_id || "")
+            setStatus(menuItem.status || "active")
+            setSelectedComponents(menuItem.composition || [])
+            setInitialized(true)
+        }
+    }, [menuItem, initialized])
+
+    // Fetch categories for dropdown
+    const { data: categoryData } = useQuery({
+        queryKey: ["menu-item-categories-all"],
+        queryFn: () => queryMenuItemCategories({ p: 1 }),
+        refetchOnWindowFocus: false,
+    })
+
+    const categories = categoryData?.data?.data as MenuItemCategory[]
+
+    // Search components for composition
+    const hasShownError = useRef(false)
+
+    const { data: componentData, isError: componentError, error: componentFetchError, refetch: componentRefetch } = useQuery({
+        queryKey: ["menu-item-components-search", { search: debouncedComponentQuery }],
+        queryFn: () => queryMenuItemComponents({ search: debouncedComponentQuery }),
+        enabled: debouncedComponentQuery.length >= 2,
+        refetchOnWindowFocus: false,
+    })
+
+    useEffect(() => {
+        if (componentError && !hasShownError.current) {
+            hasShownError.current = true
+            handleFetchError(componentFetchError, {
+                onRetry: () => {
+                    hasShownError.current = false
+                    componentRefetch()
+                },
+                context: "menu item components"
+            })
+        }
+        if (!componentError) {
+            hasShownError.current = false
+        }
+    }, [componentError, componentFetchError, componentRefetch])
+
+    const componentList = componentData?.data?.data as MenuItemComponent[]
+
+    const handleToggleComponent = (component: MenuItemComponent) => {
+        const exists = selectedComponents.find(c => c.component_id === component.id)
+        if (exists) {
+            setSelectedComponents(selectedComponents.filter(c => c.component_id !== component.id))
+        } else {
+            setSelectedComponents([...selectedComponents, { component_id: component.id, component_name: component.name }])
+        }
+    }
+
+    const { mutate, isPending } = useMutation({
+        mutationFn: updateMenuItem,
+        onSuccess: () => {
+            toast({
+                description: "Menu item updated successfully",
+            })
+            router.push("/dashboard/restaurants/menu-items")
+        },
+        onError: (error) => {
+            handleApiError(error, {
+                context: "menu item update"
+            })
+        },
+    })
+
+    function onSubmit(e: React.FormEvent) {
+        e.preventDefault()
+
+        if (!name.trim()) {
+            toast({ description: "Name is required", variant: "destructive" })
+            return
+        }
+
+        if (!categoryId) {
+            toast({ description: "Category is required", variant: "destructive" })
+            return
+        }
+
+        mutate({
+            id: menuItemId,
+            name: name.trim(),
+            description: description.trim(),
+            price_cents: dollarsToCents(parseFloat(priceCents || "0")),
+            category_id: categoryId,
+            composition: selectedComponents,
+            status,
+        })
+    }
+
+    if (isLoading) {
+        return (
+            <Placeholder>
+                <Placeholder.Title>Loading Menu Item</Placeholder.Title>
+            </Placeholder>
+        )
+    }
+
+    if (isError) {
+        return (
+            <Placeholder>
+                <Placeholder.Icon name="close" />
+                <Placeholder.Title>Error Loading Menu Item</Placeholder.Title>
+            </Placeholder>
+        )
+    }
+
+    return (
+        <div className="space-y-10">
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+                        Edit Menu Item
+                    </h1>
+                    <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                        Update menu item details.
+                    </p>
+                </div>
+                <Link
+                    href="/dashboard/restaurants/menu-items"
+                    className={cn(buttonVariants({ variant: "ghost" }))}
+                >
+                    <Icons.close className="w-4 h-4 mr-2" />
+                    Close
+                </Link>
+            </div>
+
+            <form onSubmit={onSubmit}>
+                <div className="space-y-12">
+                    <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
+                        <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                            Menu Item Information
+                        </h2>
+
+                        <div className="mt-10 space-y-8">
+                            <div className="px-1">
+                                <label
+                                    htmlFor="name"
+                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                >
+                                    Name
+                                </label>
+                                <div className="mt-2">
+                                    <Input
+                                        id="name"
+                                        placeholder="Enter menu item name"
+                                        value={name}
+                                        onChange={(e) => setName(e.target.value)}
+                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                    />
+                                </div>
+                            </div>
+
+                            <div className="px-1">
+                                <label
+                                    htmlFor="description"
+                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                >
+                                    Description
+                                </label>
+                                <div className="mt-2">
+                                    <Textarea
+                                        id="description"
+                                        placeholder="e.g. Sirloin steak grilled to your liking served with eggs and chips"
+                                        rows={3}
+                                        value={description}
+                                        onChange={(e) => setDescription(e.target.value)}
+                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                    />
+                                </div>
+                            </div>
+
+                            <div className="px-1">
+                                <label
+                                    htmlFor="price"
+                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                >
+                                    Price ($)
+                                </label>
+                                <div className="mt-2">
+                                    <Input
+                                        id="price"
+                                        type="number"
+                                        step="0.01"
+                                        min="0"
+                                        placeholder="e.g. 9.99"
+                                        value={priceCents}
+                                        onChange={(e) => setPriceCents(e.target.value)}
+                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                    />
+                                </div>
+                            </div>
+
+                            <div className="px-1">
+                                <label
+                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                >
+                                    Category
+                                </label>
+                                <div className="mt-2">
+                                    <Select onValueChange={setCategoryId} value={categoryId}>
+                                        <SelectTrigger className="w-full">
+                                            <SelectValue placeholder="Select a category" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {categories?.map((cat) => (
+                                                <SelectItem key={cat.id} value={cat.id}>
+                                                    {cat.name}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                            </div>
+
+                            <div className="px-1">
+                                <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                                    Composition
+                                </label>
+
+                                {selectedComponents.length > 0 && (
+                                    <div className="flex flex-wrap gap-2 mt-2 mb-3">
+                                        {selectedComponents.map(comp => (
+                                            <span
+                                                key={comp.component_id}
+                                                className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-sm bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-300 cursor-pointer hover:bg-blue-100 dark:hover:bg-blue-900/40"
+                                                onClick={() => setSelectedComponents(selectedComponents.filter(c => c.component_id !== comp.component_id))}
+                                            >
+                                                {comp.component_name}
+                                                <Icons.close className="w-3 h-3" />
+                                            </span>
+                                        ))}
+                                    </div>
+                                )}
+
+                                <Popover open={openComponents} onOpenChange={setOpenComponents}>
+                                    <PopoverTrigger asChild>
+                                        <Button
+                                            type="button"
+                                            variant="outline"
+                                            role="combobox"
+                                            aria-expanded={openComponents}
+                                            className="w-full justify-start text-left font-normal"
+                                        >
+                                            <Icons.search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+                                            Search and add components...
+                                        </Button>
+                                    </PopoverTrigger>
+                                    <PopoverContent className="w-full p-0" align="start">
+                                        <Command shouldFilter={false}>
+                                            <CommandInput
+                                                placeholder="Type component name (min 2 chars)..."
+                                                value={searchComponent}
+                                                onValueChange={setSearchComponent}
+                                            />
+                                            <CommandList>
+                                                <CommandEmpty>
+                                                    {debouncedComponentQuery.length < 2
+                                                        ? "Type at least 2 characters to search"
+                                                        : "No components found"
+                                                    }
+                                                </CommandEmpty>
+                                                {componentList?.map((comp) => {
+                                                    const isSelected = selectedComponents.some(c => c.component_id === comp.id)
+                                                    return (
+                                                        <CommandItem
+                                                            key={comp.id}
+                                                            value={comp.id}
+                                                            onSelect={() => handleToggleComponent(comp)}
+                                                        >
+                                                            <span className={cn(
+                                                                "mr-2 flex h-4 w-4 items-center justify-center rounded-sm border",
+                                                                isSelected
+                                                                    ? "bg-primary border-primary text-primary-foreground"
+                                                                    : "border-gray-300 dark:border-gray-600"
+                                                            )}>
+                                                                {isSelected && <Icons.check className="w-3 h-3" />}
+                                                            </span>
+                                                            {comp.name}
+                                                        </CommandItem>
+                                                    )
+                                                })}
+                                            </CommandList>
+                                        </Command>
+                                    </PopoverContent>
+                                </Popover>
+                                <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                    Select the components that make up this dish (e.g. Steak, Eggs, Chips).
+                                </p>
+                            </div>
+
+                            <div className="px-1">
+                                <label
+                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                >
+                                    Status
+                                </label>
+                                <div className="mt-2">
+                                    <Select onValueChange={setStatus} value={status}>
+                                        <SelectTrigger className="w-full">
+                                            <SelectValue placeholder="Select status" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value="active">Active</SelectItem>
+                                            <SelectItem value="inactive">Inactive</SelectItem>
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div className="mt-6 flex items-center justify-end gap-x-6">
+                    <button
+                        type="button"
+                        onClick={() => router.push("/dashboard/restaurants/menu-items")}
+                        className="text-sm/6 font-semibold text-gray-900 dark:text-white"
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        type="submit"
+                        disabled={isPending}
+                        className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
+                    >
+                        {isPending && <Icons.spinner className="w-4 h-4 mr-2 animate-spin" />}
+                        Update
+                    </button>
+                </div>
+            </form>
+        </div>
+    )
+}

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-items/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-items/[slug]/edit/page.tsx
@@ -8,7 +8,7 @@ import { useDebounce } from "use-debounce"
 
 import { queryMenuItem, updateMenuItem, queryMenuItemCategories, queryMenuItemComponents, queryMenus } from "@/lib/query"
 import { MenuItem, MenuItemCategory, MenuItemComponent, CompositionEntry, Menu } from "@/lib/schemas"
-import { cn, dollarsToCents, centsToDollarsFormInputs } from "@/lib/utilities"
+import { cn, dollarsToCents, centsToDollarsFormInputs, centsToDollars } from "@/lib/utilities"
 import { buttonVariants } from "@/components/ui/button"
 import { Button } from "@/components/ui/button"
 import { Icons } from "@/components/icons/lucide"
@@ -52,9 +52,10 @@ export default function EditMenuItemPage() {
     const [searchComponent, setSearchComponent] = useState("")
     const [openComponents, setOpenComponents] = useState(false)
     const [selectedTags, setSelectedTags] = useState<string[]>([])
+    const [sizes, setSizes] = useState<{ name: string; price_cents: string }[]>([])
     const [initialized, setInitialized] = useState(false)
 
-    const availableTags = ["Vegetarian", "Gluten Free"]
+    const availableTags = ["Vegetarian", "Vegetarian On Request", "Gluten Free", "Scrambled", "Fried", "Grilled"]
 
     const handleToggleTag = (tag: string) => {
         setSelectedTags(prev =>
@@ -93,6 +94,10 @@ export default function EditMenuItemPage() {
             setStatus(menuItem.status || "active")
             setSelectedComponents(menuItem.composition || [])
             setSelectedTags(menuItem.tags || [])
+            setSizes((menuItem.sizes || []).map(s => ({
+                name: s.name,
+                price_cents: String(centsToDollarsFormInputs(s.price_cents || 0)),
+            })))
             setInitialized(true)
         }
     }, [menuItem, initialized])
@@ -100,7 +105,7 @@ export default function EditMenuItemPage() {
     // Fetch categories for dropdown
     const { data: categoryData } = useQuery({
         queryKey: ["menu-item-categories-all"],
-        queryFn: () => queryMenuItemCategories({ p: 1 }),
+        queryFn: () => queryMenuItemCategories({ p: 1, limit: 100 }),
         refetchOnWindowFocus: false,
     })
 
@@ -187,6 +192,10 @@ export default function EditMenuItemPage() {
             price_cents: dollarsToCents(parseFloat(priceCents || "0")),
             category_id: effectiveCategoryId,
             composition: selectedComponents,
+            sizes: sizes.filter(s => s.name.trim()).map(s => ({
+                name: s.name.trim(),
+                price_cents: dollarsToCents(parseFloat(s.price_cents || "0")),
+            })),
             tags: selectedTags,
             status,
         })
@@ -331,6 +340,60 @@ export default function EditMenuItemPage() {
                                             ))}
                                         </SelectContent>
                                     </Select>
+                                </div>
+                            </div>
+
+                            <div className="col-span-full">
+                                <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                                    Size Options
+                                </label>
+                                <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                                    Add size variants if this item comes in multiple sizes (e.g. Small, Medium, Large).
+                                </p>
+                                <div className="mt-3 space-y-3">
+                                    {sizes.map((size, index) => (
+                                        <div key={index} className="flex items-center gap-3">
+                                            <Input
+                                                placeholder="Size name (e.g. Medium)"
+                                                value={size.name}
+                                                onChange={(e) => {
+                                                    const updated = [...sizes]
+                                                    updated[index] = { ...updated[index], name: e.target.value }
+                                                    setSizes(updated)
+                                                }}
+                                                className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                            />
+                                            <Input
+                                                type="number"
+                                                step="0.01"
+                                                min="0"
+                                                placeholder="Price ($)"
+                                                value={size.price_cents}
+                                                onChange={(e) => {
+                                                    const updated = [...sizes]
+                                                    updated[index] = { ...updated[index], price_cents: e.target.value }
+                                                    setSizes(updated)
+                                                }}
+                                                className="block w-40 rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                            />
+                                            <button
+                                                type="button"
+                                                onClick={() => setSizes(sizes.filter((_, i) => i !== index))}
+                                                className="text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+                                            >
+                                                <Icons.close className="w-4 h-4" />
+                                            </button>
+                                        </div>
+                                    ))}
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        size="sm"
+                                        onClick={() => setSizes([...sizes, { name: "", price_cents: "" }])}
+                                    >
+                                        <Icons.add className="w-4 h-4 mr-1" />
+                                        Add Size
+                                    </Button>
                                 </div>
                             </div>
 

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-items/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-items/[slug]/edit/page.tsx
@@ -6,8 +6,8 @@ import { useMutation, useQuery } from "@tanstack/react-query"
 import { useRouter, useParams } from "next/navigation"
 import { useDebounce } from "use-debounce"
 
-import { queryMenuItem, updateMenuItem, queryMenuItemCategories, queryMenuItemComponents } from "@/lib/query"
-import { MenuItem, MenuItemCategory, MenuItemComponent, CompositionEntry } from "@/lib/schemas"
+import { queryMenuItem, updateMenuItem, queryMenuItemCategories, queryMenuItemComponents, queryMenus } from "@/lib/query"
+import { MenuItem, MenuItemCategory, MenuItemComponent, CompositionEntry, Menu } from "@/lib/schemas"
 import { cn, dollarsToCents, centsToDollarsFormInputs } from "@/lib/utilities"
 import { buttonVariants } from "@/components/ui/button"
 import { Button } from "@/components/ui/button"
@@ -42,6 +42,7 @@ export default function EditMenuItemPage() {
     const params = useParams()
     const menuItemId = params.slug as string
 
+    const [menuId, setMenuId] = useState("")
     const [name, setName] = useState("")
     const [description, setDescription] = useState("")
     const [priceCents, setPriceCents] = useState("")
@@ -50,7 +51,16 @@ export default function EditMenuItemPage() {
     const [selectedComponents, setSelectedComponents] = useState<CompositionEntry[]>([])
     const [searchComponent, setSearchComponent] = useState("")
     const [openComponents, setOpenComponents] = useState(false)
+    const [selectedTags, setSelectedTags] = useState<string[]>([])
     const [initialized, setInitialized] = useState(false)
+
+    const availableTags = ["Vegetarian", "Gluten Free"]
+
+    const handleToggleTag = (tag: string) => {
+        setSelectedTags(prev =>
+            prev.includes(tag) ? prev.filter(t => t !== tag) : [...prev, tag]
+        )
+    }
 
     const [debouncedComponentQuery] = useDebounce(searchComponent, 1000)
 
@@ -63,15 +73,26 @@ export default function EditMenuItemPage() {
 
     const menuItem = menuItemData?.data as MenuItem
 
+    // Fetch menus for dropdown
+    const { data: menuData } = useQuery({
+        queryKey: ["menus-all"],
+        queryFn: () => queryMenus({ p: 1 }),
+        refetchOnWindowFocus: false,
+    })
+
+    const menus = (menuData?.data?.data as Menu[]) || []
+
     // Populate form when data loads
     useEffect(() => {
         if (menuItem && !initialized) {
+            setMenuId(menuItem.menu_id || "")
             setName(menuItem.name || "")
             setDescription(menuItem.description || "")
             setPriceCents(String(centsToDollarsFormInputs(menuItem.price_cents || 0)))
             setCategoryId(menuItem.category_id || "")
             setStatus(menuItem.status || "active")
             setSelectedComponents(menuItem.composition || [])
+            setSelectedTags(menuItem.tags || [])
             setInitialized(true)
         }
     }, [menuItem, initialized])
@@ -83,7 +104,7 @@ export default function EditMenuItemPage() {
         refetchOnWindowFocus: false,
     })
 
-    const categories = categoryData?.data?.data as MenuItemCategory[]
+    const categories = (categoryData?.data?.data as MenuItemCategory[]) || []
 
     // Search components for composition
     const hasShownError = useRef(false)
@@ -140,23 +161,33 @@ export default function EditMenuItemPage() {
     function onSubmit(e: React.FormEvent) {
         e.preventDefault()
 
+        const effectiveMenuId = menuId || menuItem?.menu_id || ""
+        const effectiveCategoryId = categoryId || menuItem?.category_id || ""
+
+        if (!effectiveMenuId) {
+            toast({ description: "Menu is required", variant: "destructive" })
+            return
+        }
+
         if (!name.trim()) {
             toast({ description: "Name is required", variant: "destructive" })
             return
         }
 
-        if (!categoryId) {
+        if (!effectiveCategoryId) {
             toast({ description: "Category is required", variant: "destructive" })
             return
         }
 
         mutate({
             id: menuItemId,
+            menu_id: effectiveMenuId,
             name: name.trim(),
             description: description.trim(),
             price_cents: dollarsToCents(parseFloat(priceCents || "0")),
-            category_id: categoryId,
+            category_id: effectiveCategoryId,
             composition: selectedComponents,
+            tags: selectedTags,
             status,
         })
     }
@@ -180,7 +211,7 @@ export default function EditMenuItemPage() {
 
     return (
         <div className="space-y-10">
-            <div className="flex items-center justify-between">
+<div className="flex items-center justify-between">
                 <div>
                     <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
                         Edit Menu Item
@@ -200,17 +231,42 @@ export default function EditMenuItemPage() {
 
             <form onSubmit={onSubmit}>
                 <div className="space-y-12">
-                    <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
-                        <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
-                            Menu Item Information
-                        </h2>
+                    <div className="grid grid-cols-1 gap-x-8 gap-y-10 border-b border-gray-900/10 pb-12 md:grid-cols-3 dark:border-white/10">
+                        <div>
+                            <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                                Menu Item Details
+                            </h2>
+                            <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                                Update the menu, name, pricing and category for this item.
+                            </p>
+                        </div>
 
-                        <div className="mt-10 space-y-8">
-                            <div className="px-1">
-                                <label
-                                    htmlFor="name"
-                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
-                                >
+                        <div className="grid max-w-2xl grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6 md:col-span-2">
+                            <div className="sm:col-span-4">
+                                <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                                    Menu
+                                </label>
+                                <div className="mt-2">
+                                    <Select onValueChange={setMenuId} value={menuId || menuItem?.menu_id || ""}>
+                                        <SelectTrigger className="w-full">
+                                            <SelectValue placeholder="Select a menu" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {menus.map((menu) => (
+                                                <SelectItem key={menu.id} value={menu.id}>
+                                                    <span className="capitalize">{menu.name}</span>
+                                                    {menu.location_name && (
+                                                        <span className="ml-1 text-gray-500 dark:text-gray-400">— {menu.location_name}</span>
+                                                    )}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                            </div>
+
+                            <div className="sm:col-span-4">
+                                <label htmlFor="name" className="block text-sm/6 font-medium text-gray-900 dark:text-white">
                                     Name
                                 </label>
                                 <div className="mt-2">
@@ -219,16 +275,13 @@ export default function EditMenuItemPage() {
                                         placeholder="Enter menu item name"
                                         value={name}
                                         onChange={(e) => setName(e.target.value)}
-                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
                                     />
                                 </div>
                             </div>
 
-                            <div className="px-1">
-                                <label
-                                    htmlFor="description"
-                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
-                                >
+                            <div className="col-span-full">
+                                <label htmlFor="description" className="block text-sm/6 font-medium text-gray-900 dark:text-white">
                                     Description
                                 </label>
                                 <div className="mt-2">
@@ -238,16 +291,13 @@ export default function EditMenuItemPage() {
                                         rows={3}
                                         value={description}
                                         onChange={(e) => setDescription(e.target.value)}
-                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
                                     />
                                 </div>
                             </div>
 
-                            <div className="px-1">
-                                <label
-                                    htmlFor="price"
-                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
-                                >
+                            <div className="sm:col-span-3">
+                                <label htmlFor="price" className="block text-sm/6 font-medium text-gray-900 dark:text-white">
                                     Price ($)
                                 </label>
                                 <div className="mt-2">
@@ -259,24 +309,22 @@ export default function EditMenuItemPage() {
                                         placeholder="e.g. 9.99"
                                         value={priceCents}
                                         onChange={(e) => setPriceCents(e.target.value)}
-                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
                                     />
                                 </div>
                             </div>
 
-                            <div className="px-1">
-                                <label
-                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
-                                >
+                            <div className="sm:col-span-3">
+                                <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
                                     Category
                                 </label>
                                 <div className="mt-2">
-                                    <Select onValueChange={setCategoryId} value={categoryId}>
+                                    <Select onValueChange={setCategoryId} value={categoryId || menuItem?.category_id || ""}>
                                         <SelectTrigger className="w-full">
                                             <SelectValue placeholder="Select a category" />
                                         </SelectTrigger>
                                         <SelectContent>
-                                            {categories?.map((cat) => (
+                                            {categories.map((cat) => (
                                                 <SelectItem key={cat.id} value={cat.id}>
                                                     {cat.name}
                                                 </SelectItem>
@@ -286,7 +334,37 @@ export default function EditMenuItemPage() {
                                 </div>
                             </div>
 
-                            <div className="px-1">
+                            <div className="sm:col-span-4">
+                                <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                                    Status
+                                </label>
+                                <div className="mt-2">
+                                    <Select onValueChange={setStatus} value={status}>
+                                        <SelectTrigger className="w-full">
+                                            <SelectValue placeholder="Select status" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value="active">Active</SelectItem>
+                                            <SelectItem value="inactive">Inactive</SelectItem>
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="grid grid-cols-1 gap-x-8 gap-y-10 border-b border-gray-900/10 pb-12 md:grid-cols-3 dark:border-white/10">
+                        <div>
+                            <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                                Composition & Tags
+                            </h2>
+                            <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                                Add the ingredients that make up this dish and any dietary tags.
+                            </p>
+                        </div>
+
+                        <div className="grid max-w-2xl grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6 md:col-span-2">
+                            <div className="col-span-full">
                                 <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
                                     Composition
                                 </label>
@@ -319,7 +397,7 @@ export default function EditMenuItemPage() {
                                             Search and add components...
                                         </Button>
                                     </PopoverTrigger>
-                                    <PopoverContent className="w-full p-0" align="start">
+                                    <PopoverContent className="p-0" align="start" style={{ width: 'var(--radix-popover-trigger-width)' }}>
                                         <Command shouldFilter={false}>
                                             <CommandInput
                                                 placeholder="Type component name (min 2 chars)..."
@@ -362,22 +440,27 @@ export default function EditMenuItemPage() {
                                 </p>
                             </div>
 
-                            <div className="px-1">
-                                <label
-                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
-                                >
-                                    Status
+                            <div className="col-span-full">
+                                <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                                    Tags
                                 </label>
-                                <div className="mt-2">
-                                    <Select onValueChange={setStatus} value={status}>
-                                        <SelectTrigger className="w-full">
-                                            <SelectValue placeholder="Select status" />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            <SelectItem value="active">Active</SelectItem>
-                                            <SelectItem value="inactive">Inactive</SelectItem>
-                                        </SelectContent>
-                                    </Select>
+                                <div className="flex flex-wrap gap-2 mt-2">
+                                    {availableTags.map(tag => (
+                                        <button
+                                            key={tag}
+                                            type="button"
+                                            onClick={() => handleToggleTag(tag)}
+                                            className={cn(
+                                                "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium border transition-colors",
+                                                selectedTags.includes(tag)
+                                                    ? "bg-indigo-50 border-indigo-300 text-indigo-700 dark:bg-indigo-900/20 dark:border-indigo-600 dark:text-indigo-300"
+                                                    : "bg-white border-gray-300 text-gray-700 hover:bg-gray-50 dark:bg-white/5 dark:border-white/10 dark:text-gray-300 dark:hover:bg-white/10"
+                                            )}
+                                        >
+                                            {selectedTags.includes(tag) && <Icons.check className="w-3.5 h-3.5" />}
+                                            {tag}
+                                        </button>
+                                    ))}
                                 </div>
                             </div>
                         </div>

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-items/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-items/new/page.tsx
@@ -49,8 +49,9 @@ export default function NewMenuItemPage() {
     const [searchComponent, setSearchComponent] = useState("")
     const [openComponents, setOpenComponents] = useState(false)
     const [selectedTags, setSelectedTags] = useState<string[]>([])
+    const [sizes, setSizes] = useState<{ name: string; price_cents: string }[]>([])
 
-    const availableTags = ["Vegetarian", "Gluten Free"]
+    const availableTags = ["Vegetarian", "Vegetarian On Request", "Gluten Free", "Scrambled", "Fried", "Grilled"]
 
     const handleToggleTag = (tag: string) => {
         setSelectedTags(prev =>
@@ -72,7 +73,7 @@ export default function NewMenuItemPage() {
     // Fetch categories for dropdown
     const { data: categoryData } = useQuery({
         queryKey: ["menu-item-categories-all"],
-        queryFn: () => queryMenuItemCategories({ p: 1 }),
+        queryFn: () => queryMenuItemCategories({ p: 1, limit: 100 }),
         refetchOnWindowFocus: false,
     })
 
@@ -155,6 +156,10 @@ export default function NewMenuItemPage() {
             price_cents: dollarsToCents(parseFloat(priceCents || "0")),
             category_id: categoryId,
             composition: selectedComponents,
+            sizes: sizes.filter(s => s.name.trim()).map(s => ({
+                name: s.name.trim(),
+                price_cents: dollarsToCents(parseFloat(s.price_cents || "0")),
+            })),
             tags: selectedTags,
             status,
         })
@@ -282,6 +287,60 @@ export default function NewMenuItemPage() {
                                             ))}
                                         </SelectContent>
                                     </Select>
+                                </div>
+                            </div>
+
+                            <div className="col-span-full">
+                                <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                                    Size Options
+                                </label>
+                                <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                                    Add size variants if this item comes in multiple sizes (e.g. Small, Medium, Large).
+                                </p>
+                                <div className="mt-3 space-y-3">
+                                    {sizes.map((size, index) => (
+                                        <div key={index} className="flex items-center gap-3">
+                                            <Input
+                                                placeholder="Size name (e.g. Medium)"
+                                                value={size.name}
+                                                onChange={(e) => {
+                                                    const updated = [...sizes]
+                                                    updated[index] = { ...updated[index], name: e.target.value }
+                                                    setSizes(updated)
+                                                }}
+                                                className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                            />
+                                            <Input
+                                                type="number"
+                                                step="0.01"
+                                                min="0"
+                                                placeholder="Price ($)"
+                                                value={size.price_cents}
+                                                onChange={(e) => {
+                                                    const updated = [...sizes]
+                                                    updated[index] = { ...updated[index], price_cents: e.target.value }
+                                                    setSizes(updated)
+                                                }}
+                                                className="block w-40 rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                            />
+                                            <button
+                                                type="button"
+                                                onClick={() => setSizes(sizes.filter((_, i) => i !== index))}
+                                                className="text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+                                            >
+                                                <Icons.close className="w-4 h-4" />
+                                            </button>
+                                        </div>
+                                    ))}
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        size="sm"
+                                        onClick={() => setSizes([...sizes, { name: "", price_cents: "" }])}
+                                    >
+                                        <Icons.add className="w-4 h-4 mr-1" />
+                                        Add Size
+                                    </Button>
                                 </div>
                             </div>
 

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-items/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-items/new/page.tsx
@@ -6,8 +6,8 @@ import { useMutation, useQuery } from "@tanstack/react-query"
 import { useRouter } from "next/navigation"
 import { useDebounce } from "use-debounce"
 
-import { addMenuItem, queryMenuItemCategories, queryMenuItemComponents } from "@/lib/query"
-import { MenuItemCategory, MenuItemComponent, CompositionEntry } from "@/lib/schemas"
+import { addMenuItem, queryMenuItemCategories, queryMenuItemComponents, queryMenus } from "@/lib/query"
+import { MenuItemCategory, MenuItemComponent, CompositionEntry, Menu } from "@/lib/schemas"
 import { cn, dollarsToCents } from "@/lib/utilities"
 import { buttonVariants } from "@/components/ui/button"
 import { Button } from "@/components/ui/button"
@@ -39,6 +39,7 @@ import {
 export default function NewMenuItemPage() {
     const router = useRouter()
 
+    const [menuId, setMenuId] = useState("")
     const [name, setName] = useState("")
     const [description, setDescription] = useState("")
     const [priceCents, setPriceCents] = useState("")
@@ -47,8 +48,26 @@ export default function NewMenuItemPage() {
     const [selectedComponents, setSelectedComponents] = useState<CompositionEntry[]>([])
     const [searchComponent, setSearchComponent] = useState("")
     const [openComponents, setOpenComponents] = useState(false)
+    const [selectedTags, setSelectedTags] = useState<string[]>([])
+
+    const availableTags = ["Vegetarian", "Gluten Free"]
+
+    const handleToggleTag = (tag: string) => {
+        setSelectedTags(prev =>
+            prev.includes(tag) ? prev.filter(t => t !== tag) : [...prev, tag]
+        )
+    }
 
     const [debouncedComponentQuery] = useDebounce(searchComponent, 1000)
+
+    // Fetch menus for dropdown
+    const { data: menuData } = useQuery({
+        queryKey: ["menus-all"],
+        queryFn: () => queryMenus({ p: 1 }),
+        refetchOnWindowFocus: false,
+    })
+
+    const menus = menuData?.data?.data as Menu[]
 
     // Fetch categories for dropdown
     const { data: categoryData } = useQuery({
@@ -114,6 +133,11 @@ export default function NewMenuItemPage() {
     function onSubmit(e: React.FormEvent) {
         e.preventDefault()
 
+        if (!menuId) {
+            toast({ description: "Menu is required", variant: "destructive" })
+            return
+        }
+
         if (!name.trim()) {
             toast({ description: "Name is required", variant: "destructive" })
             return
@@ -125,11 +149,13 @@ export default function NewMenuItemPage() {
         }
 
         mutate({
+            menu_id: menuId,
             name: name.trim(),
             description: description.trim(),
             price_cents: dollarsToCents(parseFloat(priceCents || "0")),
             category_id: categoryId,
             composition: selectedComponents,
+            tags: selectedTags,
             status,
         })
     }
@@ -156,20 +182,42 @@ export default function NewMenuItemPage() {
 
             <form onSubmit={onSubmit}>
                 <div className="space-y-12">
-                    <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
-                        <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
-                            Menu Item Information
-                        </h2>
-                        <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
-                            e.g. Sirloin Steak Breakfast, Caesar Salad, Fish and Chips
-                        </p>
+                    <div className="grid grid-cols-1 gap-x-8 gap-y-10 border-b border-gray-900/10 pb-12 md:grid-cols-3 dark:border-white/10">
+                        <div>
+                            <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                                Menu Item Details
+                            </h2>
+                            <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                                Select which menu this item belongs to and provide the basic details.
+                            </p>
+                        </div>
 
-                        <div className="mt-10 space-y-8">
-                            <div className="px-1">
-                                <label
-                                    htmlFor="name"
-                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
-                                >
+                        <div className="grid max-w-2xl grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6 md:col-span-2">
+                            <div className="sm:col-span-4">
+                                <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                                    Menu
+                                </label>
+                                <div className="mt-2">
+                                    <Select onValueChange={setMenuId} value={menuId}>
+                                        <SelectTrigger className="w-full">
+                                            <SelectValue placeholder="Select a menu" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {menus?.map((menu) => (
+                                                <SelectItem key={menu.id} value={menu.id}>
+                                                    <span className="capitalize">{menu.name}</span>
+                                                    {menu.location_name && (
+                                                        <span className="ml-1 text-gray-500 dark:text-gray-400">— {menu.location_name}</span>
+                                                    )}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                            </div>
+
+                            <div className="sm:col-span-4">
+                                <label htmlFor="name" className="block text-sm/6 font-medium text-gray-900 dark:text-white">
                                     Name
                                 </label>
                                 <div className="mt-2">
@@ -178,16 +226,13 @@ export default function NewMenuItemPage() {
                                         placeholder="Enter menu item name"
                                         value={name}
                                         onChange={(e) => setName(e.target.value)}
-                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
                                     />
                                 </div>
                             </div>
 
-                            <div className="px-1">
-                                <label
-                                    htmlFor="description"
-                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
-                                >
+                            <div className="col-span-full">
+                                <label htmlFor="description" className="block text-sm/6 font-medium text-gray-900 dark:text-white">
                                     Description
                                 </label>
                                 <div className="mt-2">
@@ -197,16 +242,13 @@ export default function NewMenuItemPage() {
                                         rows={3}
                                         value={description}
                                         onChange={(e) => setDescription(e.target.value)}
-                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
                                     />
                                 </div>
                             </div>
 
-                            <div className="px-1">
-                                <label
-                                    htmlFor="price"
-                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
-                                >
+                            <div className="sm:col-span-3">
+                                <label htmlFor="price" className="block text-sm/6 font-medium text-gray-900 dark:text-white">
                                     Price ($)
                                 </label>
                                 <div className="mt-2">
@@ -218,15 +260,13 @@ export default function NewMenuItemPage() {
                                         placeholder="e.g. 9.99"
                                         value={priceCents}
                                         onChange={(e) => setPriceCents(e.target.value)}
-                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
                                     />
                                 </div>
                             </div>
 
-                            <div className="px-1">
-                                <label
-                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
-                                >
+                            <div className="sm:col-span-3">
+                                <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
                                     Category
                                 </label>
                                 <div className="mt-2">
@@ -245,7 +285,37 @@ export default function NewMenuItemPage() {
                                 </div>
                             </div>
 
-                            <div className="px-1">
+                            <div className="sm:col-span-4">
+                                <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                                    Status
+                                </label>
+                                <div className="mt-2">
+                                    <Select onValueChange={setStatus} value={status}>
+                                        <SelectTrigger className="w-full">
+                                            <SelectValue placeholder="Select status" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value="active">Active</SelectItem>
+                                            <SelectItem value="inactive">Inactive</SelectItem>
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="grid grid-cols-1 gap-x-8 gap-y-10 border-b border-gray-900/10 pb-12 md:grid-cols-3 dark:border-white/10">
+                        <div>
+                            <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                                Composition & Tags
+                            </h2>
+                            <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                                Add the ingredients that make up this dish and any dietary tags.
+                            </p>
+                        </div>
+
+                        <div className="grid max-w-2xl grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6 md:col-span-2">
+                            <div className="col-span-full">
                                 <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
                                     Composition
                                 </label>
@@ -278,7 +348,7 @@ export default function NewMenuItemPage() {
                                             Search and add components...
                                         </Button>
                                     </PopoverTrigger>
-                                    <PopoverContent className="w-full p-0" align="start">
+                                    <PopoverContent className="p-0" align="start" style={{ width: 'var(--radix-popover-trigger-width)' }}>
                                         <Command shouldFilter={false}>
                                             <CommandInput
                                                 placeholder="Type component name (min 2 chars)..."
@@ -321,22 +391,27 @@ export default function NewMenuItemPage() {
                                 </p>
                             </div>
 
-                            <div className="px-1">
-                                <label
-                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
-                                >
-                                    Status
+                            <div className="col-span-full">
+                                <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                                    Tags
                                 </label>
-                                <div className="mt-2">
-                                    <Select onValueChange={setStatus} value={status}>
-                                        <SelectTrigger className="w-full">
-                                            <SelectValue placeholder="Select status" />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            <SelectItem value="active">Active</SelectItem>
-                                            <SelectItem value="inactive">Inactive</SelectItem>
-                                        </SelectContent>
-                                    </Select>
+                                <div className="flex flex-wrap gap-2 mt-2">
+                                    {availableTags.map(tag => (
+                                        <button
+                                            key={tag}
+                                            type="button"
+                                            onClick={() => handleToggleTag(tag)}
+                                            className={cn(
+                                                "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium border transition-colors",
+                                                selectedTags.includes(tag)
+                                                    ? "bg-indigo-50 border-indigo-300 text-indigo-700 dark:bg-indigo-900/20 dark:border-indigo-600 dark:text-indigo-300"
+                                                    : "bg-white border-gray-300 text-gray-700 hover:bg-gray-50 dark:bg-white/5 dark:border-white/10 dark:text-gray-300 dark:hover:bg-white/10"
+                                            )}
+                                        >
+                                            {selectedTags.includes(tag) && <Icons.check className="w-3.5 h-3.5" />}
+                                            {tag}
+                                        </button>
+                                    ))}
                                 </div>
                             </div>
                         </div>

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-items/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-items/new/page.tsx
@@ -1,0 +1,366 @@
+"use client"
+
+import { useState, useRef, useEffect } from "react"
+import Link from "next/link"
+import { useMutation, useQuery } from "@tanstack/react-query"
+import { useRouter } from "next/navigation"
+import { useDebounce } from "use-debounce"
+
+import { addMenuItem, queryMenuItemCategories, queryMenuItemComponents } from "@/lib/query"
+import { MenuItemCategory, MenuItemComponent, CompositionEntry } from "@/lib/schemas"
+import { cn, dollarsToCents } from "@/lib/utilities"
+import { buttonVariants } from "@/components/ui/button"
+import { Button } from "@/components/ui/button"
+import { Icons } from "@/components/icons/lucide"
+import { toast } from "@/components/ui/use-toast"
+import { handleApiError, handleFetchError } from "@/lib/error-handler"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select"
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from "@/components/ui/popover"
+import {
+    Command,
+    CommandEmpty,
+    CommandInput,
+    CommandItem,
+    CommandList,
+} from "@/components/ui/command"
+
+export default function NewMenuItemPage() {
+    const router = useRouter()
+
+    const [name, setName] = useState("")
+    const [description, setDescription] = useState("")
+    const [priceCents, setPriceCents] = useState("")
+    const [categoryId, setCategoryId] = useState("")
+    const [status, setStatus] = useState("active")
+    const [selectedComponents, setSelectedComponents] = useState<CompositionEntry[]>([])
+    const [searchComponent, setSearchComponent] = useState("")
+    const [openComponents, setOpenComponents] = useState(false)
+
+    const [debouncedComponentQuery] = useDebounce(searchComponent, 1000)
+
+    // Fetch categories for dropdown
+    const { data: categoryData } = useQuery({
+        queryKey: ["menu-item-categories-all"],
+        queryFn: () => queryMenuItemCategories({ p: 1 }),
+        refetchOnWindowFocus: false,
+    })
+
+    const categories = categoryData?.data?.data as MenuItemCategory[]
+
+    // Search components for composition
+    const hasShownError = useRef(false)
+
+    const { data: componentData, isError: componentError, error: componentFetchError, refetch: componentRefetch } = useQuery({
+        queryKey: ["menu-item-components-search", { search: debouncedComponentQuery }],
+        queryFn: () => queryMenuItemComponents({ search: debouncedComponentQuery }),
+        enabled: debouncedComponentQuery.length >= 2,
+        refetchOnWindowFocus: false,
+    })
+
+    useEffect(() => {
+        if (componentError && !hasShownError.current) {
+            hasShownError.current = true
+            handleFetchError(componentFetchError, {
+                onRetry: () => {
+                    hasShownError.current = false
+                    componentRefetch()
+                },
+                context: "menu item components"
+            })
+        }
+        if (!componentError) {
+            hasShownError.current = false
+        }
+    }, [componentError, componentFetchError, componentRefetch])
+
+    const componentList = componentData?.data?.data as MenuItemComponent[]
+
+    const handleToggleComponent = (component: MenuItemComponent) => {
+        const exists = selectedComponents.find(c => c.component_id === component.id)
+        if (exists) {
+            setSelectedComponents(selectedComponents.filter(c => c.component_id !== component.id))
+        } else {
+            setSelectedComponents([...selectedComponents, { component_id: component.id, component_name: component.name }])
+        }
+    }
+
+    const { mutate, isPending } = useMutation({
+        mutationFn: addMenuItem,
+        onSuccess: () => {
+            toast({
+                description: "Menu item added successfully",
+            })
+            router.push("/dashboard/restaurants/menu-items")
+        },
+        onError: (error) => {
+            handleApiError(error, {
+                context: "menu item creation"
+            })
+        },
+    })
+
+    function onSubmit(e: React.FormEvent) {
+        e.preventDefault()
+
+        if (!name.trim()) {
+            toast({ description: "Name is required", variant: "destructive" })
+            return
+        }
+
+        if (!categoryId) {
+            toast({ description: "Category is required", variant: "destructive" })
+            return
+        }
+
+        mutate({
+            name: name.trim(),
+            description: description.trim(),
+            price_cents: dollarsToCents(parseFloat(priceCents || "0")),
+            category_id: categoryId,
+            composition: selectedComponents,
+            status,
+        })
+    }
+
+    return (
+        <div className="space-y-10">
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+                        Add Menu Item
+                    </h1>
+                    <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                        Create a new menu item (dish).
+                    </p>
+                </div>
+                <Link
+                    href="/dashboard/restaurants/menu-items"
+                    className={cn(buttonVariants({ variant: "ghost" }))}
+                >
+                    <Icons.close className="w-4 h-4 mr-2" />
+                    Close
+                </Link>
+            </div>
+
+            <form onSubmit={onSubmit}>
+                <div className="space-y-12">
+                    <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
+                        <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                            Menu Item Information
+                        </h2>
+                        <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                            e.g. Sirloin Steak Breakfast, Caesar Salad, Fish and Chips
+                        </p>
+
+                        <div className="mt-10 space-y-8">
+                            <div className="px-1">
+                                <label
+                                    htmlFor="name"
+                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                >
+                                    Name
+                                </label>
+                                <div className="mt-2">
+                                    <Input
+                                        id="name"
+                                        placeholder="Enter menu item name"
+                                        value={name}
+                                        onChange={(e) => setName(e.target.value)}
+                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                    />
+                                </div>
+                            </div>
+
+                            <div className="px-1">
+                                <label
+                                    htmlFor="description"
+                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                >
+                                    Description
+                                </label>
+                                <div className="mt-2">
+                                    <Textarea
+                                        id="description"
+                                        placeholder="e.g. Sirloin steak grilled to your liking served with eggs and chips"
+                                        rows={3}
+                                        value={description}
+                                        onChange={(e) => setDescription(e.target.value)}
+                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                    />
+                                </div>
+                            </div>
+
+                            <div className="px-1">
+                                <label
+                                    htmlFor="price"
+                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                >
+                                    Price ($)
+                                </label>
+                                <div className="mt-2">
+                                    <Input
+                                        id="price"
+                                        type="number"
+                                        step="0.01"
+                                        min="0"
+                                        placeholder="e.g. 9.99"
+                                        value={priceCents}
+                                        onChange={(e) => setPriceCents(e.target.value)}
+                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                    />
+                                </div>
+                            </div>
+
+                            <div className="px-1">
+                                <label
+                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                >
+                                    Category
+                                </label>
+                                <div className="mt-2">
+                                    <Select onValueChange={setCategoryId} value={categoryId}>
+                                        <SelectTrigger className="w-full">
+                                            <SelectValue placeholder="Select a category" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {categories?.map((cat) => (
+                                                <SelectItem key={cat.id} value={cat.id}>
+                                                    {cat.name}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                            </div>
+
+                            <div className="px-1">
+                                <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                                    Composition
+                                </label>
+
+                                {selectedComponents.length > 0 && (
+                                    <div className="flex flex-wrap gap-2 mt-2 mb-3">
+                                        {selectedComponents.map(comp => (
+                                            <span
+                                                key={comp.component_id}
+                                                className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-sm bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-300 cursor-pointer hover:bg-blue-100 dark:hover:bg-blue-900/40"
+                                                onClick={() => setSelectedComponents(selectedComponents.filter(c => c.component_id !== comp.component_id))}
+                                            >
+                                                {comp.component_name}
+                                                <Icons.close className="w-3 h-3" />
+                                            </span>
+                                        ))}
+                                    </div>
+                                )}
+
+                                <Popover open={openComponents} onOpenChange={setOpenComponents}>
+                                    <PopoverTrigger asChild>
+                                        <Button
+                                            type="button"
+                                            variant="outline"
+                                            role="combobox"
+                                            aria-expanded={openComponents}
+                                            className="w-full justify-start text-left font-normal"
+                                        >
+                                            <Icons.search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+                                            Search and add components...
+                                        </Button>
+                                    </PopoverTrigger>
+                                    <PopoverContent className="w-full p-0" align="start">
+                                        <Command shouldFilter={false}>
+                                            <CommandInput
+                                                placeholder="Type component name (min 2 chars)..."
+                                                value={searchComponent}
+                                                onValueChange={setSearchComponent}
+                                            />
+                                            <CommandList>
+                                                <CommandEmpty>
+                                                    {debouncedComponentQuery.length < 2
+                                                        ? "Type at least 2 characters to search"
+                                                        : "No components found"
+                                                    }
+                                                </CommandEmpty>
+                                                {componentList?.map((comp) => {
+                                                    const isSelected = selectedComponents.some(c => c.component_id === comp.id)
+                                                    return (
+                                                        <CommandItem
+                                                            key={comp.id}
+                                                            value={comp.id}
+                                                            onSelect={() => handleToggleComponent(comp)}
+                                                        >
+                                                            <span className={cn(
+                                                                "mr-2 flex h-4 w-4 items-center justify-center rounded-sm border",
+                                                                isSelected
+                                                                    ? "bg-primary border-primary text-primary-foreground"
+                                                                    : "border-gray-300 dark:border-gray-600"
+                                                            )}>
+                                                                {isSelected && <Icons.check className="w-3 h-3" />}
+                                                            </span>
+                                                            {comp.name}
+                                                        </CommandItem>
+                                                    )
+                                                })}
+                                            </CommandList>
+                                        </Command>
+                                    </PopoverContent>
+                                </Popover>
+                                <p className="mt-3 text-sm/6 text-gray-600 dark:text-gray-400">
+                                    Select the components that make up this dish (e.g. Steak, Eggs, Chips).
+                                </p>
+                            </div>
+
+                            <div className="px-1">
+                                <label
+                                    className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                >
+                                    Status
+                                </label>
+                                <div className="mt-2">
+                                    <Select onValueChange={setStatus} value={status}>
+                                        <SelectTrigger className="w-full">
+                                            <SelectValue placeholder="Select status" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            <SelectItem value="active">Active</SelectItem>
+                                            <SelectItem value="inactive">Inactive</SelectItem>
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div className="mt-6 flex items-center justify-end gap-x-6">
+                    <button
+                        type="button"
+                        onClick={() => router.push("/dashboard/restaurants/menu-items")}
+                        className="text-sm/6 font-semibold text-gray-900 dark:text-white"
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        type="submit"
+                        disabled={isPending}
+                        className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
+                    >
+                        {isPending && <Icons.spinner className="w-4 h-4 mr-2 animate-spin" />}
+                        Save
+                    </button>
+                </div>
+            </form>
+        </div>
+    )
+}

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-items/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-items/page.tsx
@@ -1,0 +1,15 @@
+import { DashboardHeader } from "@/components/state/dashboardHeader"
+import { DashboardShell } from "@/components/state/dashboardShell"
+import { MenuItemsTable } from "@/components/structures/tables/menu-items"
+
+export default async function MenuItemsPage() {
+  return (
+    <DashboardShell>
+      <DashboardHeader
+        heading="Menu Items"
+        text="Manage menu items (dishes)."
+      ></DashboardHeader>
+      <MenuItemsTable />
+    </DashboardShell>
+  )
+}

--- a/apps/admin-fnp/app/dashboard/restaurants/menus/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menus/[slug]/edit/page.tsx
@@ -1,0 +1,298 @@
+"use client"
+
+import { useEffect } from "react"
+import Link from "next/link"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useMutation, useQuery } from "@tanstack/react-query"
+import { useForm } from "react-hook-form"
+import { useRouter, useParams } from "next/navigation"
+
+import { queryMenu, updateMenu, queryRestaurantLocations } from "@/lib/query"
+import { Menu, RestaurantLocation } from "@/lib/schemas"
+import { cn } from "@/lib/utilities"
+import { buttonVariants } from "@/components/ui/button"
+import { Icons } from "@/components/icons/lucide"
+import { toast } from "@/components/ui/use-toast"
+import { handleApiError } from "@/lib/error-handler"
+import { Placeholder } from "@/components/state/placeholder"
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select"
+
+import * as z from "zod"
+
+const EditFormSchema = z.object({
+    location_id: z.string().min(1, "Location is required"),
+    name: z.string().min(1, "Name is required").max(120),
+    note: z.string().optional().default(""),
+    status: z.enum(["active", "inactive"]),
+})
+
+type EditFormModel = z.infer<typeof EditFormSchema>
+
+export default function EditMenuPage() {
+    const router = useRouter()
+    const params = useParams()
+    const menuId = params.slug as string
+
+    const { data, isLoading, isError } = useQuery({
+        queryKey: ["menu", menuId],
+        queryFn: () => queryMenu(menuId),
+        refetchOnWindowFocus: false,
+    })
+
+    const menu = data?.data as Menu
+
+    const { data: locationsData } = useQuery({
+        queryKey: ["locations-for-select"],
+        queryFn: () => queryRestaurantLocations({}),
+        refetchOnWindowFocus: false,
+    })
+
+    const locations = (locationsData?.data?.data as RestaurantLocation[]) || []
+
+    const form = useForm<EditFormModel>({
+        defaultValues: {
+            location_id: "",
+            name: "",
+            note: "",
+            status: "active",
+        },
+        resolver: zodResolver(EditFormSchema),
+    })
+
+    useEffect(() => {
+        if (menu) {
+            form.reset({
+                location_id: menu.location_id || "",
+                name: menu.name || "",
+                note: menu.note || "",
+                status: (menu.status as "active" | "inactive") || "active",
+            })
+        }
+    }, [menu, form])
+
+    const { mutate, isPending } = useMutation({
+        mutationFn: updateMenu,
+        onSuccess: () => {
+            toast({
+                description: "Menu updated successfully",
+            })
+            router.push("/dashboard/restaurants/menus")
+        },
+        onError: (error) => {
+            handleApiError(error, {
+                context: "menu update"
+            })
+        },
+    })
+
+    async function onSubmit(data: EditFormModel) {
+        mutate({
+            id: menuId,
+            ...data,
+        })
+    }
+
+    if (isLoading) {
+        return (
+            <Placeholder>
+                <Placeholder.Title>Loading Menu</Placeholder.Title>
+            </Placeholder>
+        )
+    }
+
+    if (isError) {
+        return (
+            <Placeholder>
+                <Placeholder.Icon name="close" />
+                <Placeholder.Title>Error Loading Menu</Placeholder.Title>
+            </Placeholder>
+        )
+    }
+
+    return (
+        <div className="space-y-10">
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+                        Edit Menu
+                    </h1>
+                    <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                        Update menu details.
+                    </p>
+                </div>
+                <Link
+                    href="/dashboard/restaurants/menus"
+                    className={cn(buttonVariants({ variant: "ghost" }))}
+                >
+                    <Icons.close className="w-4 h-4 mr-2" />
+                    Close
+                </Link>
+            </div>
+
+            <Form {...form}>
+                <form onSubmit={form.handleSubmit(onSubmit)}>
+                    <div className="space-y-12">
+                        <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
+                            <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                                Menu Information
+                            </h2>
+
+                            <div className="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+                                <div className="sm:col-span-4 px-1">
+                                    <label
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Location
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="location_id"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <Select onValueChange={field.onChange} value={field.value}>
+                                                        <FormControl>
+                                                            <SelectTrigger className="w-full">
+                                                                <SelectValue placeholder="Select a location" />
+                                                            </SelectTrigger>
+                                                        </FormControl>
+                                                        <SelectContent>
+                                                            {locations.map((loc) => (
+                                                                <SelectItem key={loc.id} value={loc.id}>
+                                                                    <span className="capitalize">{loc.name}</span>
+                                                                </SelectItem>
+                                                            ))}
+                                                        </SelectContent>
+                                                    </Select>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                </div>
+
+                                <div className="sm:col-span-4 px-1">
+                                    <label
+                                        htmlFor="name"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Menu Name
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="name"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Input
+                                                            id="name"
+                                                            placeholder="Enter menu name"
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                </div>
+
+                                <div className="sm:col-span-4 px-1">
+                                    <label
+                                        htmlFor="note"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Note
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="note"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Input
+                                                            id="note"
+                                                            placeholder="e.g. Served until 11:00 AM"
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                </div>
+
+                                <div className="sm:col-span-4 px-1">
+                                    <label
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Status
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="status"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <Select onValueChange={field.onChange} value={field.value}>
+                                                        <FormControl>
+                                                            <SelectTrigger className="w-full">
+                                                                <SelectValue placeholder="Select status" />
+                                                            </SelectTrigger>
+                                                        </FormControl>
+                                                        <SelectContent>
+                                                            <SelectItem value="active">Active</SelectItem>
+                                                            <SelectItem value="inactive">Inactive</SelectItem>
+                                                        </SelectContent>
+                                                    </Select>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="mt-6 flex items-center justify-end gap-x-6">
+                        <button
+                            type="button"
+                            onClick={() => router.push("/dashboard/restaurants/menus")}
+                            className="text-sm/6 font-semibold text-gray-900 dark:text-white"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={isPending}
+                            className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
+                        >
+                            {isPending && <Icons.spinner className="w-4 h-4 mr-2 animate-spin" />}
+                            Update
+                        </button>
+                    </div>
+                </form>
+            </Form>
+        </div>
+    )
+}

--- a/apps/admin-fnp/app/dashboard/restaurants/menus/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menus/[slug]/edit/page.tsx
@@ -1,14 +1,15 @@
 "use client"
 
-import { useEffect } from "react"
+import { useState, useEffect } from "react"
 import Link from "next/link"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useMutation, useQuery } from "@tanstack/react-query"
 import { useForm } from "react-hook-form"
 import { useRouter, useParams } from "next/navigation"
+import { Check, ChevronsUpDown, X } from "lucide-react"
 
-import { queryMenu, updateMenu, queryRestaurantLocations } from "@/lib/query"
-import { Menu, RestaurantLocation } from "@/lib/schemas"
+import { queryMenu, updateMenu, queryRestaurantLocations, queryMenuItemCategories } from "@/lib/query"
+import { FormMenuSchema, FormMenuModel, Menu, RestaurantLocation, MenuLocationEntry, MenuItemCategory } from "@/lib/schemas"
 import { cn } from "@/lib/utilities"
 import { buttonVariants } from "@/components/ui/button"
 import { Icons } from "@/components/icons/lucide"
@@ -30,22 +31,22 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select"
-
-import * as z from "zod"
-
-const EditFormSchema = z.object({
-    location_id: z.string().min(1, "Location is required"),
-    name: z.string().min(1, "Name is required").max(120),
-    note: z.string().optional().default(""),
-    status: z.enum(["active", "inactive"]),
-})
-
-type EditFormModel = z.infer<typeof EditFormSchema>
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import {
+    Command,
+    CommandEmpty,
+    CommandGroup,
+    CommandInput,
+    CommandItem,
+    CommandList,
+} from "@/components/ui/command"
+import { Badge } from "@/components/ui/badge"
 
 export default function EditMenuPage() {
     const router = useRouter()
     const params = useParams()
     const menuId = params.slug as string
+    const [locationsOpen, setLocationsOpen] = useState(false)
 
     const { data, isLoading, isError } = useQuery({
         queryKey: ["menu", menuId],
@@ -63,23 +64,33 @@ export default function EditMenuPage() {
 
     const locations = (locationsData?.data?.data as RestaurantLocation[]) || []
 
-    const form = useForm<EditFormModel>({
+    const { data: categoriesData } = useQuery({
+        queryKey: ["categories-for-notes"],
+        queryFn: () => queryMenuItemCategories({ limit: 100 }),
+        refetchOnWindowFocus: false,
+    })
+
+    const categories = (categoriesData?.data?.data as MenuItemCategory[]) || []
+
+    const form = useForm<FormMenuModel>({
         defaultValues: {
-            location_id: "",
+            locations: [],
             name: "",
             note: "",
             status: "active",
+            category_notes: {},
         },
-        resolver: zodResolver(EditFormSchema),
+        resolver: zodResolver(FormMenuSchema),
     })
 
     useEffect(() => {
         if (menu) {
             form.reset({
-                location_id: menu.location_id || "",
+                locations: menu.locations || [],
                 name: menu.name || "",
                 note: menu.note || "",
                 status: (menu.status as "active" | "inactive") || "active",
+                category_notes: menu.category_notes || {},
             })
         }
     }, [menu, form])
@@ -99,11 +110,19 @@ export default function EditMenuPage() {
         },
     })
 
-    async function onSubmit(data: EditFormModel) {
+    async function onSubmit(data: FormMenuModel) {
         mutate({
             id: menuId,
             ...data,
         })
+    }
+
+    function toggleLocation(loc: RestaurantLocation, currentLocations: MenuLocationEntry[]) {
+        const exists = currentLocations.some((l) => l.location_id === loc.id)
+        if (exists) {
+            return currentLocations.filter((l) => l.location_id !== loc.id)
+        }
+        return [...currentLocations, { location_id: loc.id, location_name: loc.name }]
     }
 
     if (isLoading) {
@@ -156,28 +175,86 @@ export default function EditMenuPage() {
                                     <label
                                         className="block text-sm/6 font-medium text-gray-900 dark:text-white"
                                     >
-                                        Location
+                                        Locations
                                     </label>
                                     <div className="mt-2">
                                         <FormField
                                             control={form.control}
-                                            name="location_id"
+                                            name="locations"
                                             render={({ field }) => (
                                                 <FormItem>
-                                                    <Select onValueChange={field.onChange} value={field.value}>
-                                                        <FormControl>
-                                                            <SelectTrigger className="w-full">
-                                                                <SelectValue placeholder="Select a location" />
-                                                            </SelectTrigger>
-                                                        </FormControl>
-                                                        <SelectContent>
-                                                            {locations.map((loc) => (
-                                                                <SelectItem key={loc.id} value={loc.id}>
-                                                                    <span className="capitalize">{loc.name}</span>
-                                                                </SelectItem>
+                                                    <Popover open={locationsOpen} onOpenChange={setLocationsOpen}>
+                                                        <PopoverTrigger asChild>
+                                                            <button
+                                                                type="button"
+                                                                role="combobox"
+                                                                aria-expanded={locationsOpen}
+                                                                className="flex w-full items-center justify-between rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 hover:bg-gray-50 dark:border-white/10 dark:bg-white/5 dark:text-white dark:hover:bg-white/10"
+                                                            >
+                                                                <span className="text-gray-400 dark:text-gray-500">
+                                                                    {field.value?.length
+                                                                        ? `${field.value.length} location${field.value.length > 1 ? "s" : ""} selected`
+                                                                        : "Select locations"}
+                                                                </span>
+                                                                <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                                                            </button>
+                                                        </PopoverTrigger>
+                                                        <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+                                                            <Command>
+                                                                <CommandInput placeholder="Search locations..." />
+                                                                <CommandList>
+                                                                    <CommandEmpty>No locations found.</CommandEmpty>
+                                                                    <CommandGroup>
+                                                                        {locations.map((loc) => {
+                                                                            const isSelected = field.value?.some(
+                                                                                (l) => l.location_id === loc.id
+                                                                            )
+                                                                            return (
+                                                                                <CommandItem
+                                                                                    key={loc.id}
+                                                                                    value={loc.name}
+                                                                                    onSelect={() => {
+                                                                                        field.onChange(
+                                                                                            toggleLocation(loc, field.value || [])
+                                                                                        )
+                                                                                    }}
+                                                                                >
+                                                                                    <Check
+                                                                                        className={cn(
+                                                                                            "mr-2 h-4 w-4",
+                                                                                            isSelected ? "opacity-100" : "opacity-0"
+                                                                                        )}
+                                                                                    />
+                                                                                    <span className="capitalize">{loc.name}</span>
+                                                                                </CommandItem>
+                                                                            )
+                                                                        })}
+                                                                    </CommandGroup>
+                                                                </CommandList>
+                                                            </Command>
+                                                        </PopoverContent>
+                                                    </Popover>
+                                                    {field.value && field.value.length > 0 && (
+                                                        <div className="flex flex-wrap gap-1.5 mt-2">
+                                                            {field.value.map((loc) => (
+                                                                <Badge
+                                                                    key={loc.location_id}
+                                                                    variant="secondary"
+                                                                    className="capitalize cursor-pointer"
+                                                                    onClick={() => {
+                                                                        field.onChange(
+                                                                            field.value?.filter(
+                                                                                (l) => l.location_id !== loc.location_id
+                                                                            ) || []
+                                                                        )
+                                                                    }}
+                                                                >
+                                                                    {loc.location_name}
+                                                                    <X className="ml-1 h-3 w-3" />
+                                                                </Badge>
                                                             ))}
-                                                        </SelectContent>
-                                                    </Select>
+                                                        </div>
+                                                    )}
                                                     <FormMessage />
                                                 </FormItem>
                                             )}
@@ -272,6 +349,45 @@ export default function EditMenuPage() {
                                 </div>
                             </div>
                         </div>
+
+                        {categories.length > 0 && (
+                            <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
+                                <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                                    Category Notes
+                                </h2>
+                                <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                                    Add notes for specific categories on this menu. e.g. &quot;All steaks are 14-day aged and served with your choice of sides&quot;
+                                </p>
+
+                                <div className="mt-10 grid grid-cols-1 gap-x-6 gap-y-6 sm:grid-cols-6">
+                                    {categories.map((cat) => (
+                                        <div key={cat.id} className="sm:col-span-4 px-1">
+                                            <label
+                                                className="block text-sm/6 font-medium text-gray-900 dark:text-white capitalize"
+                                            >
+                                                {cat.name}
+                                            </label>
+                                            <div className="mt-2">
+                                                <Input
+                                                    placeholder={`Note for ${cat.name} (optional)`}
+                                                    value={form.watch("category_notes")?.[cat.id] || ""}
+                                                    onChange={(e) => {
+                                                        const current = form.getValues("category_notes") || {}
+                                                        if (e.target.value === "") {
+                                                            const { [cat.id]: _, ...rest } = current
+                                                            form.setValue("category_notes", rest, { shouldDirty: true })
+                                                        } else {
+                                                            form.setValue("category_notes", { ...current, [cat.id]: e.target.value }, { shouldDirty: true })
+                                                        }
+                                                    }}
+                                                    className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                />
+                                            </div>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
                     </div>
 
                     <div className="mt-6 flex items-center justify-end gap-x-6">

--- a/apps/admin-fnp/app/dashboard/restaurants/menus/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menus/new/page.tsx
@@ -1,13 +1,15 @@
 "use client"
 
+import { useState } from "react"
 import Link from "next/link"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useMutation, useQuery } from "@tanstack/react-query"
 import { useForm } from "react-hook-form"
 import { useRouter } from "next/navigation"
+import { Check, ChevronsUpDown, X } from "lucide-react"
 
-import { addMenu, queryRestaurantLocations } from "@/lib/query"
-import { FormMenuSchema, FormMenuModel, RestaurantLocation } from "@/lib/schemas"
+import { addMenu, queryRestaurantLocations, queryMenuItemCategories } from "@/lib/query"
+import { FormMenuSchema, FormMenuModel, RestaurantLocation, MenuLocationEntry, MenuItemCategory } from "@/lib/schemas"
 import { cn } from "@/lib/utilities"
 import { buttonVariants } from "@/components/ui/button"
 import { Icons } from "@/components/icons/lucide"
@@ -28,9 +30,20 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import {
+    Command,
+    CommandEmpty,
+    CommandGroup,
+    CommandInput,
+    CommandItem,
+    CommandList,
+} from "@/components/ui/command"
+import { Badge } from "@/components/ui/badge"
 
 export default function NewMenuPage() {
     const router = useRouter()
+    const [locationsOpen, setLocationsOpen] = useState(false)
 
     const { data: locationsData } = useQuery({
         queryKey: ["locations-for-select"],
@@ -40,12 +53,21 @@ export default function NewMenuPage() {
 
     const locations = (locationsData?.data?.data as RestaurantLocation[]) || []
 
+    const { data: categoriesData } = useQuery({
+        queryKey: ["categories-for-notes"],
+        queryFn: () => queryMenuItemCategories({ limit: 100 }),
+        refetchOnWindowFocus: false,
+    })
+
+    const categories = (categoriesData?.data?.data as MenuItemCategory[]) || []
+
     const form = useForm<FormMenuModel>({
         defaultValues: {
-            location_id: "",
+            locations: [],
             name: "",
             note: "",
             status: "active",
+            category_notes: {},
         },
         resolver: zodResolver(FormMenuSchema),
     })
@@ -67,6 +89,14 @@ export default function NewMenuPage() {
 
     async function onSubmit(data: FormMenuModel) {
         mutate(data)
+    }
+
+    function toggleLocation(loc: RestaurantLocation, currentLocations: MenuLocationEntry[]) {
+        const exists = currentLocations.some((l) => l.location_id === loc.id)
+        if (exists) {
+            return currentLocations.filter((l) => l.location_id !== loc.id)
+        }
+        return [...currentLocations, { location_id: loc.id, location_name: loc.name }]
     }
 
     return (
@@ -105,28 +135,86 @@ export default function NewMenuPage() {
                                     <label
                                         className="block text-sm/6 font-medium text-gray-900 dark:text-white"
                                     >
-                                        Location
+                                        Locations
                                     </label>
                                     <div className="mt-2">
                                         <FormField
                                             control={form.control}
-                                            name="location_id"
+                                            name="locations"
                                             render={({ field }) => (
                                                 <FormItem>
-                                                    <Select onValueChange={field.onChange} defaultValue={field.value}>
-                                                        <FormControl>
-                                                            <SelectTrigger className="w-full">
-                                                                <SelectValue placeholder="Select a location" />
-                                                            </SelectTrigger>
-                                                        </FormControl>
-                                                        <SelectContent>
-                                                            {locations.map((loc) => (
-                                                                <SelectItem key={loc.id} value={loc.id}>
-                                                                    <span className="capitalize">{loc.name}</span>
-                                                                </SelectItem>
+                                                    <Popover open={locationsOpen} onOpenChange={setLocationsOpen}>
+                                                        <PopoverTrigger asChild>
+                                                            <button
+                                                                type="button"
+                                                                role="combobox"
+                                                                aria-expanded={locationsOpen}
+                                                                className="flex w-full items-center justify-between rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 hover:bg-gray-50 dark:border-white/10 dark:bg-white/5 dark:text-white dark:hover:bg-white/10"
+                                                            >
+                                                                <span className="text-gray-400 dark:text-gray-500">
+                                                                    {field.value?.length
+                                                                        ? `${field.value.length} location${field.value.length > 1 ? "s" : ""} selected`
+                                                                        : "Select locations"}
+                                                                </span>
+                                                                <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                                                            </button>
+                                                        </PopoverTrigger>
+                                                        <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+                                                            <Command>
+                                                                <CommandInput placeholder="Search locations..." />
+                                                                <CommandList>
+                                                                    <CommandEmpty>No locations found.</CommandEmpty>
+                                                                    <CommandGroup>
+                                                                        {locations.map((loc) => {
+                                                                            const isSelected = field.value?.some(
+                                                                                (l) => l.location_id === loc.id
+                                                                            )
+                                                                            return (
+                                                                                <CommandItem
+                                                                                    key={loc.id}
+                                                                                    value={loc.name}
+                                                                                    onSelect={() => {
+                                                                                        field.onChange(
+                                                                                            toggleLocation(loc, field.value || [])
+                                                                                        )
+                                                                                    }}
+                                                                                >
+                                                                                    <Check
+                                                                                        className={cn(
+                                                                                            "mr-2 h-4 w-4",
+                                                                                            isSelected ? "opacity-100" : "opacity-0"
+                                                                                        )}
+                                                                                    />
+                                                                                    <span className="capitalize">{loc.name}</span>
+                                                                                </CommandItem>
+                                                                            )
+                                                                        })}
+                                                                    </CommandGroup>
+                                                                </CommandList>
+                                                            </Command>
+                                                        </PopoverContent>
+                                                    </Popover>
+                                                    {field.value && field.value.length > 0 && (
+                                                        <div className="flex flex-wrap gap-1.5 mt-2">
+                                                            {field.value.map((loc) => (
+                                                                <Badge
+                                                                    key={loc.location_id}
+                                                                    variant="secondary"
+                                                                    className="capitalize cursor-pointer"
+                                                                    onClick={() => {
+                                                                        field.onChange(
+                                                                            field.value?.filter(
+                                                                                (l) => l.location_id !== loc.location_id
+                                                                            ) || []
+                                                                        )
+                                                                    }}
+                                                                >
+                                                                    {loc.location_name}
+                                                                    <X className="ml-1 h-3 w-3" />
+                                                                </Badge>
                                                             ))}
-                                                        </SelectContent>
-                                                    </Select>
+                                                        </div>
+                                                    )}
                                                     <FormMessage />
                                                 </FormItem>
                                             )}
@@ -221,6 +309,45 @@ export default function NewMenuPage() {
                                 </div>
                             </div>
                         </div>
+
+                        {categories.length > 0 && (
+                            <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
+                                <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                                    Category Notes
+                                </h2>
+                                <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                                    Add notes for specific categories on this menu. e.g. &quot;All steaks are 14-day aged and served with your choice of sides&quot;
+                                </p>
+
+                                <div className="mt-10 grid grid-cols-1 gap-x-6 gap-y-6 sm:grid-cols-6">
+                                    {categories.map((cat) => (
+                                        <div key={cat.id} className="sm:col-span-4 px-1">
+                                            <label
+                                                className="block text-sm/6 font-medium text-gray-900 dark:text-white capitalize"
+                                            >
+                                                {cat.name}
+                                            </label>
+                                            <div className="mt-2">
+                                                <Input
+                                                    placeholder={`Note for ${cat.name} (optional)`}
+                                                    value={form.watch("category_notes")?.[cat.id] || ""}
+                                                    onChange={(e) => {
+                                                        const current = form.getValues("category_notes") || {}
+                                                        if (e.target.value === "") {
+                                                            const { [cat.id]: _, ...rest } = current
+                                                            form.setValue("category_notes", rest, { shouldDirty: true })
+                                                        } else {
+                                                            form.setValue("category_notes", { ...current, [cat.id]: e.target.value }, { shouldDirty: true })
+                                                        }
+                                                    }}
+                                                    className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                />
+                                            </div>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
                     </div>
 
                     <div className="mt-6 flex items-center justify-end gap-x-6">

--- a/apps/admin-fnp/app/dashboard/restaurants/menus/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menus/new/page.tsx
@@ -1,0 +1,247 @@
+"use client"
+
+import Link from "next/link"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useMutation, useQuery } from "@tanstack/react-query"
+import { useForm } from "react-hook-form"
+import { useRouter } from "next/navigation"
+
+import { addMenu, queryRestaurantLocations } from "@/lib/query"
+import { FormMenuSchema, FormMenuModel, RestaurantLocation } from "@/lib/schemas"
+import { cn } from "@/lib/utilities"
+import { buttonVariants } from "@/components/ui/button"
+import { Icons } from "@/components/icons/lucide"
+import { toast } from "@/components/ui/use-toast"
+import { handleApiError } from "@/lib/error-handler"
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select"
+
+export default function NewMenuPage() {
+    const router = useRouter()
+
+    const { data: locationsData } = useQuery({
+        queryKey: ["locations-for-select"],
+        queryFn: () => queryRestaurantLocations({}),
+        refetchOnWindowFocus: false,
+    })
+
+    const locations = (locationsData?.data?.data as RestaurantLocation[]) || []
+
+    const form = useForm<FormMenuModel>({
+        defaultValues: {
+            location_id: "",
+            name: "",
+            note: "",
+            status: "active",
+        },
+        resolver: zodResolver(FormMenuSchema),
+    })
+
+    const { mutate, isPending } = useMutation({
+        mutationFn: addMenu,
+        onSuccess: () => {
+            toast({
+                description: "Menu added successfully",
+            })
+            router.push("/dashboard/restaurants/menus")
+        },
+        onError: (error) => {
+            handleApiError(error, {
+                context: "menu creation"
+            })
+        },
+    })
+
+    async function onSubmit(data: FormMenuModel) {
+        mutate(data)
+    }
+
+    return (
+        <div className="space-y-10">
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+                        Add Menu
+                    </h1>
+                    <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                        Create a new menu for a restaurant location.
+                    </p>
+                </div>
+                <Link
+                    href="/dashboard/restaurants/menus"
+                    className={cn(buttonVariants({ variant: "ghost" }))}
+                >
+                    <Icons.close className="w-4 h-4 mr-2" />
+                    Close
+                </Link>
+            </div>
+
+            <Form {...form}>
+                <form onSubmit={form.handleSubmit(onSubmit)}>
+                    <div className="space-y-12">
+                        <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
+                            <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                                Menu Information
+                            </h2>
+                            <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                                e.g. Breakfast Menu, Lunch Menu, Weekend Special
+                            </p>
+
+                            <div className="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+                                <div className="sm:col-span-4 px-1">
+                                    <label
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Location
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="location_id"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <Select onValueChange={field.onChange} defaultValue={field.value}>
+                                                        <FormControl>
+                                                            <SelectTrigger className="w-full">
+                                                                <SelectValue placeholder="Select a location" />
+                                                            </SelectTrigger>
+                                                        </FormControl>
+                                                        <SelectContent>
+                                                            {locations.map((loc) => (
+                                                                <SelectItem key={loc.id} value={loc.id}>
+                                                                    <span className="capitalize">{loc.name}</span>
+                                                                </SelectItem>
+                                                            ))}
+                                                        </SelectContent>
+                                                    </Select>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                </div>
+
+                                <div className="sm:col-span-4 px-1">
+                                    <label
+                                        htmlFor="name"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Menu Name
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="name"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Input
+                                                            id="name"
+                                                            placeholder="Enter menu name"
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                </div>
+
+                                <div className="sm:col-span-4 px-1">
+                                    <label
+                                        htmlFor="note"
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Note
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="note"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Input
+                                                            id="note"
+                                                            placeholder="e.g. Served until 11:00 AM"
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                </div>
+
+                                <div className="sm:col-span-4 px-1">
+                                    <label
+                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
+                                    >
+                                        Status
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="status"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <Select onValueChange={field.onChange} defaultValue={field.value}>
+                                                        <FormControl>
+                                                            <SelectTrigger className="w-full">
+                                                                <SelectValue placeholder="Select status" />
+                                                            </SelectTrigger>
+                                                        </FormControl>
+                                                        <SelectContent>
+                                                            <SelectItem value="active">Active</SelectItem>
+                                                            <SelectItem value="inactive">Inactive</SelectItem>
+                                                        </SelectContent>
+                                                    </Select>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="mt-6 flex items-center justify-end gap-x-6">
+                        <button
+                            type="button"
+                            onClick={() => router.push("/dashboard/restaurants/menus")}
+                            className="text-sm/6 font-semibold text-gray-900 dark:text-white"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={isPending}
+                            className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
+                        >
+                            {isPending && <Icons.spinner className="w-4 h-4 mr-2 animate-spin" />}
+                            Save
+                        </button>
+                    </div>
+                </form>
+            </Form>
+        </div>
+    )
+}

--- a/apps/admin-fnp/app/dashboard/restaurants/menus/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menus/page.tsx
@@ -1,0 +1,15 @@
+import { DashboardHeader } from "@/components/state/dashboardHeader"
+import { DashboardShell } from "@/components/state/dashboardShell"
+import { MenusTable } from "@/components/structures/tables/menus"
+
+export default async function MenusPage() {
+  return (
+    <DashboardShell>
+      <DashboardHeader
+        heading="Menus"
+        text="Manage restaurant menus."
+      ></DashboardHeader>
+      <MenusTable />
+    </DashboardShell>
+  )
+}

--- a/apps/admin-fnp/components/structures/columns/menu-item-categories.tsx
+++ b/apps/admin-fnp/components/structures/columns/menu-item-categories.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import { ColumnDef } from "@tanstack/react-table"
+import { MenuItemCategory } from "@/lib/schemas"
+import { Checkbox } from "@/components/ui/checkbox"
+import { MenuItemCategoryDropDown } from "@/components/structures/dropdowns/menu-item-category-dropdown"
+
+export const menuItemCategoryColumns: ColumnDef<MenuItemCategory>[] = [
+  {
+    id: "select",
+    header: ({ table }) => (
+      <Checkbox
+        checked={table.getIsAllPageRowsSelected()}
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Select all"
+        className="translate-y-[2px]"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label="Select row"
+        className="translate-y-[2px]"
+      />
+    ),
+    enableSorting: false,
+    enableHiding: false,
+  },
+  {
+    accessorKey: "name",
+    header: "Name",
+  },
+  {
+    accessorKey: "slug",
+    header: "Slug",
+  },
+  {
+    accessorKey: "created",
+    header: "Date Added",
+    cell: ({ row }) => {
+      const date = row.original.created
+      if (!date) return "-"
+      return new Date(date).toLocaleDateString("en-GB", {
+        day: "numeric",
+        month: "short",
+        year: "numeric",
+      })
+    },
+  },
+  {
+    id: "actions",
+    cell: ({ row }) => <MenuItemCategoryDropDown category={row.original} />,
+  },
+]

--- a/apps/admin-fnp/components/structures/columns/menu-item-components.tsx
+++ b/apps/admin-fnp/components/structures/columns/menu-item-components.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import { ColumnDef } from "@tanstack/react-table"
+import { MenuItemComponent } from "@/lib/schemas"
+import { Checkbox } from "@/components/ui/checkbox"
+import { MenuItemComponentDropDown } from "@/components/structures/dropdowns/menu-item-component-dropdown"
+
+export const menuItemComponentColumns: ColumnDef<MenuItemComponent>[] = [
+  {
+    id: "select",
+    header: ({ table }) => (
+      <Checkbox
+        checked={table.getIsAllPageRowsSelected()}
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Select all"
+        className="translate-y-[2px]"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label="Select row"
+        className="translate-y-[2px]"
+      />
+    ),
+    enableSorting: false,
+    enableHiding: false,
+  },
+  {
+    accessorKey: "name",
+    header: "Name",
+  },
+  {
+    accessorKey: "slug",
+    header: "Slug",
+  },
+  {
+    accessorKey: "status",
+    header: "Status",
+    cell: ({ row }) => (
+      <span className="capitalize">{row.original.status || "-"}</span>
+    ),
+  },
+  {
+    accessorKey: "created",
+    header: "Date Added",
+    cell: ({ row }) => {
+      const date = row.original.created
+      if (!date) return "-"
+      return new Date(date).toLocaleDateString("en-GB", {
+        day: "numeric",
+        month: "short",
+        year: "numeric",
+      })
+    },
+  },
+  {
+    id: "actions",
+    cell: ({ row }) => <MenuItemComponentDropDown component={row.original} />,
+  },
+]

--- a/apps/admin-fnp/components/structures/columns/menu-items.tsx
+++ b/apps/admin-fnp/components/structures/columns/menu-items.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import { ColumnDef } from "@tanstack/react-table"
+import { MenuItem } from "@/lib/schemas"
+import { centsToDollars } from "@/lib/utilities"
+import { Checkbox } from "@/components/ui/checkbox"
+import { MenuItemDropDown } from "@/components/structures/dropdowns/menu-item-dropdown"
+
+export const menuItemColumns: ColumnDef<MenuItem>[] = [
+  {
+    id: "select",
+    header: ({ table }) => (
+      <Checkbox
+        checked={table.getIsAllPageRowsSelected()}
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Select all"
+        className="translate-y-[2px]"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label="Select row"
+        className="translate-y-[2px]"
+      />
+    ),
+    enableSorting: false,
+    enableHiding: false,
+  },
+  {
+    accessorKey: "name",
+    header: "Name",
+  },
+  {
+    accessorKey: "price_cents",
+    header: "Price",
+    cell: ({ row }) => centsToDollars(row.original.price_cents || 0),
+  },
+  {
+    accessorKey: "category_name",
+    header: "Category",
+  },
+  {
+    accessorKey: "composition",
+    header: "Composition",
+    cell: ({ row }) => {
+      const composition = row.original.composition
+      if (!composition || composition.length === 0) return "-"
+      return composition.map(c => c.component_name).join(", ")
+    },
+  },
+  {
+    accessorKey: "status",
+    header: "Status",
+    cell: ({ row }) => (
+      <span className="capitalize">{row.original.status || "-"}</span>
+    ),
+  },
+  {
+    accessorKey: "created",
+    header: "Date Added",
+    cell: ({ row }) => {
+      const date = row.original.created
+      if (!date) return "-"
+      return new Date(date).toLocaleDateString("en-GB", {
+        day: "numeric",
+        month: "short",
+        year: "numeric",
+      })
+    },
+  },
+  {
+    id: "actions",
+    cell: ({ row }) => <MenuItemDropDown menuItem={row.original} />,
+  },
+]

--- a/apps/admin-fnp/components/structures/columns/menu-items.tsx
+++ b/apps/admin-fnp/components/structures/columns/menu-items.tsx
@@ -42,7 +42,17 @@ export const menuItemColumns: ColumnDef<MenuItem>[] = [
   {
     accessorKey: "price_cents",
     header: "Price",
-    cell: ({ row }) => centsToDollars(row.original.price_cents || 0),
+    cell: ({ row }) => {
+      const sizes = row.original.sizes
+      if (sizes && sizes.length > 0) {
+        const prices = sizes.map(s => s.price_cents)
+        const min = Math.min(...prices)
+        const max = Math.max(...prices)
+        if (min === max) return centsToDollars(min)
+        return `${centsToDollars(min)} – ${centsToDollars(max)}`
+      }
+      return centsToDollars(row.original.price_cents || 0)
+    },
   },
   {
     accessorKey: "category_name",
@@ -55,15 +65,6 @@ export const menuItemColumns: ColumnDef<MenuItem>[] = [
       const composition = row.original.composition
       if (!composition || composition.length === 0) return "-"
       return composition.map(c => c.component_name).join(", ")
-    },
-  },
-  {
-    accessorKey: "tags",
-    header: "Tags",
-    cell: ({ row }) => {
-      const tags = row.original.tags
-      if (!tags || tags.length === 0) return "-"
-      return tags.join(", ")
     },
   },
   {

--- a/apps/admin-fnp/components/structures/columns/menu-items.tsx
+++ b/apps/admin-fnp/components/structures/columns/menu-items.tsx
@@ -33,6 +33,13 @@ export const menuItemColumns: ColumnDef<MenuItem>[] = [
     header: "Name",
   },
   {
+    accessorKey: "menu_name",
+    header: "Menu",
+    cell: ({ row }) => (
+      <span className="capitalize">{row.original.menu_name || "-"}</span>
+    ),
+  },
+  {
     accessorKey: "price_cents",
     header: "Price",
     cell: ({ row }) => centsToDollars(row.original.price_cents || 0),
@@ -48,6 +55,15 @@ export const menuItemColumns: ColumnDef<MenuItem>[] = [
       const composition = row.original.composition
       if (!composition || composition.length === 0) return "-"
       return composition.map(c => c.component_name).join(", ")
+    },
+  },
+  {
+    accessorKey: "tags",
+    header: "Tags",
+    cell: ({ row }) => {
+      const tags = row.original.tags
+      if (!tags || tags.length === 0) return "-"
+      return tags.join(", ")
     },
   },
   {

--- a/apps/admin-fnp/components/structures/columns/menus.tsx
+++ b/apps/admin-fnp/components/structures/columns/menus.tsx
@@ -1,11 +1,11 @@
 "use client"
 
 import { ColumnDef } from "@tanstack/react-table"
-import { MenuItemComponent } from "@/lib/schemas"
+import { Menu } from "@/lib/schemas"
 import { Checkbox } from "@/components/ui/checkbox"
-import { MenuItemComponentDropDown } from "@/components/structures/dropdowns/menu-item-component-dropdown"
+import { MenuDropDown } from "@/components/structures/dropdowns/menu-dropdown"
 
-export const menuItemComponentColumns: ColumnDef<MenuItemComponent>[] = [
+export const menuColumns: ColumnDef<Menu>[] = [
   {
     id: "select",
     header: ({ table }) => (
@@ -32,8 +32,23 @@ export const menuItemComponentColumns: ColumnDef<MenuItemComponent>[] = [
     header: "Name",
   },
   {
-    accessorKey: "slug",
-    header: "Slug",
+    accessorKey: "note",
+    header: "Note",
+    cell: ({ row }) => row.original.note || "-",
+  },
+  {
+    accessorKey: "location_name",
+    header: "Location",
+    cell: ({ row }) => (
+      <span className="capitalize">{row.original.location_name || "-"}</span>
+    ),
+  },
+  {
+    accessorKey: "status",
+    header: "Status",
+    cell: ({ row }) => (
+      <span className="capitalize">{row.original.status || "-"}</span>
+    ),
   },
   {
     accessorKey: "created",
@@ -50,6 +65,6 @@ export const menuItemComponentColumns: ColumnDef<MenuItemComponent>[] = [
   },
   {
     id: "actions",
-    cell: ({ row }) => <MenuItemComponentDropDown component={row.original} />,
+    cell: ({ row }) => <MenuDropDown menu={row.original} />,
   },
 ]

--- a/apps/admin-fnp/components/structures/columns/menus.tsx
+++ b/apps/admin-fnp/components/structures/columns/menus.tsx
@@ -37,11 +37,20 @@ export const menuColumns: ColumnDef<Menu>[] = [
     cell: ({ row }) => row.original.note || "-",
   },
   {
-    accessorKey: "location_name",
+    accessorKey: "locations",
     header: "Location",
-    cell: ({ row }) => (
-      <span className="capitalize">{row.original.location_name || "-"}</span>
-    ),
+    cell: ({ row }) => {
+      const locations = row.original.locations
+      if (!locations || locations.length === 0) return "-"
+      if (locations.length === 1) {
+        return <span className="capitalize">{locations[0].location_name}</span>
+      }
+      return (
+        <span className="capitalize" title={locations.map((l) => l.location_name).join(", ")}>
+          {locations[0].location_name}, {locations.length - 1}+
+        </span>
+      )
+    },
   },
   {
     accessorKey: "status",

--- a/apps/admin-fnp/components/structures/dropdowns/menu-dropdown.tsx
+++ b/apps/admin-fnp/components/structures/dropdowns/menu-dropdown.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import Link from "next/link"
+import { MoreHorizontal } from "lucide-react"
+
+import { Menu } from "@/lib/schemas"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+interface MenuDropDownProps {
+  menu?: Menu
+}
+
+export function MenuDropDown({
+  menu,
+}: MenuDropDownProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className="w-8 h-8 p-0">
+          <span className="sr-only">Open menu</span>
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Actions</DropdownMenuLabel>
+        <DropdownMenuItem>
+          <Link
+            className="w-full"
+            href={`/dashboard/restaurants/menus/${menu?.id}/edit`}
+          >
+            Edit
+          </Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/admin-fnp/components/structures/dropdowns/menu-item-category-dropdown.tsx
+++ b/apps/admin-fnp/components/structures/dropdowns/menu-item-category-dropdown.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import Link from "next/link"
+import { MoreHorizontal } from "lucide-react"
+
+import { MenuItemCategory } from "@/lib/schemas"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+interface MenuItemCategoryDropDownProps {
+  category?: MenuItemCategory
+}
+
+export function MenuItemCategoryDropDown({
+  category,
+}: MenuItemCategoryDropDownProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className="w-8 h-8 p-0">
+          <span className="sr-only">Open menu</span>
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Actions</DropdownMenuLabel>
+        <DropdownMenuItem>
+          <Link
+            className="w-full"
+            href={`/dashboard/restaurants/menu-item-categories/${category?.id}/edit`}
+          >
+            Edit
+          </Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/admin-fnp/components/structures/dropdowns/menu-item-component-dropdown.tsx
+++ b/apps/admin-fnp/components/structures/dropdowns/menu-item-component-dropdown.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import Link from "next/link"
+import { MoreHorizontal } from "lucide-react"
+
+import { MenuItemComponent } from "@/lib/schemas"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+interface MenuItemComponentDropDownProps {
+  component?: MenuItemComponent
+}
+
+export function MenuItemComponentDropDown({
+  component,
+}: MenuItemComponentDropDownProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className="w-8 h-8 p-0">
+          <span className="sr-only">Open menu</span>
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Actions</DropdownMenuLabel>
+        <DropdownMenuItem>
+          <Link
+            className="w-full"
+            href={`/dashboard/restaurants/menu-item-components/${component?.id}/edit`}
+          >
+            Edit
+          </Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/admin-fnp/components/structures/dropdowns/menu-item-dropdown.tsx
+++ b/apps/admin-fnp/components/structures/dropdowns/menu-item-dropdown.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import Link from "next/link"
+import { MoreHorizontal } from "lucide-react"
+
+import { MenuItem } from "@/lib/schemas"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+interface MenuItemDropDownProps {
+  menuItem?: MenuItem
+}
+
+export function MenuItemDropDown({
+  menuItem,
+}: MenuItemDropDownProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className="w-8 h-8 p-0">
+          <span className="sr-only">Open menu</span>
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Actions</DropdownMenuLabel>
+        <DropdownMenuItem>
+          <Link
+            className="w-full"
+            href={`/dashboard/restaurants/menu-items/${menuItem?.id}/edit`}
+          >
+            Edit
+          </Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/admin-fnp/components/structures/tables/menu-item-categories.tsx
+++ b/apps/admin-fnp/components/structures/tables/menu-item-categories.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import { useState, useEffect, useRef } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { PaginationState } from "@tanstack/react-table"
+
+import { queryMenuItemCategories } from "@/lib/query"
+import { MenuItemCategory } from "@/lib/schemas"
+import { handleFetchError } from "@/lib/error-handler"
+import { Placeholder } from "@/components/state/placeholder"
+import { DataTable } from "@/components/structures/data-table"
+import { menuItemCategoryColumns } from "@/components/structures/columns/menu-item-categories"
+
+export function MenuItemCategoriesTable() {
+  const [search, setSearch] = useState("")
+
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 10,
+  })
+
+  const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
+    queryKey: ["dashboard-menu-item-categories", { p: pagination.pageIndex + 1, search }],
+    queryFn: () =>
+      queryMenuItemCategories({
+        p: pagination.pageIndex + 1,
+        search: search,
+      }),
+    refetchOnWindowFocus: false
+  })
+
+  const categories = data?.data?.data as MenuItemCategory[]
+  const total = data?.data?.total as number
+
+  const hasShownError = useRef(false)
+  useEffect(() => {
+    if (isError && !hasShownError.current) {
+      hasShownError.current = true
+      handleFetchError(error, {
+        onRetry: () => {
+          hasShownError.current = false
+          refetch()
+        },
+        context: "menu item categories"
+      })
+    }
+    if (!isError) {
+      hasShownError.current = false
+    }
+  }, [isError, error, refetch])
+
+  if (isError) {
+    return (
+      <Placeholder>
+        <Placeholder.Icon name="close" />
+        <Placeholder.Title>Error Fetching Categories</Placeholder.Title>
+        <Placeholder.Description>
+          Error fetching menu item categories from the database
+        </Placeholder.Description>
+      </Placeholder>
+    )
+  }
+
+  if (isLoading || isFetching) {
+    return (
+      <Placeholder>
+        <Placeholder.Title>Fetching Categories</Placeholder.Title>
+      </Placeholder>
+    )
+  }
+
+  return (
+    <DataTable
+      columns={menuItemCategoryColumns}
+      data={categories}
+      newUrl="/dashboard/restaurants/menu-item-categories/new"
+      tableName="Category"
+      total={total}
+      pagination={pagination}
+      setPagination={setPagination}
+      search={search}
+      setSearch={setSearch}
+    />
+  )
+}

--- a/apps/admin-fnp/components/structures/tables/menu-item-components.tsx
+++ b/apps/admin-fnp/components/structures/tables/menu-item-components.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import { useState, useEffect, useRef } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { PaginationState } from "@tanstack/react-table"
+
+import { queryMenuItemComponents } from "@/lib/query"
+import { MenuItemComponent } from "@/lib/schemas"
+import { handleFetchError } from "@/lib/error-handler"
+import { Placeholder } from "@/components/state/placeholder"
+import { DataTable } from "@/components/structures/data-table"
+import { menuItemComponentColumns } from "@/components/structures/columns/menu-item-components"
+
+export function MenuItemComponentsTable() {
+  const [search, setSearch] = useState("")
+
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 10,
+  })
+
+  const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
+    queryKey: ["dashboard-menu-item-components", { p: pagination.pageIndex + 1, search }],
+    queryFn: () =>
+      queryMenuItemComponents({
+        p: pagination.pageIndex + 1,
+        search: search,
+      }),
+    refetchOnWindowFocus: false
+  })
+
+  const components = data?.data?.data as MenuItemComponent[]
+  const total = data?.data?.total as number
+
+  const hasShownError = useRef(false)
+  useEffect(() => {
+    if (isError && !hasShownError.current) {
+      hasShownError.current = true
+      handleFetchError(error, {
+        onRetry: () => {
+          hasShownError.current = false
+          refetch()
+        },
+        context: "menu item components"
+      })
+    }
+    if (!isError) {
+      hasShownError.current = false
+    }
+  }, [isError, error, refetch])
+
+  if (isError) {
+    return (
+      <Placeholder>
+        <Placeholder.Icon name="close" />
+        <Placeholder.Title>Error Fetching Components</Placeholder.Title>
+        <Placeholder.Description>
+          Error fetching menu item components from the database
+        </Placeholder.Description>
+      </Placeholder>
+    )
+  }
+
+  if (isLoading || isFetching) {
+    return (
+      <Placeholder>
+        <Placeholder.Title>Fetching Components</Placeholder.Title>
+      </Placeholder>
+    )
+  }
+
+  return (
+    <DataTable
+      columns={menuItemComponentColumns}
+      data={components}
+      newUrl="/dashboard/restaurants/menu-item-components/new"
+      tableName="Component"
+      total={total}
+      pagination={pagination}
+      setPagination={setPagination}
+      search={search}
+      setSearch={setSearch}
+    />
+  )
+}

--- a/apps/admin-fnp/components/structures/tables/menu-items.tsx
+++ b/apps/admin-fnp/components/structures/tables/menu-items.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from "react"
 import { useQuery } from "@tanstack/react-query"
 import { PaginationState } from "@tanstack/react-table"
+import { useDebounce } from "use-debounce"
 
 import { queryMenuItems } from "@/lib/query"
 import { MenuItem } from "@/lib/schemas"
@@ -13,6 +14,7 @@ import { menuItemColumns } from "@/components/structures/columns/menu-items"
 
 export function MenuItemsTable() {
   const [search, setSearch] = useState("")
+  const [debouncedSearch] = useDebounce(search, 500)
 
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
@@ -20,11 +22,11 @@ export function MenuItemsTable() {
   })
 
   const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
-    queryKey: ["dashboard-menu-items", { p: pagination.pageIndex + 1, search }],
+    queryKey: ["dashboard-menu-items", { p: pagination.pageIndex + 1, search: debouncedSearch }],
     queryFn: () =>
       queryMenuItems({
         p: pagination.pageIndex + 1,
-        search: search,
+        search: debouncedSearch,
       }),
     refetchOnWindowFocus: false
   })

--- a/apps/admin-fnp/components/structures/tables/menu-items.tsx
+++ b/apps/admin-fnp/components/structures/tables/menu-items.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import { useState, useEffect, useRef } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { PaginationState } from "@tanstack/react-table"
+
+import { queryMenuItems } from "@/lib/query"
+import { MenuItem } from "@/lib/schemas"
+import { handleFetchError } from "@/lib/error-handler"
+import { Placeholder } from "@/components/state/placeholder"
+import { DataTable } from "@/components/structures/data-table"
+import { menuItemColumns } from "@/components/structures/columns/menu-items"
+
+export function MenuItemsTable() {
+  const [search, setSearch] = useState("")
+
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 10,
+  })
+
+  const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
+    queryKey: ["dashboard-menu-items", { p: pagination.pageIndex + 1, search }],
+    queryFn: () =>
+      queryMenuItems({
+        p: pagination.pageIndex + 1,
+        search: search,
+      }),
+    refetchOnWindowFocus: false
+  })
+
+  const menuItems = data?.data?.data as MenuItem[]
+  const total = data?.data?.total as number
+
+  const hasShownError = useRef(false)
+  useEffect(() => {
+    if (isError && !hasShownError.current) {
+      hasShownError.current = true
+      handleFetchError(error, {
+        onRetry: () => {
+          hasShownError.current = false
+          refetch()
+        },
+        context: "menu items"
+      })
+    }
+    if (!isError) {
+      hasShownError.current = false
+    }
+  }, [isError, error, refetch])
+
+  if (isError) {
+    return (
+      <Placeholder>
+        <Placeholder.Icon name="close" />
+        <Placeholder.Title>Error Fetching Menu Items</Placeholder.Title>
+        <Placeholder.Description>
+          Error fetching menu items from the database
+        </Placeholder.Description>
+      </Placeholder>
+    )
+  }
+
+  if (isLoading || isFetching) {
+    return (
+      <Placeholder>
+        <Placeholder.Title>Fetching Menu Items</Placeholder.Title>
+      </Placeholder>
+    )
+  }
+
+  return (
+    <DataTable
+      columns={menuItemColumns}
+      data={menuItems}
+      newUrl="/dashboard/restaurants/menu-items/new"
+      tableName="Menu Item"
+      total={total}
+      pagination={pagination}
+      setPagination={setPagination}
+      search={search}
+      setSearch={setSearch}
+    />
+  )
+}

--- a/apps/admin-fnp/components/structures/tables/menus.tsx
+++ b/apps/admin-fnp/components/structures/tables/menus.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import { useState, useEffect, useRef } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { PaginationState } from "@tanstack/react-table"
+
+import { queryMenus } from "@/lib/query"
+import { Menu } from "@/lib/schemas"
+import { handleFetchError } from "@/lib/error-handler"
+import { Placeholder } from "@/components/state/placeholder"
+import { DataTable } from "@/components/structures/data-table"
+import { menuColumns } from "@/components/structures/columns/menus"
+
+export function MenusTable() {
+  const [search, setSearch] = useState("")
+
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 10,
+  })
+
+  const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
+    queryKey: ["dashboard-menus", { p: pagination.pageIndex + 1, search }],
+    queryFn: () =>
+      queryMenus({
+        p: pagination.pageIndex + 1,
+        search: search,
+      }),
+    refetchOnWindowFocus: false
+  })
+
+  const menus = data?.data?.data as Menu[]
+  const total = data?.data?.total as number
+
+  const hasShownError = useRef(false)
+  useEffect(() => {
+    if (isError && !hasShownError.current) {
+      hasShownError.current = true
+      handleFetchError(error, {
+        onRetry: () => {
+          hasShownError.current = false
+          refetch()
+        },
+        context: "menus"
+      })
+    }
+    if (!isError) {
+      hasShownError.current = false
+    }
+  }, [isError, error, refetch])
+
+  if (isError) {
+    return (
+      <Placeholder>
+        <Placeholder.Icon name="close" />
+        <Placeholder.Title>Error Fetching Menus</Placeholder.Title>
+        <Placeholder.Description>
+          Error fetching menus from the database
+        </Placeholder.Description>
+      </Placeholder>
+    )
+  }
+
+  if (isLoading || isFetching) {
+    return (
+      <Placeholder>
+        <Placeholder.Title>Fetching Menus</Placeholder.Title>
+      </Placeholder>
+    )
+  }
+
+  return (
+    <DataTable
+      columns={menuColumns}
+      data={menus}
+      newUrl="/dashboard/restaurants/menus/new"
+      tableName="Menu"
+      total={total}
+      pagination={pagination}
+      setPagination={setPagination}
+      search={search}
+      setSearch={setSearch}
+    />
+  )
+}

--- a/apps/admin-fnp/config/restaurants-dashboard.ts
+++ b/apps/admin-fnp/config/restaurants-dashboard.ts
@@ -18,5 +18,25 @@ export const restaurantsDashboardConfig: DashboardConfig = {
         },
       ],
     },
+    {
+      label: "Menu Catalog",
+      items: [
+        {
+          title: "Categories",
+          href: "/dashboard/restaurants/menu-item-categories",
+          icon: "layers",
+        },
+        {
+          title: "Components",
+          href: "/dashboard/restaurants/menu-item-components",
+          icon: "layers",
+        },
+        {
+          title: "Menu Items",
+          href: "/dashboard/restaurants/menu-items",
+          icon: "layers",
+        },
+      ],
+    },
   ],
 }

--- a/apps/admin-fnp/config/restaurants-dashboard.ts
+++ b/apps/admin-fnp/config/restaurants-dashboard.ts
@@ -24,17 +24,22 @@ export const restaurantsDashboardConfig: DashboardConfig = {
         {
           title: "Categories",
           href: "/dashboard/restaurants/menu-item-categories",
-          icon: "layers",
+          icon: "tag",
         },
         {
           title: "Components",
           href: "/dashboard/restaurants/menu-item-components",
-          icon: "layers",
+          icon: "egg",
+        },
+        {
+          title: "Menus",
+          href: "/dashboard/restaurants/menus",
+          icon: "clipboardList",
         },
         {
           title: "Menu Items",
           href: "/dashboard/restaurants/menu-items",
-          icon: "layers",
+          icon: "utensilsCrossed",
         },
       ],
     },

--- a/apps/admin-fnp/lib/query.ts
+++ b/apps/admin-fnp/lib/query.ts
@@ -43,6 +43,7 @@ export function queryLogin(data: LoginFormData) {
 type pagination = {
   p?: number
   search?: string
+  limit?: number
   type?: string[]
   category?: string[]
   produce?: string[]
@@ -994,6 +995,9 @@ export function queryMenuItemCategories(pagination?: pagination) {
   }
   if (pagination?.search !== undefined && pagination.search.length >= 2) {
     params.set("search", pagination.search)
+  }
+  if (pagination?.limit !== undefined) {
+    params.set("limit", String(pagination.limit))
   }
   const qs = params.toString()
   const url = `${baseUrl}/menu-item-categories/list${qs ? `?${qs}` : ""}`

--- a/apps/admin-fnp/lib/query.ts
+++ b/apps/admin-fnp/lib/query.ts
@@ -1054,9 +1054,51 @@ export function deleteMenuItemComponent(id: string) {
   return api.delete(url)
 }
 
+// Menus
+type menuPagination = pagination & {
+  location_id?: string
+}
+
+export function queryMenus(pagination?: menuPagination) {
+  const params = new URLSearchParams()
+  if (pagination?.p !== undefined && pagination.p >= 2) {
+    params.set("p", String(pagination.p))
+  }
+  if (pagination?.search !== undefined && pagination.search.length >= 2) {
+    params.set("search", pagination.search)
+  }
+  if (pagination?.location_id) {
+    params.set("location_id", pagination.location_id)
+  }
+  const qs = params.toString()
+  const url = `${baseUrl}/menus/list${qs ? `?${qs}` : ""}`
+  return api.get(url)
+}
+
+export function queryMenu(id: string) {
+  let url = `${baseUrl}/menus/get/${id}`
+  return api.get(url)
+}
+
+export function addMenu(data: any) {
+  let url = `${baseUrl}/menus/add`
+  return api.post(url, data)
+}
+
+export function updateMenu(data: any) {
+  let url = `${baseUrl}/menus/update`
+  return api.post(url, data)
+}
+
+export function deleteMenu(id: string) {
+  let url = `${baseUrl}/menus/delete/${id}`
+  return api.delete(url)
+}
+
 // Menu Items
 type menuItemPagination = pagination & {
   category_id?: string
+  menu_id?: string
 }
 
 export function queryMenuItems(pagination?: menuItemPagination) {
@@ -1069,6 +1111,9 @@ export function queryMenuItems(pagination?: menuItemPagination) {
   }
   if (pagination?.category_id) {
     params.set("category_id", pagination.category_id)
+  }
+  if (pagination?.menu_id) {
+    params.set("menu_id", pagination.menu_id)
   }
   const qs = params.toString()
   const url = `${baseUrl}/menu-items/list${qs ? `?${qs}` : ""}`

--- a/apps/admin-fnp/lib/query.ts
+++ b/apps/admin-fnp/lib/query.ts
@@ -985,3 +985,112 @@ export function deleteRestaurantLocation(id: string) {
   let url = `${baseUrl}/restaurant-locations/delete/${id}`
   return api.delete(url)
 }
+
+// Menu Item Categories
+export function queryMenuItemCategories(pagination?: pagination) {
+  const params = new URLSearchParams()
+  if (pagination?.p !== undefined && pagination.p >= 2) {
+    params.set("p", String(pagination.p))
+  }
+  if (pagination?.search !== undefined && pagination.search.length >= 2) {
+    params.set("search", pagination.search)
+  }
+  const qs = params.toString()
+  const url = `${baseUrl}/menu-item-categories/list${qs ? `?${qs}` : ""}`
+  return api.get(url)
+}
+
+export function queryMenuItemCategory(id: string) {
+  let url = `${baseUrl}/menu-item-categories/get/${id}`
+  return api.get(url)
+}
+
+export function addMenuItemCategory(data: { name: string }) {
+  let url = `${baseUrl}/menu-item-categories/add`
+  return api.post(url, data)
+}
+
+export function updateMenuItemCategory(data: { id: string; name: string }) {
+  let url = `${baseUrl}/menu-item-categories/update`
+  return api.post(url, data)
+}
+
+export function deleteMenuItemCategory(id: string) {
+  let url = `${baseUrl}/menu-item-categories/delete/${id}`
+  return api.delete(url)
+}
+
+// Menu Item Components
+export function queryMenuItemComponents(pagination?: pagination) {
+  const params = new URLSearchParams()
+  if (pagination?.p !== undefined && pagination.p >= 2) {
+    params.set("p", String(pagination.p))
+  }
+  if (pagination?.search !== undefined && pagination.search.length >= 2) {
+    params.set("search", pagination.search)
+  }
+  const qs = params.toString()
+  const url = `${baseUrl}/menu-item-components/list${qs ? `?${qs}` : ""}`
+  return api.get(url)
+}
+
+export function queryMenuItemComponent(id: string) {
+  let url = `${baseUrl}/menu-item-components/get/${id}`
+  return api.get(url)
+}
+
+export function addMenuItemComponent(data: { name: string; status: string }) {
+  let url = `${baseUrl}/menu-item-components/add`
+  return api.post(url, data)
+}
+
+export function updateMenuItemComponent(data: { id: string; name: string; status: string }) {
+  let url = `${baseUrl}/menu-item-components/update`
+  return api.post(url, data)
+}
+
+export function deleteMenuItemComponent(id: string) {
+  let url = `${baseUrl}/menu-item-components/delete/${id}`
+  return api.delete(url)
+}
+
+// Menu Items
+type menuItemPagination = pagination & {
+  category_id?: string
+}
+
+export function queryMenuItems(pagination?: menuItemPagination) {
+  const params = new URLSearchParams()
+  if (pagination?.p !== undefined && pagination.p >= 2) {
+    params.set("p", String(pagination.p))
+  }
+  if (pagination?.search !== undefined && pagination.search.length >= 2) {
+    params.set("search", pagination.search)
+  }
+  if (pagination?.category_id) {
+    params.set("category_id", pagination.category_id)
+  }
+  const qs = params.toString()
+  const url = `${baseUrl}/menu-items/list${qs ? `?${qs}` : ""}`
+  return api.get(url)
+}
+
+export function queryMenuItem(id: string) {
+  let url = `${baseUrl}/menu-items/get/${id}`
+  return api.get(url)
+}
+
+export function addMenuItem(data: any) {
+  let url = `${baseUrl}/menu-items/add`
+  return api.post(url, data)
+}
+
+export function updateMenuItem(data: any) {
+  let url = `${baseUrl}/menu-items/update`
+  return api.post(url, data)
+}
+
+export function deleteMenuItem(id: string) {
+  let url = `${baseUrl}/menu-items/delete/${id}`
+  return api.delete(url)
+}

--- a/apps/admin-fnp/lib/schemas.ts
+++ b/apps/admin-fnp/lib/schemas.ts
@@ -1132,3 +1132,86 @@ export type RestaurantLocationResponse = {
   total: number
   data: RestaurantLocation[]
 }
+
+// Menu Item Category
+export const MenuItemCategorySchema = z.object({
+  id: z.string(),
+  name: z.string().min(1, "Name is required").max(120, "Name cannot exceed 120 characters"),
+  slug: z.string().optional(),
+  created: z.string().optional(),
+  updated: z.string().optional(),
+})
+
+export const FormMenuItemCategorySchema = MenuItemCategorySchema.pick({
+  name: true,
+})
+
+export type MenuItemCategory = z.infer<typeof MenuItemCategorySchema>
+export type FormMenuItemCategoryModel = z.infer<typeof FormMenuItemCategorySchema>
+
+export type MenuItemCategoryResponse = {
+  total: number
+  data: MenuItemCategory[]
+}
+
+// Menu Item Component
+export const MenuItemComponentSchema = z.object({
+  id: z.string(),
+  name: z.string().min(1, "Name is required").max(120, "Name cannot exceed 120 characters"),
+  slug: z.string().optional(),
+  status: z.enum(["active", "inactive"]).default("active"),
+  created: z.string().optional(),
+  updated: z.string().optional(),
+})
+
+export const FormMenuItemComponentSchema = MenuItemComponentSchema.pick({
+  name: true,
+  status: true,
+})
+
+export type MenuItemComponent = z.infer<typeof MenuItemComponentSchema>
+export type FormMenuItemComponentModel = z.infer<typeof FormMenuItemComponentSchema>
+
+export type MenuItemComponentResponse = {
+  total: number
+  data: MenuItemComponent[]
+}
+
+// Menu Item
+export const CompositionEntrySchema = z.object({
+  component_id: z.string(),
+  component_name: z.string(),
+})
+
+export const MenuItemSchema = z.object({
+  id: z.string(),
+  name: z.string().min(1, "Name is required").max(120, "Name cannot exceed 120 characters"),
+  slug: z.string().optional(),
+  description: z.string().optional().default(""),
+  price_cents: z.number().default(0),
+  category_id: z.string().min(1, "Category is required"),
+  category_name: z.string().optional(),
+  composition: z.array(CompositionEntrySchema).default([]),
+  status: z.enum(["active", "inactive"]).default("active"),
+  created: z.string().optional(),
+  updated: z.string().optional(),
+})
+
+export const FormMenuItemSchema = MenuItemSchema.pick({
+  name: true,
+  description: true,
+  price_cents: true,
+  category_id: true,
+  status: true,
+}).extend({
+  composition: z.array(CompositionEntrySchema).default([]),
+})
+
+export type CompositionEntry = z.infer<typeof CompositionEntrySchema>
+export type MenuItem = z.infer<typeof MenuItemSchema>
+export type FormMenuItemModel = z.infer<typeof FormMenuItemSchema>
+
+export type MenuItemResponse = {
+  total: number
+  data: MenuItem[]
+}

--- a/apps/admin-fnp/lib/schemas.ts
+++ b/apps/admin-fnp/lib/schemas.ts
@@ -1134,24 +1134,33 @@ export type RestaurantLocationResponse = {
 }
 
 // Menu
+export const MenuLocationEntrySchema = z.object({
+  location_id: z.string(),
+  location_name: z.string(),
+})
+
 export const MenuSchema = z.object({
   id: z.string(),
-  location_id: z.string().min(1, "Location is required"),
-  location_name: z.string().optional(),
+  locations: z.array(MenuLocationEntrySchema).default([]),
   name: z.string().min(1, "Menu name is required").max(120, "Name cannot exceed 120 characters"),
   note: z.string().optional().default(""),
   slug: z.string().optional(),
+  category_notes: z.record(z.string(), z.string()).optional().default({}),
   status: z.enum(["active", "inactive"]).default("active"),
   created: z.string().optional(),
   updated: z.string().optional(),
 })
 
 export const FormMenuSchema = MenuSchema.pick({
-  location_id: true,
   name: true,
   note: true,
   status: true,
+}).extend({
+  locations: z.array(MenuLocationEntrySchema).default([]),
+  category_notes: z.record(z.string(), z.string()).optional().default({}),
 })
+
+export type MenuLocationEntry = z.infer<typeof MenuLocationEntrySchema>
 
 export type Menu = z.infer<typeof MenuSchema>
 export type FormMenuModel = z.infer<typeof FormMenuSchema>
@@ -1209,6 +1218,11 @@ export const CompositionEntrySchema = z.object({
   component_name: z.string(),
 })
 
+export const MenuItemSizeSchema = z.object({
+  name: z.string().min(1),
+  price_cents: z.number().default(0),
+})
+
 export const MenuItemSchema = z.object({
   id: z.string(),
   menu_id: z.string().min(1, "Menu is required"),
@@ -1220,6 +1234,7 @@ export const MenuItemSchema = z.object({
   category_id: z.string().min(1, "Category is required"),
   category_name: z.string().optional(),
   composition: z.array(CompositionEntrySchema).default([]),
+  sizes: z.array(MenuItemSizeSchema).default([]),
   tags: z.array(z.string()).default([]),
   status: z.enum(["active", "inactive"]).default("active"),
   created: z.string().optional(),
@@ -1235,6 +1250,7 @@ export const FormMenuItemSchema = MenuItemSchema.pick({
   status: true,
 }).extend({
   composition: z.array(CompositionEntrySchema).default([]),
+  sizes: z.array(MenuItemSizeSchema).default([]),
   tags: z.array(z.string()).default([]),
 })
 

--- a/apps/admin-fnp/lib/schemas.ts
+++ b/apps/admin-fnp/lib/schemas.ts
@@ -1133,6 +1133,34 @@ export type RestaurantLocationResponse = {
   data: RestaurantLocation[]
 }
 
+// Menu
+export const MenuSchema = z.object({
+  id: z.string(),
+  location_id: z.string().min(1, "Location is required"),
+  location_name: z.string().optional(),
+  name: z.string().min(1, "Menu name is required").max(120, "Name cannot exceed 120 characters"),
+  note: z.string().optional().default(""),
+  slug: z.string().optional(),
+  status: z.enum(["active", "inactive"]).default("active"),
+  created: z.string().optional(),
+  updated: z.string().optional(),
+})
+
+export const FormMenuSchema = MenuSchema.pick({
+  location_id: true,
+  name: true,
+  note: true,
+  status: true,
+})
+
+export type Menu = z.infer<typeof MenuSchema>
+export type FormMenuModel = z.infer<typeof FormMenuSchema>
+
+export type MenuResponse = {
+  total: number
+  data: Menu[]
+}
+
 // Menu Item Category
 export const MenuItemCategorySchema = z.object({
   id: z.string(),
@@ -1159,14 +1187,12 @@ export const MenuItemComponentSchema = z.object({
   id: z.string(),
   name: z.string().min(1, "Name is required").max(120, "Name cannot exceed 120 characters"),
   slug: z.string().optional(),
-  status: z.enum(["active", "inactive"]).default("active"),
   created: z.string().optional(),
   updated: z.string().optional(),
 })
 
 export const FormMenuItemComponentSchema = MenuItemComponentSchema.pick({
   name: true,
-  status: true,
 })
 
 export type MenuItemComponent = z.infer<typeof MenuItemComponentSchema>
@@ -1185,6 +1211,8 @@ export const CompositionEntrySchema = z.object({
 
 export const MenuItemSchema = z.object({
   id: z.string(),
+  menu_id: z.string().min(1, "Menu is required"),
+  menu_name: z.string().optional(),
   name: z.string().min(1, "Name is required").max(120, "Name cannot exceed 120 characters"),
   slug: z.string().optional(),
   description: z.string().optional().default(""),
@@ -1192,12 +1220,14 @@ export const MenuItemSchema = z.object({
   category_id: z.string().min(1, "Category is required"),
   category_name: z.string().optional(),
   composition: z.array(CompositionEntrySchema).default([]),
+  tags: z.array(z.string()).default([]),
   status: z.enum(["active", "inactive"]).default("active"),
   created: z.string().optional(),
   updated: z.string().optional(),
 })
 
 export const FormMenuItemSchema = MenuItemSchema.pick({
+  menu_id: true,
   name: true,
   description: true,
   price_cents: true,
@@ -1205,6 +1235,7 @@ export const FormMenuItemSchema = MenuItemSchema.pick({
   status: true,
 }).extend({
   composition: z.array(CompositionEntrySchema).default([]),
+  tags: z.array(z.string()).default([]),
 })
 
 export type CompositionEntry = z.infer<typeof CompositionEntrySchema>


### PR DESCRIPTION
## Summary
- Update menu forms to support multiple locations (checkboxes) and per-category notes
- Add size options UI to menu item new and edit pages (dynamic rows with name + price)
- Update price column in menu items table to show range for items with sizes
- Remove deprecated note field from menu item category forms
- Update schemas with MenuItemSize, LocationEntry, and category_notes support

## Test Plan
- [ ] Create/edit menus with multiple locations and category notes
- [ ] Add/edit menu items with size variants
- [ ] Verify price range display in menu items table
- [ ] Verify menu item category forms no longer show note field