### PR TITLE
Add admin sales dashboard and order management UI

### DIFF
--- a/apps/admin-fnp/app/dashboard/farmnport/layout.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/layout.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link"
 import { dashboardConfig } from "@/config/dashboard"
 import { AccountNavigation } from "@/components/navigation/account"
+import { NotificationBell } from "@/components/notifications/notification-bell"
 import { SidebarNavigation } from "@/components/navigation/sidebar"
 import { ScrollArea } from "@/components/ui/scroll-area"
 
@@ -18,7 +19,10 @@ export default async function DashboardLayout({
           <Link href="/dashboard" className="text-sm font-medium hover:text-muted-foreground transition-colors">
             farmnport
           </Link>
-          <AccountNavigation />
+          <div className="flex items-center gap-2">
+            <NotificationBell />
+            <AccountNavigation />
+          </div>
         </div>
       </header>
       <div className="max-w-full flex flex-1 px-8">

--- a/apps/admin-fnp/app/dashboard/farmnport/sales/orders/[id]/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/sales/orders/[id]/page.tsx
@@ -1,0 +1,459 @@
+"use client"
+
+import { useParams, useRouter } from "next/navigation"
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { format } from "date-fns"
+import {
+  ArrowLeft,
+  Package,
+  Truck,
+  CheckCircle2,
+  XCircle,
+  Clock,
+  CreditCard,
+} from "lucide-react"
+import Link from "next/link"
+
+import { queryOrder, updateOrderStatus } from "@/lib/query"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Separator } from "@/components/ui/separator"
+import { useToast } from "@/components/ui/use-toast"
+
+const STATUS_STEPS = ["pending", "paid", "processing", "dispatched", "delivered"]
+const STATUS_STEPS_COLLECT = ["pending", "paid", "processing", "ready", "delivered"]
+
+const STATUS_COLORS: Record<string, string> = {
+  pending: "bg-yellow-100 text-yellow-800",
+  paid: "bg-blue-100 text-blue-800",
+  processing: "bg-purple-100 text-purple-800",
+  dispatched: "bg-indigo-100 text-indigo-800",
+  ready: "bg-teal-100 text-teal-800",
+  delivered: "bg-green-100 text-green-800",
+  cancelled: "bg-red-100 text-red-800",
+}
+
+const STATUS_ICONS: Record<string, React.ReactNode> = {
+  pending: <Clock className="h-4 w-4" />,
+  paid: <CreditCard className="h-4 w-4" />,
+  processing: <Package className="h-4 w-4" />,
+  dispatched: <Truck className="h-4 w-4" />,
+  ready: <CheckCircle2 className="h-4 w-4" />,
+  delivered: <CheckCircle2 className="h-4 w-4" />,
+  cancelled: <XCircle className="h-4 w-4" />,
+}
+
+interface OrderItem {
+  product_id: string
+  product_name: string
+  product_slug: string
+  quantity: number
+  unit_price: number
+  line_total: number
+  image_src: string
+}
+
+interface StatusChange {
+  from: string
+  to: string
+  changed_by: string
+  note: string
+  timestamp: string
+}
+
+interface DeliveryAddress {
+  name: string
+  phone: string
+  address: string
+  city: string
+  province: string
+}
+
+interface Order {
+  id: string
+  order_number: string
+  client_id: string
+  client_name: string
+  client_first_name: string
+  client_last_name: string
+  client_email: string
+  client_phone: string
+  order_type: string
+  status: string
+  items: OrderItem[]
+  subtotal: number
+  delivery_fee: number
+  total: number
+  currency: string
+  fulfillment: string
+  delivery_address?: DeliveryAddress
+  payment_provider: string
+  payment_method: string
+  payment_ref: string
+  paid_at?: string
+  verify_token: string
+  status_history: StatusChange[]
+  notes?: string
+  admin_notes?: string
+  delivered_at?: string
+  created: string
+  updated: string
+}
+
+function getNextActions(
+  status: string,
+  fulfillment: string
+): { label: string; status: string; variant: "default" | "destructive" }[] {
+  const actions: { label: string; status: string; variant: "default" | "destructive" }[] = []
+
+  switch (status) {
+    case "paid":
+      actions.push({ label: "Acknowledge Order", status: "processing", variant: "default" })
+      break
+    case "processing":
+      if (fulfillment === "click_collect") {
+        actions.push({ label: "Ready for Pickup", status: "ready", variant: "default" })
+      } else {
+        actions.push({ label: "Mark Dispatched", status: "dispatched", variant: "default" })
+      }
+      break
+    case "dispatched":
+    case "ready":
+      actions.push({ label: "Mark Delivered", status: "delivered", variant: "default" })
+      break
+  }
+
+  if (status !== "delivered" && status !== "cancelled") {
+    actions.push({ label: "Cancel Order", status: "cancelled", variant: "destructive" })
+  }
+
+  return actions
+}
+
+export default function OrderDetailPage() {
+  const params = useParams()
+  const router = useRouter()
+  const queryClient = useQueryClient()
+  const { toast } = useToast()
+
+  const orderId = params.id as string
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["admin-order", orderId],
+    queryFn: () => queryOrder(orderId),
+    refetchOnWindowFocus: false,
+  })
+
+  const statusMutation = useMutation({
+    mutationFn: (newStatus: string) =>
+      updateOrderStatus({ order_id: orderId, status: newStatus }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin-order", orderId] })
+      queryClient.invalidateQueries({ queryKey: ["admin-orders"] })
+      queryClient.invalidateQueries({ queryKey: ["notifications"] })
+      toast({ title: "Order status updated" })
+    },
+    onError: () => {
+      toast({ title: "Failed to update status", variant: "destructive" })
+    },
+  })
+
+  const order: Order | undefined = data?.data
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-6">
+        <Skeleton className="h-8 w-64" />
+        <div className="grid gap-4 md:grid-cols-2">
+          <Skeleton className="h-48" />
+          <Skeleton className="h-48" />
+        </div>
+      </div>
+    )
+  }
+
+  if (!order) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-muted-foreground">Order not found</p>
+      </div>
+    )
+  }
+
+  const steps =
+    order.fulfillment === "click_collect" ? STATUS_STEPS_COLLECT : STATUS_STEPS
+  const currentStepIndex = steps.indexOf(order.status)
+  const actions = getNextActions(order.status, order.fulfillment)
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Header */}
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="icon" onClick={() => router.back()}>
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+        <div className="flex-1">
+          <div className="flex items-center gap-3">
+            <h2 className="text-2xl font-bold">{order.order_number}</h2>
+            <Badge className={STATUS_COLORS[order.status] ?? ""}>
+              {order.status}
+            </Badge>
+            <Badge variant="outline" className="capitalize">
+              {order.order_type.replace("_", " ")}
+            </Badge>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {format(new Date(order.created), "PPp")}
+          </p>
+        </div>
+      </div>
+
+      {/* Status Stepper */}
+      {order.status !== "cancelled" && (
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              {steps.map((step, i) => {
+                const isCompleted = i <= currentStepIndex
+                const isCurrent = i === currentStepIndex
+                return (
+                  <div key={step} className="flex flex-1 items-center">
+                    <div className="flex flex-col items-center gap-1">
+                      <div
+                        className={`flex h-8 w-8 items-center justify-center rounded-full border-2 ${
+                          isCompleted
+                            ? "border-primary bg-primary text-primary-foreground"
+                            : "border-muted-foreground/30 text-muted-foreground/30"
+                        } ${isCurrent ? "ring-2 ring-primary/20" : ""}`}
+                      >
+                        {STATUS_ICONS[step]}
+                      </div>
+                      <span
+                        className={`text-xs capitalize ${
+                          isCompleted
+                            ? "font-medium text-foreground"
+                            : "text-muted-foreground/50"
+                        }`}
+                      >
+                        {step === "click_collect" ? "Ready" : step}
+                      </span>
+                    </div>
+                    {i < steps.length - 1 && (
+                      <div
+                        className={`mx-2 h-0.5 flex-1 ${
+                          i < currentStepIndex ? "bg-primary" : "bg-muted"
+                        }`}
+                      />
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Actions */}
+      {actions.length > 0 && (
+        <div className="flex gap-2">
+          {actions.map((action) => (
+            <Button
+              key={action.status}
+              variant={action.variant}
+              onClick={() => statusMutation.mutate(action.status)}
+              disabled={statusMutation.isPending}
+            >
+              {action.label}
+            </Button>
+          ))}
+        </div>
+      )}
+
+      <div className="grid gap-6 md:grid-cols-2">
+        {/* Customer Info */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Customer</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            <p>
+              <span className="text-muted-foreground">Name:</span>{" "}
+              {order.client_first_name} {order.client_last_name}
+            </p>
+            <p>
+              <span className="text-muted-foreground">Email:</span>{" "}
+              {order.client_email}
+            </p>
+            <p>
+              <span className="text-muted-foreground">Phone:</span>{" "}
+              {order.client_phone}
+            </p>
+          </CardContent>
+        </Card>
+
+        {/* Payment Info */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Payment</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            <p>
+              <span className="text-muted-foreground">Provider:</span>{" "}
+              <span className="capitalize">{order.payment_provider}</span>
+            </p>
+            <p>
+              <span className="text-muted-foreground">Method:</span>{" "}
+              {order.payment_method || "—"}
+            </p>
+            <p>
+              <span className="text-muted-foreground">Reference:</span>{" "}
+              {order.payment_ref}
+            </p>
+            {order.paid_at && (
+              <p>
+                <span className="text-muted-foreground">Paid at:</span>{" "}
+                {format(new Date(order.paid_at), "PPp")}
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Delivery Info */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Fulfillment</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            <p>
+              <span className="text-muted-foreground">Method:</span>{" "}
+              {order.fulfillment === "click_collect"
+                ? "Click & Collect"
+                : "Delivery"}
+            </p>
+            {order.delivery_address && (
+              <>
+                <p>
+                  <span className="text-muted-foreground">Address:</span>{" "}
+                  {order.delivery_address.address}
+                </p>
+                <p>
+                  <span className="text-muted-foreground">City:</span>{" "}
+                  {order.delivery_address.city},{" "}
+                  {order.delivery_address.province}
+                </p>
+              </>
+            )}
+            {order.delivered_at && (
+              <p>
+                <span className="text-muted-foreground">Delivered:</span>{" "}
+                {format(new Date(order.delivered_at), "PPp")}
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* QR Verification */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">QR Verification</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm">
+            <p className="text-muted-foreground mb-2">
+              Verify URL for pickup confirmation:
+            </p>
+            <code className="block rounded bg-muted p-2 text-xs break-all">
+              {typeof window !== "undefined" ? window.location.origin : ""}/order/verify/{order.id}/{order.verify_token}
+            </code>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Order Items */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Items</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {order.items.map((item, i) => (
+              <div
+                key={i}
+                className="flex items-center justify-between rounded-lg border p-3"
+              >
+                <div>
+                  <p className="text-sm font-medium">{item.product_name}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {item.quantity} x ${item.unit_price.toFixed(2)}
+                  </p>
+                </div>
+                <span className="text-sm font-medium">
+                  ${item.line_total.toFixed(2)}
+                </span>
+              </div>
+            ))}
+          </div>
+
+          <Separator className="my-4" />
+
+          <div className="space-y-1 text-sm">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Subtotal</span>
+              <span>${order.subtotal.toFixed(2)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Delivery</span>
+              <span>
+                {order.delivery_fee > 0
+                  ? `$${order.delivery_fee.toFixed(2)}`
+                  : "Free"}
+              </span>
+            </div>
+            <div className="flex justify-between font-medium text-base pt-1">
+              <span>Total</span>
+              <span>${order.total.toFixed(2)}</span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Status Timeline */}
+      {order.status_history && order.status_history.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Timeline</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              {order.status_history.map((change, i) => (
+                <div key={i} className="flex gap-3">
+                  <div className="flex flex-col items-center">
+                    <div className="h-2 w-2 rounded-full bg-primary mt-2" />
+                    {i < order.status_history.length - 1 && (
+                      <div className="w-px flex-1 bg-border" />
+                    )}
+                  </div>
+                  <div className="pb-4">
+                    <p className="text-sm font-medium capitalize">
+                      {change.to}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {change.changed_by} &middot;{" "}
+                      {format(new Date(change.timestamp), "PPp")}
+                    </p>
+                    {change.note && (
+                      <p className="text-xs text-muted-foreground mt-1">
+                        {change.note}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/apps/admin-fnp/app/dashboard/farmnport/sales/orders/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/sales/orders/page.tsx
@@ -1,0 +1,12 @@
+import { DashboardHeader } from "@/components/state/dashboardHeader"
+import { DashboardShell } from "@/components/state/dashboardShell"
+import { OrdersTable } from "@/components/structures/tables/orders"
+
+export default async function OrdersPage() {
+  return (
+    <DashboardShell>
+      <DashboardHeader heading="Orders" text="Manage customer orders." />
+      <OrdersTable />
+    </DashboardShell>
+  )
+}

--- a/apps/admin-fnp/app/dashboard/farmnport/sales/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/sales/page.tsx
@@ -1,0 +1,294 @@
+"use client"
+
+import Link from "next/link"
+import { useQuery } from "@tanstack/react-query"
+import {
+  DollarSign,
+  ShoppingCart,
+  Clock,
+  CheckCircle2,
+  ArrowRight,
+  Package,
+} from "lucide-react"
+
+import { querySalesStats, queryOrders } from "@/lib/query"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { useState } from "react"
+
+const ORDER_TYPES = [
+  { value: "", label: "All" },
+  { value: "retail", label: "Retail" },
+  { value: "bundle", label: "Bundle" },
+  { value: "marketplace", label: "Marketplace" },
+  { value: "wholesale", label: "Wholesale" },
+  { value: "pre_order", label: "Pre-orders" },
+]
+
+const STATUS_COLORS: Record<string, string> = {
+  pending: "bg-yellow-100 text-yellow-800",
+  paid: "bg-blue-100 text-blue-800",
+  processing: "bg-purple-100 text-purple-800",
+  dispatched: "bg-indigo-100 text-indigo-800",
+  ready: "bg-teal-100 text-teal-800",
+  delivered: "bg-green-100 text-green-800",
+  cancelled: "bg-red-100 text-red-800",
+}
+
+interface SalesStats {
+  revenue: { today: number; week: number; month: number; all_time: number }
+  orders: {
+    pending: number
+    paid: number
+    processing: number
+    delivered: number
+    total: number
+  }
+}
+
+interface Order {
+  id: string
+  order_number: string
+  client_name: string
+  status: string
+  total: number
+  order_type: string
+  created: string
+}
+
+export default function SalesOverviewPage() {
+  const [orderType, setOrderType] = useState("")
+
+  const { data: statsData, isLoading: statsLoading } = useQuery({
+    queryKey: ["sales-stats", orderType],
+    queryFn: () => querySalesStats(orderType || undefined),
+    refetchOnWindowFocus: false,
+  })
+
+  const { data: recentData, isLoading: recentLoading } = useQuery({
+    queryKey: ["recent-orders", orderType],
+    queryFn: () =>
+      queryOrders({
+        limit: 10,
+        order_type: orderType || undefined,
+      }),
+    refetchOnWindowFocus: false,
+  })
+
+  const stats: SalesStats | undefined = statsData?.data
+  const recentOrders: Order[] = recentData?.data?.orders ?? []
+
+  if (statsLoading) {
+    return (
+      <div className="flex flex-col gap-6">
+        <div>
+          <Skeleton className="h-9 w-48" />
+          <Skeleton className="h-4 w-64 mt-2" />
+        </div>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Card key={i}>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <Skeleton className="h-4 w-24" />
+              </CardHeader>
+              <CardContent>
+                <Skeleton className="h-7 w-20" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-3xl font-bold tracking-tight">Sales</h2>
+          <p className="text-muted-foreground">Revenue and order overview</p>
+        </div>
+        <Link
+          href="/dashboard/farmnport/sales/orders"
+          className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          View all orders
+          <ArrowRight className="h-4 w-4" />
+        </Link>
+      </div>
+
+      {/* Channel Tabs */}
+      <Tabs value={orderType} onValueChange={setOrderType}>
+        <TabsList>
+          {ORDER_TYPES.map((type) => (
+            <TabsTrigger key={type.value} value={type.value}>
+              {type.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+
+      {/* Revenue Cards */}
+      {stats && (
+        <>
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Today</CardTitle>
+                <DollarSign className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">
+                  ${stats.revenue.today.toFixed(2)}
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">This Week</CardTitle>
+                <DollarSign className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">
+                  ${stats.revenue.week.toFixed(2)}
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">
+                  This Month
+                </CardTitle>
+                <DollarSign className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">
+                  ${stats.revenue.month.toFixed(2)}
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">All Time</CardTitle>
+                <DollarSign className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">
+                  ${stats.revenue.all_time.toFixed(2)}
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Order Status Cards */}
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Pending</CardTitle>
+                <Clock className="h-4 w-4 text-yellow-500" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">
+                  {stats.orders.pending}
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Paid</CardTitle>
+                <ShoppingCart className="h-4 w-4 text-blue-500" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{stats.orders.paid}</div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">
+                  Processing
+                </CardTitle>
+                <Package className="h-4 w-4 text-purple-500" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">
+                  {stats.orders.processing}
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Delivered</CardTitle>
+                <CheckCircle2 className="h-4 w-4 text-green-500" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">
+                  {stats.orders.delivered}
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </>
+      )}
+
+      {/* Recent Orders */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Recent Orders</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {recentLoading ? (
+            <div className="space-y-3">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Skeleton key={i} className="h-10 w-full" />
+              ))}
+            </div>
+          ) : recentOrders.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-4 text-center">
+              No orders yet
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {recentOrders.map((order) => (
+                <Link
+                  key={order.id}
+                  href={`/dashboard/farmnport/sales/orders/${order.id}`}
+                  className="flex items-center justify-between rounded-lg border p-3 hover:bg-muted/50 transition-colors"
+                >
+                  <div className="flex items-center gap-3">
+                    <div>
+                      <p className="text-sm font-medium">
+                        {order.order_number}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {order.client_name}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <span className="text-sm font-medium">
+                      ${order.total.toFixed(2)}
+                    </span>
+                    <Badge
+                      variant="secondary"
+                      className={STATUS_COLORS[order.status] ?? ""}
+                    >
+                      {order.status}
+                    </Badge>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-items/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-items/[slug]/edit/page.tsx
@@ -268,8 +268,8 @@ export default function EditMenuItemPage() {
                                             {menus.map((menu) => (
                                                 <SelectItem key={menu.id} value={menu.id}>
                                                     <span className="capitalize">{menu.name}</span>
-                                                    {menu.location_name && (
-                                                        <span className="ml-1 text-gray-500 dark:text-gray-400">— {menu.location_name}</span>
+                                                    {menu.locations?.length > 0 && (
+                                                        <span className="ml-1 text-gray-500 dark:text-gray-400">— {menu.locations.map(l => l.location_name).join(", ")}</span>
                                                     )}
                                                 </SelectItem>
                                             ))}

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-items/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-items/new/page.tsx
@@ -214,8 +214,8 @@ export default function NewMenuItemPage() {
                                             {menus?.map((menu) => (
                                                 <SelectItem key={menu.id} value={menu.id}>
                                                     <span className="capitalize">{menu.name}</span>
-                                                    {menu.location_name && (
-                                                        <span className="ml-1 text-gray-500 dark:text-gray-400">— {menu.location_name}</span>
+                                                    {menu.locations?.length > 0 && (
+                                                        <span className="ml-1 text-gray-500 dark:text-gray-400">— {menu.locations.map(l => l.location_name).join(", ")}</span>
                                                     )}
                                                 </SelectItem>
                                             ))}

--- a/apps/admin-fnp/app/dashboard/restaurants/sales/orders/[id]/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/sales/orders/[id]/page.tsx
@@ -1,0 +1,374 @@
+"use client"
+
+import { useParams, useRouter } from "next/navigation"
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { format } from "date-fns"
+import {
+  ArrowLeft,
+  Package,
+  Truck,
+  CheckCircle2,
+  XCircle,
+  Clock,
+  CreditCard,
+} from "lucide-react"
+
+import { queryOrder, updateOrderStatus } from "@/lib/query"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Separator } from "@/components/ui/separator"
+import { useToast } from "@/components/ui/use-toast"
+
+const STATUS_STEPS = ["pending", "paid", "processing", "dispatched", "delivered"]
+const STATUS_STEPS_COLLECT = ["pending", "paid", "processing", "ready", "delivered"]
+
+const STATUS_COLORS: Record<string, string> = {
+  pending: "bg-yellow-100 text-yellow-800",
+  paid: "bg-blue-100 text-blue-800",
+  processing: "bg-purple-100 text-purple-800",
+  dispatched: "bg-indigo-100 text-indigo-800",
+  ready: "bg-teal-100 text-teal-800",
+  delivered: "bg-green-100 text-green-800",
+  cancelled: "bg-red-100 text-red-800",
+}
+
+const STATUS_ICONS: Record<string, React.ReactNode> = {
+  pending: <Clock className="h-4 w-4" />,
+  paid: <CreditCard className="h-4 w-4" />,
+  processing: <Package className="h-4 w-4" />,
+  dispatched: <Truck className="h-4 w-4" />,
+  ready: <CheckCircle2 className="h-4 w-4" />,
+  delivered: <CheckCircle2 className="h-4 w-4" />,
+  cancelled: <XCircle className="h-4 w-4" />,
+}
+
+interface OrderItem {
+  product_name: string
+  quantity: number
+  unit_price: number
+  line_total: number
+}
+
+interface StatusChange {
+  from: string
+  to: string
+  changed_by: string
+  note: string
+  timestamp: string
+}
+
+interface DeliveryAddress {
+  name: string
+  phone: string
+  address: string
+  city: string
+  province: string
+}
+
+interface Order {
+  id: string
+  order_number: string
+  client_name: string
+  client_first_name: string
+  client_last_name: string
+  client_email: string
+  client_phone: string
+  order_type: string
+  status: string
+  items: OrderItem[]
+  subtotal: number
+  delivery_fee: number
+  total: number
+  currency: string
+  fulfillment: string
+  delivery_address?: DeliveryAddress
+  payment_provider: string
+  payment_method: string
+  payment_ref: string
+  paid_at?: string
+  verify_token: string
+  status_history: StatusChange[]
+  delivered_at?: string
+  created: string
+  updated: string
+}
+
+function getNextActions(
+  status: string,
+  fulfillment: string
+): { label: string; status: string; variant: "default" | "destructive" }[] {
+  const actions: { label: string; status: string; variant: "default" | "destructive" }[] = []
+
+  switch (status) {
+    case "paid":
+      actions.push({ label: "Acknowledge Order", status: "processing", variant: "default" })
+      break
+    case "processing":
+      if (fulfillment === "click_collect") {
+        actions.push({ label: "Ready for Pickup", status: "ready", variant: "default" })
+      } else {
+        actions.push({ label: "Mark Dispatched", status: "dispatched", variant: "default" })
+      }
+      break
+    case "dispatched":
+    case "ready":
+      actions.push({ label: "Mark Delivered", status: "delivered", variant: "default" })
+      break
+  }
+
+  if (status !== "delivered" && status !== "cancelled") {
+    actions.push({ label: "Cancel Order", status: "cancelled", variant: "destructive" })
+  }
+
+  return actions
+}
+
+export default function RestaurantOrderDetailPage() {
+  const params = useParams()
+  const router = useRouter()
+  const queryClient = useQueryClient()
+  const { toast } = useToast()
+
+  const orderId = params.id as string
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["admin-order", orderId],
+    queryFn: () => queryOrder(orderId),
+    refetchOnWindowFocus: false,
+  })
+
+  const statusMutation = useMutation({
+    mutationFn: (newStatus: string) =>
+      updateOrderStatus({ order_id: orderId, status: newStatus }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin-order", orderId] })
+      queryClient.invalidateQueries({ queryKey: ["admin-orders"] })
+      queryClient.invalidateQueries({ queryKey: ["notifications"] })
+      toast({ title: "Order status updated" })
+    },
+    onError: () => {
+      toast({ title: "Failed to update status", variant: "destructive" })
+    },
+  })
+
+  const order: Order | undefined = data?.data
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-6">
+        <Skeleton className="h-8 w-64" />
+        <div className="grid gap-4 md:grid-cols-2">
+          <Skeleton className="h-48" />
+          <Skeleton className="h-48" />
+        </div>
+      </div>
+    )
+  }
+
+  if (!order) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-muted-foreground">Order not found</p>
+      </div>
+    )
+  }
+
+  const steps =
+    order.fulfillment === "click_collect" ? STATUS_STEPS_COLLECT : STATUS_STEPS
+  const currentStepIndex = steps.indexOf(order.status)
+  const actions = getNextActions(order.status, order.fulfillment)
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Header */}
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="icon" onClick={() => router.back()}>
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+        <div className="flex-1">
+          <div className="flex items-center gap-3">
+            <h2 className="text-2xl font-bold">{order.order_number}</h2>
+            <Badge className={STATUS_COLORS[order.status] ?? ""}>
+              {order.status}
+            </Badge>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {format(new Date(order.created), "PPp")}
+          </p>
+        </div>
+      </div>
+
+      {/* Status Stepper */}
+      {order.status !== "cancelled" && (
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              {steps.map((step, i) => {
+                const isCompleted = i <= currentStepIndex
+                const isCurrent = i === currentStepIndex
+                return (
+                  <div key={step} className="flex flex-1 items-center">
+                    <div className="flex flex-col items-center gap-1">
+                      <div
+                        className={`flex h-8 w-8 items-center justify-center rounded-full border-2 ${
+                          isCompleted
+                            ? "border-primary bg-primary text-primary-foreground"
+                            : "border-muted-foreground/30 text-muted-foreground/30"
+                        } ${isCurrent ? "ring-2 ring-primary/20" : ""}`}
+                      >
+                        {STATUS_ICONS[step]}
+                      </div>
+                      <span
+                        className={`text-xs capitalize ${
+                          isCompleted ? "font-medium text-foreground" : "text-muted-foreground/50"
+                        }`}
+                      >
+                        {step}
+                      </span>
+                    </div>
+                    {i < steps.length - 1 && (
+                      <div className={`mx-2 h-0.5 flex-1 ${i < currentStepIndex ? "bg-primary" : "bg-muted"}`} />
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Actions */}
+      {actions.length > 0 && (
+        <div className="flex gap-2">
+          {actions.map((action) => (
+            <Button
+              key={action.status}
+              variant={action.variant}
+              onClick={() => statusMutation.mutate(action.status)}
+              disabled={statusMutation.isPending}
+            >
+              {action.label}
+            </Button>
+          ))}
+        </div>
+      )}
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Customer</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            <p><span className="text-muted-foreground">Name:</span> {order.client_first_name} {order.client_last_name}</p>
+            <p><span className="text-muted-foreground">Email:</span> {order.client_email}</p>
+            <p><span className="text-muted-foreground">Phone:</span> {order.client_phone}</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Payment</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            <p><span className="text-muted-foreground">Provider:</span> <span className="capitalize">{order.payment_provider}</span></p>
+            <p><span className="text-muted-foreground">Reference:</span> {order.payment_ref}</p>
+            {order.paid_at && (
+              <p><span className="text-muted-foreground">Paid at:</span> {format(new Date(order.paid_at), "PPp")}</p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Fulfillment</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            <p>
+              <span className="text-muted-foreground">Method:</span>{" "}
+              {order.fulfillment === "click_collect" ? "Click & Collect" : "Delivery"}
+            </p>
+            {order.delivery_address && (
+              <p><span className="text-muted-foreground">Address:</span> {order.delivery_address.address}, {order.delivery_address.city}</p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">QR Verification</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm">
+            <code className="block rounded bg-muted p-2 text-xs break-all">
+              {typeof window !== "undefined" ? window.location.origin : ""}/order/verify/{order.id}/{order.verify_token}
+            </code>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Items */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Items</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            {order.items.map((item, i) => (
+              <div key={i} className="flex items-center justify-between rounded-lg border p-3">
+                <div>
+                  <p className="text-sm font-medium">{item.product_name}</p>
+                  <p className="text-xs text-muted-foreground">{item.quantity} x ${item.unit_price.toFixed(2)}</p>
+                </div>
+                <span className="text-sm font-medium">${item.line_total.toFixed(2)}</span>
+              </div>
+            ))}
+          </div>
+          <Separator className="my-4" />
+          <div className="space-y-1 text-sm">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Subtotal</span>
+              <span>${order.subtotal.toFixed(2)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Delivery</span>
+              <span>{order.delivery_fee > 0 ? `$${order.delivery_fee.toFixed(2)}` : "Free"}</span>
+            </div>
+            <div className="flex justify-between font-medium text-base pt-1">
+              <span>Total</span>
+              <span>${order.total.toFixed(2)}</span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Timeline */}
+      {order.status_history && order.status_history.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Timeline</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              {order.status_history.map((change, i) => (
+                <div key={i} className="flex gap-3">
+                  <div className="flex flex-col items-center">
+                    <div className="h-2 w-2 rounded-full bg-primary mt-2" />
+                    {i < order.status_history.length - 1 && <div className="w-px flex-1 bg-border" />}
+                  </div>
+                  <div className="pb-4">
+                    <p className="text-sm font-medium capitalize">{change.to}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {change.changed_by} &middot; {format(new Date(change.timestamp), "PPp")}
+                    </p>
+                    {change.note && <p className="text-xs text-muted-foreground mt-1">{change.note}</p>}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/apps/admin-fnp/app/dashboard/restaurants/sales/orders/[id]/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/sales/orders/[id]/page.tsx
@@ -242,16 +242,18 @@ export default function RestaurantOrderDetailPage() {
       {/* Actions */}
       {actions.length > 0 && (
         <div className="flex gap-2">
-          {actions.map((action) => (
-            <Button
-              key={action.status}
-              variant={action.variant}
-              onClick={() => statusMutation.mutate(action.status)}
-              disabled={statusMutation.isPending}
-            >
-              {action.label}
-            </Button>
-          ))}
+          {actions
+            .filter((action) => action.status !== "cancelled")
+            .map((action) => (
+              <Button
+                key={action.status}
+                variant={action.variant}
+                onClick={() => statusMutation.mutate(action.status)}
+                disabled={statusMutation.isPending}
+              >
+                {action.label}
+              </Button>
+            ))}
         </div>
       )}
 
@@ -368,6 +370,19 @@ export default function RestaurantOrderDetailPage() {
             </div>
           </CardContent>
         </Card>
+      )}
+
+      {/* Cancel Order */}
+      {order.status !== "delivered" && order.status !== "cancelled" && (
+        <div className="flex gap-2 pt-4 border-t">
+          <Button
+            variant="destructive"
+            onClick={() => statusMutation.mutate("cancelled")}
+            disabled={statusMutation.isPending}
+          >
+            Cancel Order
+          </Button>
+        </div>
       )}
     </div>
   )

--- a/apps/admin-fnp/app/dashboard/restaurants/sales/orders/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/sales/orders/page.tsx
@@ -1,0 +1,133 @@
+"use client"
+
+import { useState, useEffect, useRef } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { PaginationState } from "@tanstack/react-table"
+
+import { queryOrders } from "@/lib/query"
+import { handleFetchError } from "@/lib/error-handler"
+import { Placeholder } from "@/components/state/placeholder"
+import { DashboardHeader } from "@/components/state/dashboardHeader"
+import { DashboardShell } from "@/components/state/dashboardShell"
+import { DataTable } from "@/components/structures/data-table"
+import { orderColumns, OrderRow } from "@/components/structures/columns/orders"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+
+const STATUS_FILTERS = [
+  { value: "", label: "All" },
+  { value: "pending", label: "Pending" },
+  { value: "paid", label: "Paid" },
+  { value: "processing", label: "Processing" },
+  { value: "dispatched", label: "Dispatched" },
+  { value: "ready", label: "Ready" },
+  { value: "delivered", label: "Delivered" },
+  { value: "cancelled", label: "Cancelled" },
+]
+
+export default function RestaurantOrdersPage() {
+  const [search, setSearch] = useState("")
+  const [statusFilter, setStatusFilter] = useState("")
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 20,
+  })
+
+  const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
+    queryKey: [
+      "admin-orders",
+      "restaurant",
+      { p: pagination.pageIndex + 1, search, status: statusFilter },
+    ],
+    queryFn: () =>
+      queryOrders({
+        p: pagination.pageIndex + 1,
+        search,
+        limit: pagination.pageSize,
+        order_type: "restaurant",
+        status: statusFilter || undefined,
+      }),
+    refetchOnWindowFocus: false,
+  })
+
+  const hasShownError = useRef(false)
+
+  useEffect(() => {
+    if (isError && !hasShownError.current) {
+      hasShownError.current = true
+      handleFetchError(error, {
+        onRetry: () => {
+          hasShownError.current = false
+          refetch()
+        },
+        context: "restaurant orders",
+      })
+    }
+    if (!isError) {
+      hasShownError.current = false
+    }
+  }, [isError, error, refetch])
+
+  const orders = (data?.data?.orders as OrderRow[]) ?? []
+  const total = (data?.data?.total as number) ?? 0
+
+  if (isError) {
+    return (
+      <DashboardShell>
+        <DashboardHeader heading="Restaurant Orders" text="Manage restaurant orders." />
+        <Placeholder>
+          <Placeholder.Icon name="close" />
+          <Placeholder.Title>Error Fetching Orders</Placeholder.Title>
+          <Placeholder.Description>
+            Something went wrong. Please try again.
+          </Placeholder.Description>
+        </Placeholder>
+      </DashboardShell>
+    )
+  }
+
+  if (isLoading || isFetching) {
+    return (
+      <DashboardShell>
+        <DashboardHeader heading="Restaurant Orders" text="Manage restaurant orders." />
+        <Placeholder>
+          <Placeholder.Title>Fetching Orders</Placeholder.Title>
+        </Placeholder>
+      </DashboardShell>
+    )
+  }
+
+  return (
+    <DashboardShell>
+      <DashboardHeader heading="Restaurant Orders" text="Manage restaurant orders." />
+
+      <Tabs
+        value={statusFilter}
+        onValueChange={(v) => {
+          setStatusFilter(v)
+          setPagination((p) => ({ ...p, pageIndex: 0 }))
+        }}
+      >
+        <TabsList>
+          {STATUS_FILTERS.map((status) => (
+            <TabsTrigger key={status.value} value={status.value}>
+              {status.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+
+      <DataTable
+        columns={orderColumns}
+        data={orders}
+        newUrl=""
+        tableName="Order"
+        total={total}
+        pagination={pagination}
+        setPagination={setPagination}
+        search={search}
+        setSearch={setSearch}
+        searchPlaceholder="Search orders..."
+      />
+    </DashboardShell>
+  )
+}

--- a/apps/admin-fnp/app/dashboard/restaurants/sales/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/sales/page.tsx
@@ -1,0 +1,223 @@
+"use client"
+
+import Link from "next/link"
+import { useQuery } from "@tanstack/react-query"
+import {
+  DollarSign,
+  ShoppingCart,
+  Clock,
+  CheckCircle2,
+  ArrowRight,
+  Package,
+} from "lucide-react"
+
+import { querySalesStats, queryOrders } from "@/lib/query"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
+
+const STATUS_COLORS: Record<string, string> = {
+  pending: "bg-yellow-100 text-yellow-800",
+  paid: "bg-blue-100 text-blue-800",
+  processing: "bg-purple-100 text-purple-800",
+  dispatched: "bg-indigo-100 text-indigo-800",
+  ready: "bg-teal-100 text-teal-800",
+  delivered: "bg-green-100 text-green-800",
+  cancelled: "bg-red-100 text-red-800",
+}
+
+interface SalesStats {
+  revenue: { today: number; week: number; month: number; all_time: number }
+  orders: {
+    pending: number
+    paid: number
+    processing: number
+    delivered: number
+    total: number
+  }
+}
+
+interface Order {
+  id: string
+  order_number: string
+  client_name: string
+  status: string
+  total: number
+  created: string
+}
+
+export default function RestaurantSalesPage() {
+  const { data: statsData, isLoading: statsLoading } = useQuery({
+    queryKey: ["sales-stats", "restaurant"],
+    queryFn: () => querySalesStats("restaurant"),
+    refetchOnWindowFocus: false,
+  })
+
+  const { data: recentData, isLoading: recentLoading } = useQuery({
+    queryKey: ["recent-orders", "restaurant"],
+    queryFn: () => queryOrders({ limit: 10, order_type: "restaurant" }),
+    refetchOnWindowFocus: false,
+  })
+
+  const stats: SalesStats | undefined = statsData?.data
+  const recentOrders: Order[] = recentData?.data?.orders ?? []
+
+  if (statsLoading) {
+    return (
+      <div className="flex flex-col gap-6">
+        <Skeleton className="h-9 w-48" />
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Card key={i}>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <Skeleton className="h-4 w-24" />
+              </CardHeader>
+              <CardContent>
+                <Skeleton className="h-7 w-20" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-3xl font-bold tracking-tight">Restaurant Sales</h2>
+          <p className="text-muted-foreground">Restaurant order overview</p>
+        </div>
+        <Link
+          href="/dashboard/restaurants/sales/orders"
+          className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          View all orders
+          <ArrowRight className="h-4 w-4" />
+        </Link>
+      </div>
+
+      {stats && (
+        <>
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Today</CardTitle>
+                <DollarSign className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">${stats.revenue.today.toFixed(2)}</div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">This Week</CardTitle>
+                <DollarSign className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">${stats.revenue.week.toFixed(2)}</div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">This Month</CardTitle>
+                <DollarSign className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">${stats.revenue.month.toFixed(2)}</div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">All Time</CardTitle>
+                <DollarSign className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">${stats.revenue.all_time.toFixed(2)}</div>
+              </CardContent>
+            </Card>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Pending</CardTitle>
+                <Clock className="h-4 w-4 text-yellow-500" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{stats.orders.pending}</div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Paid</CardTitle>
+                <ShoppingCart className="h-4 w-4 text-blue-500" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{stats.orders.paid}</div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Processing</CardTitle>
+                <Package className="h-4 w-4 text-purple-500" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{stats.orders.processing}</div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Delivered</CardTitle>
+                <CheckCircle2 className="h-4 w-4 text-green-500" />
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold">{stats.orders.delivered}</div>
+              </CardContent>
+            </Card>
+          </div>
+        </>
+      )}
+
+      {/* Recent Orders */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Recent Orders</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {recentLoading ? (
+            <div className="space-y-3">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Skeleton key={i} className="h-10 w-full" />
+              ))}
+            </div>
+          ) : recentOrders.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-4 text-center">No orders yet</p>
+          ) : (
+            <div className="space-y-2">
+              {recentOrders.map((order) => (
+                <Link
+                  key={order.id}
+                  href={`/dashboard/restaurants/sales/orders/${order.id}`}
+                  className="flex items-center justify-between rounded-lg border p-3 hover:bg-muted/50 transition-colors"
+                >
+                  <div>
+                    <p className="text-sm font-medium">{order.order_number}</p>
+                    <p className="text-xs text-muted-foreground">{order.client_name}</p>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <span className="text-sm font-medium">${order.total.toFixed(2)}</span>
+                    <Badge variant="secondary" className={STATUS_COLORS[order.status] ?? ""}>
+                      {order.status}
+                    </Badge>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/apps/admin-fnp/components/icons/lucide.ts
+++ b/apps/admin-fnp/components/icons/lucide.ts
@@ -54,6 +54,9 @@ import {
   Sprout,
   Egg,
   LayoutDashboard,
+  ShoppingCart,
+  Bell,
+  BarChart3,
 } from "lucide-react"
 
 export type Icon = LucideIcon
@@ -116,4 +119,7 @@ export const Icons = {
   sprout: Sprout,
   egg: Egg,
   dashboard: LayoutDashboard,
+  shoppingCart: ShoppingCart,
+  bell: Bell,
+  barChart: BarChart3,
 }

--- a/apps/admin-fnp/components/notifications/notification-bell.tsx
+++ b/apps/admin-fnp/components/notifications/notification-bell.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import { useState } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { Bell } from "lucide-react"
+
+import { queryUnreadNotificationCount } from "@/lib/query"
+import { Button } from "@/components/ui/button"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { NotificationDropdown } from "./notification-dropdown"
+
+export function NotificationBell() {
+  const [open, setOpen] = useState(false)
+
+  const { data } = useQuery({
+    queryKey: ["notifications", "unread-count"],
+    queryFn: () => queryUnreadNotificationCount(),
+    refetchInterval: 15000,
+  })
+
+  const count = data?.data?.count ?? 0
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="ghost" size="icon" className="relative h-8 w-8">
+          <Bell className="h-4 w-4" />
+          {count > 0 && (
+            <span className="absolute -top-0.5 -right-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-destructive text-[10px] font-medium text-destructive-foreground">
+              {count > 99 ? "99+" : count}
+            </span>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-80 p-0" align="end">
+        <NotificationDropdown onClose={() => setOpen(false)} />
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/admin-fnp/components/notifications/notification-dropdown.tsx
+++ b/apps/admin-fnp/components/notifications/notification-dropdown.tsx
@@ -1,0 +1,117 @@
+"use client"
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { useRouter } from "next/navigation"
+import { formatDistanceToNow } from "date-fns"
+
+import { queryRecentNotifications, markNotificationsRead } from "@/lib/query"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import { Button } from "@/components/ui/button"
+import { Skeleton } from "@/components/ui/skeleton"
+
+interface Notification {
+  id: string
+  type: string
+  title: string
+  message: string
+  link_to: string
+  read: boolean
+  created: string
+}
+
+interface NotificationDropdownProps {
+  onClose: () => void
+}
+
+export function NotificationDropdown({ onClose }: NotificationDropdownProps) {
+  const router = useRouter()
+  const queryClient = useQueryClient()
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["notifications", "recent"],
+    queryFn: () => queryRecentNotifications(),
+  })
+
+  const markReadMutation = useMutation({
+    mutationFn: (data: { ids?: string[]; all?: boolean }) => markNotificationsRead(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["notifications"] })
+    },
+  })
+
+  const notifications: Notification[] = data?.data?.notifications ?? []
+
+  const handleClick = (notification: Notification) => {
+    if (!notification.read) {
+      markReadMutation.mutate({ ids: [notification.id] })
+    }
+    onClose()
+    router.push(notification.link_to)
+  }
+
+  const handleMarkAllRead = () => {
+    markReadMutation.mutate({ all: true })
+  }
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <h4 className="text-sm font-semibold">Notifications</h4>
+        {notifications.some((n) => !n.read) && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-auto p-0 text-xs text-muted-foreground hover:text-foreground"
+            onClick={handleMarkAllRead}
+          >
+            Mark all read
+          </Button>
+        )}
+      </div>
+
+      <ScrollArea className="max-h-[300px]">
+        {isLoading ? (
+          <div className="space-y-3 p-4">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="flex flex-col gap-1">
+                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="h-3 w-full" />
+              </div>
+            ))}
+          </div>
+        ) : notifications.length === 0 ? (
+          <div className="p-6 text-center text-sm text-muted-foreground">
+            No notifications
+          </div>
+        ) : (
+          <div>
+            {notifications.map((notification) => (
+              <button
+                key={notification.id}
+                onClick={() => handleClick(notification)}
+                className={`flex w-full flex-col gap-0.5 border-b px-4 py-3 text-left transition-colors hover:bg-muted/50 ${
+                  !notification.read ? "bg-muted/30" : ""
+                }`}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <span className="text-sm font-medium leading-tight">
+                    {notification.title}
+                  </span>
+                  {!notification.read && (
+                    <span className="mt-1 h-2 w-2 shrink-0 rounded-full bg-primary" />
+                  )}
+                </div>
+                <span className="text-xs text-muted-foreground line-clamp-1">
+                  {notification.message}
+                </span>
+                <span className="text-[11px] text-muted-foreground/60">
+                  {formatDistanceToNow(new Date(notification.created), { addSuffix: true })}
+                </span>
+              </button>
+            ))}
+          </div>
+        )}
+      </ScrollArea>
+    </div>
+  )
+}

--- a/apps/admin-fnp/components/structures/columns/orders.tsx
+++ b/apps/admin-fnp/components/structures/columns/orders.tsx
@@ -1,0 +1,129 @@
+"use client"
+
+import { ColumnDef } from "@tanstack/react-table"
+import Link from "next/link"
+import { Badge } from "@/components/ui/badge"
+import { Checkbox } from "@/components/ui/checkbox"
+import { formatDate } from "@/lib/utilities"
+
+const STATUS_COLORS: Record<string, string> = {
+  pending: "bg-yellow-100 text-yellow-800",
+  paid: "bg-blue-100 text-blue-800",
+  processing: "bg-purple-100 text-purple-800",
+  dispatched: "bg-indigo-100 text-indigo-800",
+  ready: "bg-teal-100 text-teal-800",
+  delivered: "bg-green-100 text-green-800",
+  cancelled: "bg-red-100 text-red-800",
+}
+
+export interface OrderRow {
+  id: string
+  order_number: string
+  client_name: string
+  client_email: string
+  status: string
+  total: number
+  order_type: string
+  fulfillment: string
+  items: { product_name: string; quantity: number }[]
+  created: string
+}
+
+export const orderColumns: ColumnDef<OrderRow>[] = [
+  {
+    id: "select",
+    header: ({ table }) => (
+      <Checkbox
+        checked={table.getIsAllPageRowsSelected()}
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Select all"
+        className="translate-y-[2px]"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label="Select row"
+        className="translate-y-[2px]"
+      />
+    ),
+    enableSorting: false,
+    enableHiding: false,
+  },
+  {
+    accessorKey: "order_number",
+    header: "Order",
+    cell: ({ row }) => {
+      const order = row.original
+      return (
+        <Link
+          href={`/dashboard/farmnport/sales/orders/${order.id}`}
+          className="font-medium text-primary hover:underline"
+        >
+          {order.order_number}
+        </Link>
+      )
+    },
+  },
+  {
+    accessorKey: "client_name",
+    header: "Customer",
+    cell: ({ row }) => {
+      const order = row.original
+      return (
+        <div>
+          <span className="text-sm">{order.client_name}</span>
+          <p className="text-xs text-muted-foreground">{order.client_email}</p>
+        </div>
+      )
+    },
+  },
+  {
+    accessorKey: "status",
+    header: "Status",
+    cell: ({ row }) => {
+      const status = row.getValue("status") as string
+      return (
+        <Badge variant="secondary" className={STATUS_COLORS[status] ?? ""}>
+          {status}
+        </Badge>
+      )
+    },
+  },
+  {
+    accessorKey: "total",
+    header: "Total",
+    cell: ({ row }) => {
+      const total = row.getValue("total") as number
+      return <span className="font-medium">${total.toFixed(2)}</span>
+    },
+  },
+  {
+    accessorKey: "order_type",
+    header: "Channel",
+    cell: ({ row }) => {
+      const type = row.getValue("order_type") as string
+      return <span className="text-sm capitalize">{type.replace("_", " ")}</span>
+    },
+  },
+  {
+    accessorKey: "fulfillment",
+    header: "Fulfillment",
+    cell: ({ row }) => {
+      const fulfillment = row.getValue("fulfillment") as string
+      return (
+        <span className="text-sm capitalize">
+          {fulfillment === "click_collect" ? "Click & Collect" : fulfillment}
+        </span>
+      )
+    },
+  },
+  {
+    accessorKey: "created",
+    header: "Date",
+    cell: ({ row }) => {
+      return <span className="text-sm">{formatDate(row.original.created)}</span>
+    },
+  },
+]

--- a/apps/admin-fnp/components/structures/columns/orders.tsx
+++ b/apps/admin-fnp/components/structures/columns/orders.tsx
@@ -126,4 +126,21 @@ export const orderColumns: ColumnDef<OrderRow>[] = [
       return <span className="text-sm">{formatDate(row.original.created)}</span>
     },
   },
+  {
+    id: "actions",
+    header: "Actions",
+    cell: ({ row }) => {
+      const order = row.original
+      return (
+        <Link
+          href={`/dashboard/restaurants/sales/orders/${order.id}`}
+          className="text-sm font-medium text-blue-600 hover:text-blue-800"
+        >
+          View
+        </Link>
+      )
+    },
+    enableSorting: false,
+    enableHiding: false,
+  },
 ]

--- a/apps/admin-fnp/components/structures/tables/orders.tsx
+++ b/apps/admin-fnp/components/structures/tables/orders.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import { useState, useEffect, useRef } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { PaginationState } from "@tanstack/react-table"
+
+import { queryOrders } from "@/lib/query"
+import { handleFetchError } from "@/lib/error-handler"
+import { Placeholder } from "@/components/state/placeholder"
+import { DataTable } from "@/components/structures/data-table"
+import { orderColumns, OrderRow } from "@/components/structures/columns/orders"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
+
+const ORDER_TYPES = [
+  { value: "", label: "All" },
+  { value: "retail", label: "Retail" },
+  { value: "bundle", label: "Bundle" },
+  { value: "marketplace", label: "Marketplace" },
+  { value: "wholesale", label: "Wholesale" },
+  { value: "pre_order", label: "Pre-orders" },
+]
+
+const STATUS_FILTERS = [
+  { value: "", label: "All" },
+  { value: "pending", label: "Pending" },
+  { value: "paid", label: "Paid" },
+  { value: "processing", label: "Processing" },
+  { value: "dispatched", label: "Dispatched" },
+  { value: "ready", label: "Ready" },
+  { value: "delivered", label: "Delivered" },
+  { value: "cancelled", label: "Cancelled" },
+]
+
+export function OrdersTable() {
+  const [search, setSearch] = useState("")
+  const [orderType, setOrderType] = useState("")
+  const [statusFilter, setStatusFilter] = useState("")
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 20,
+  })
+
+  const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
+    queryKey: [
+      "admin-orders",
+      {
+        p: pagination.pageIndex + 1,
+        search,
+        order_type: orderType,
+        status: statusFilter,
+      },
+    ],
+    queryFn: () =>
+      queryOrders({
+        p: pagination.pageIndex + 1,
+        search,
+        limit: pagination.pageSize,
+        order_type: orderType || undefined,
+        status: statusFilter || undefined,
+      }),
+    refetchOnWindowFocus: false,
+  })
+
+  const hasShownError = useRef(false)
+
+  useEffect(() => {
+    if (isError && !hasShownError.current) {
+      hasShownError.current = true
+      handleFetchError(error, {
+        onRetry: () => {
+          hasShownError.current = false
+          refetch()
+        },
+        context: "orders",
+      })
+    }
+    if (!isError) {
+      hasShownError.current = false
+    }
+  }, [isError, error, refetch])
+
+  const orders = (data?.data?.orders as OrderRow[]) ?? []
+  const total = (data?.data?.total as number) ?? 0
+
+  if (isError) {
+    return (
+      <Placeholder>
+        <Placeholder.Icon name="close" />
+        <Placeholder.Title>Error Fetching Orders</Placeholder.Title>
+        <Placeholder.Description>
+          Something went wrong. Please try again.
+        </Placeholder.Description>
+      </Placeholder>
+    )
+  }
+
+  if (isLoading || isFetching) {
+    return (
+      <Placeholder>
+        <Placeholder.Title>Fetching Orders</Placeholder.Title>
+      </Placeholder>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Channel filter */}
+      <Tabs value={orderType} onValueChange={(v) => { setOrderType(v); setPagination(p => ({ ...p, pageIndex: 0 })) }}>
+        <TabsList>
+          {ORDER_TYPES.map((type) => (
+            <TabsTrigger key={type.value} value={type.value}>
+              {type.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+
+      {/* Status filter */}
+      <Tabs value={statusFilter} onValueChange={(v) => { setStatusFilter(v); setPagination(p => ({ ...p, pageIndex: 0 })) }}>
+        <TabsList>
+          {STATUS_FILTERS.map((status) => (
+            <TabsTrigger key={status.value} value={status.value}>
+              {status.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+
+      <DataTable
+        columns={orderColumns}
+        data={orders}
+        newUrl=""
+        tableName="Order"
+        total={total}
+        pagination={pagination}
+        setPagination={setPagination}
+        search={search}
+        setSearch={setSearch}
+        searchPlaceholder="Search orders..."
+      />
+    </div>
+  )
+}

--- a/apps/admin-fnp/config/dashboard.ts
+++ b/apps/admin-fnp/config/dashboard.ts
@@ -19,6 +19,21 @@ export const dashboardConfig: DashboardConfig = {
       ],
     },
     {
+      label: "Sales",
+      items: [
+        {
+          title: "Overview",
+          href: "/dashboard/farmnport/sales",
+          icon: "barChart",
+        },
+        {
+          title: "Orders",
+          href: "/dashboard/farmnport/sales/orders",
+          icon: "shoppingCart",
+        },
+      ],
+    },
+    {
       label: "Management",
       items: [
         {

--- a/apps/admin-fnp/config/restaurants-dashboard.ts
+++ b/apps/admin-fnp/config/restaurants-dashboard.ts
@@ -19,8 +19,28 @@ export const restaurantsDashboardConfig: DashboardConfig = {
       ],
     },
     {
+      label: "Sales",
+      items: [
+        {
+          title: "Overview",
+          href: "/dashboard/restaurants/sales",
+          icon: "barChart",
+        },
+        {
+          title: "Orders",
+          href: "/dashboard/restaurants/sales/orders",
+          icon: "shoppingCart",
+        },
+      ],
+    },
+    {
       label: "Menu Catalog",
       items: [
+        {
+          title: "Menu Categories",
+          href: "/dashboard/restaurants/menu-categories",
+          icon: "layers",
+        },
         {
           title: "Menus",
           href: "/dashboard/restaurants/menus",

--- a/apps/admin-fnp/hooks/use-notification-stream.ts
+++ b/apps/admin-fnp/hooks/use-notification-stream.ts
@@ -1,0 +1,34 @@
+"use client"
+
+import { useEffect } from "react"
+import { useQueryClient } from "@tanstack/react-query"
+
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL
+
+export function useNotificationStream(enabled: boolean) {
+  const queryClient = useQueryClient()
+
+  useEffect(() => {
+    if (!enabled || !BASE_URL) return
+
+    const eventSource = new EventSource(
+      `${BASE_URL}/v1/user/notifications/stream`,
+      { withCredentials: true }
+    )
+
+    eventSource.addEventListener("unread-count", (e) => {
+      const { count } = JSON.parse(e.data)
+      queryClient.setQueryData(["notifications", "unread-count"], { data: { count } })
+    })
+
+    eventSource.addEventListener("new-notification", () => {
+      queryClient.invalidateQueries({ queryKey: ["notifications", "recent"] })
+    })
+
+    eventSource.onerror = () => {
+      // EventSource auto-reconnects after ~3 seconds
+    }
+
+    return () => eventSource.close()
+  }, [enabled, queryClient])
+}

--- a/apps/admin-fnp/lib/query.ts
+++ b/apps/admin-fnp/lib/query.ts
@@ -1043,12 +1043,12 @@ export function queryMenuItemComponent(id: string) {
   return api.get(url)
 }
 
-export function addMenuItemComponent(data: { name: string; status: string }) {
+export function addMenuItemComponent(data: { name: string }) {
   let url = `${baseUrl}/menu-item-components/add`
   return api.post(url, data)
 }
 
-export function updateMenuItemComponent(data: { id: string; name: string; status: string }) {
+export function updateMenuItemComponent(data: { id: string; name: string }) {
   let url = `${baseUrl}/menu-item-components/update`
   return api.post(url, data)
 }

--- a/apps/admin-fnp/lib/query.ts
+++ b/apps/admin-fnp/lib/query.ts
@@ -919,6 +919,73 @@ export function queryDashboardStats() {
   return api.get(url)
 }
 
+// Orders & Sales
+type orderPagination = {
+  p?: number
+  search?: string
+  limit?: number
+  status?: string
+  order_type?: string
+}
+
+export function queryOrders(pagination?: orderPagination) {
+  const params = new URLSearchParams()
+  if (pagination?.p !== undefined && pagination.p >= 2) {
+    params.append("p", pagination.p.toString())
+  }
+  if (pagination?.search !== undefined && pagination.search.length >= 2) {
+    params.append("search", pagination.search)
+  }
+  if (pagination?.limit !== undefined) {
+    params.append("limit", pagination.limit.toString())
+  }
+  if (pagination?.status) {
+    params.append("status", pagination.status)
+  }
+  if (pagination?.order_type) {
+    params.append("order_type", pagination.order_type)
+  }
+  const qs = params.toString()
+  const url = `${baseUrl}/user/orders${qs ? `?${qs}` : ""}`
+  return api.get(url)
+}
+
+export function queryOrder(id: string) {
+  const url = `${baseUrl}/user/orders/${id}`
+  return api.get(url)
+}
+
+export function updateOrderStatus(data: { order_id: string; status: string; note?: string }) {
+  const url = `${baseUrl}/user/orders/update-status`
+  return api.post(url, data)
+}
+
+export function querySalesStats(orderType?: string) {
+  const params = new URLSearchParams()
+  if (orderType) {
+    params.append("order_type", orderType)
+  }
+  const qs = params.toString()
+  const url = `${baseUrl}/user/sales-stats${qs ? `?${qs}` : ""}`
+  return api.get(url)
+}
+
+// Notifications
+export function queryUnreadNotificationCount() {
+  const url = `${baseUrl}/user/notifications/unread-count`
+  return api.get(url)
+}
+
+export function queryRecentNotifications() {
+  const url = `${baseUrl}/user/notifications/recent`
+  return api.get(url)
+}
+
+export function markNotificationsRead(data: { ids?: string[]; all?: boolean }) {
+  const url = `${baseUrl}/user/notifications/mark-read`
+  return api.post(url, data)
+}
+
 // Restaurants
 export function addRestaurant(data: { name: string; status: string }) {
   let url = `${baseUrl}/restaurants/add`
@@ -984,6 +1051,43 @@ export function updateRestaurantLocation(data: any) {
 
 export function deleteRestaurantLocation(id: string) {
   let url = `${baseUrl}/restaurant-locations/delete/${id}`
+  return api.delete(url)
+}
+
+// Menu Categories
+export function queryMenuCategories(pagination?: pagination) {
+  const params = new URLSearchParams()
+  if (pagination?.p !== undefined && pagination.p >= 2) {
+    params.set("p", String(pagination.p))
+  }
+  if (pagination?.search !== undefined && pagination.search.length >= 2) {
+    params.set("search", pagination.search)
+  }
+  if (pagination?.limit !== undefined) {
+    params.set("limit", String(pagination.limit))
+  }
+  const qs = params.toString()
+  const url = `${baseUrl}/menu-categories/list${qs ? `?${qs}` : ""}`
+  return api.get(url)
+}
+
+export function queryMenuCategory(id: string) {
+  let url = `${baseUrl}/menu-categories/get/${id}`
+  return api.get(url)
+}
+
+export function addMenuCategory(data: { name: string; description: string }) {
+  let url = `${baseUrl}/menu-categories/add`
+  return api.post(url, data)
+}
+
+export function updateMenuCategory(data: { id: string; name: string; description: string }) {
+  let url = `${baseUrl}/menu-categories/update`
+  return api.post(url, data)
+}
+
+export function deleteMenuCategory(id: string) {
+  let url = `${baseUrl}/menu-categories/delete/${id}`
   return api.delete(url)
 }
 

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- Add sales overview dashboard with revenue cards and order counts for Farmnport and Restaurants
- Add orders table with channel and status filter tabs
- Add order detail page with status stepper, action buttons, and timeline
- Add notification bell with unread count badge and dropdown
- Add SSE hook for real-time notification delivery (toggleable)
- Bump version to 3.7.0

## Test plan
- [ ] Verify sales overview loads with stats cards and recent orders
- [ ] Test order list filtering by channel and status tabs
- [ ] Test order detail status transitions via action buttons
- [ ] Verify notification bell shows unread count and dropdown
- [ ] Test notification mark-as-read and navigation
- [ ] Verify restaurant sales pages load correctly