### PR TITLE
Improve Core Web Vitals: fix LCP and CLS performance

### DIFF
--- a/apps/client-fnp/app/(auth)/loading.tsx
+++ b/apps/client-fnp/app/(auth)/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div className="flex items-center justify-center min-h-[50vh]">
+      <div className="animate-spin h-8 w-8 border-2 border-gray-300 border-t-gray-900 rounded-full" />
+    </div>
+  )
+}

--- a/apps/client-fnp/app/(landing)/layout.tsx
+++ b/apps/client-fnp/app/(landing)/layout.tsx
@@ -1,21 +1,16 @@
 import { SiteHeader } from "@/components/layouts/site-header"
 import { SiteFooter } from "@/components/layouts/site-footer"
 import { ImpersonationBanner } from "@/components/structures/impersonation-banner"
-import { retrieveUser } from "@/lib/actions"
 
 interface RootLayoutProps {
     children: React.ReactNode
 }
 
-
-export default async function LandingLayout({ children }: RootLayoutProps) {
-
-    const user = await retrieveUser()
-
+export default function LandingLayout({ children }: RootLayoutProps) {
     return (
         <main>
-            <ImpersonationBanner user={user} />
-            <SiteHeader user={user} />
+            <ImpersonationBanner />
+            <SiteHeader />
             {children}
             <SiteFooter />
         </main>

--- a/apps/client-fnp/app/(landing)/loading.tsx
+++ b/apps/client-fnp/app/(landing)/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div className="flex items-center justify-center min-h-[50vh]">
+      <div className="animate-spin h-8 w-8 border-2 border-gray-300 border-t-gray-900 rounded-full" />
+    </div>
+  )
+}

--- a/apps/client-fnp/app/(resources)/layout.tsx
+++ b/apps/client-fnp/app/(resources)/layout.tsx
@@ -1,24 +1,18 @@
 import { SiteHeader } from "@/components/layouts/site-header"
 import { SiteFooter } from "@/components/layouts/site-footer"
 import { ImpersonationBanner } from "@/components/structures/impersonation-banner"
-import { retrieveUser } from "@/lib/actions"
 
 interface RootLayoutProps {
     children: React.ReactNode
 }
 
-
-export default async function LandingLayout({ children }: RootLayoutProps) {
-
-    const user = await retrieveUser()
-
+export default function LandingLayout({ children }: RootLayoutProps) {
     return (
         <div>
-            <ImpersonationBanner user={user} />
-            <SiteHeader user={user} />
+            <ImpersonationBanner />
+            <SiteHeader />
             {children}
             <SiteFooter />
-
         </div>
     )
 }

--- a/apps/client-fnp/app/(resources)/loading.tsx
+++ b/apps/client-fnp/app/(resources)/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div className="flex items-center justify-center min-h-[50vh]">
+      <div className="animate-spin h-8 w-8 border-2 border-gray-300 border-t-gray-900 rounded-full" />
+    </div>
+  )
+}

--- a/apps/client-fnp/app/layout.tsx
+++ b/apps/client-fnp/app/layout.tsx
@@ -12,7 +12,7 @@ import { SpeedInsights } from "@vercel/speed-insights/next"
 import { NuqsAdapter } from "nuqs/adapters/next/app"
 
 import { cn } from "@/lib/utilities"
-import { auth } from "@/auth"
+import { AuthSessionProvider } from "@/components/providers/AuthSessionProvider"
 
 
 import "@/styles/globals.css"
@@ -56,9 +56,7 @@ interface RootLayoutProps {
 const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID as string
 const NEXT_ENV = process.env.NEXT_ENV as string
 
-export default async function RootLayout({ children }: RootLayoutProps) {
-  const session = await auth()
-
+export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <>
       <html lang="en" suppressHydrationWarning>
@@ -70,6 +68,7 @@ export default async function RootLayout({ children }: RootLayoutProps) {
             fontHeading.variable
           )}
         >
+          <AuthSessionProvider>
           <ThemeProvider
             attribute="class"
             defaultTheme="light"
@@ -111,6 +110,7 @@ export default async function RootLayout({ children }: RootLayoutProps) {
               </NuqsAdapter>
             </QueryProvider>
           </ThemeProvider>
+          </AuthSessionProvider>
         </body>
       </html>
     </>

--- a/apps/client-fnp/app/loading.tsx
+++ b/apps/client-fnp/app/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div className="flex items-center justify-center min-h-[50vh]">
+      <div className="animate-spin h-8 w-8 border-2 border-gray-300 border-t-gray-900 rounded-full" />
+    </div>
+  )
+}

--- a/apps/client-fnp/components/ads/AdSenseInFeed.tsx
+++ b/apps/client-fnp/components/ads/AdSenseInFeed.tsx
@@ -38,7 +38,7 @@ export function AdSenseInFeed() {
     }, [])
 
     return (
-        <div className="my-4">
+        <div className="my-4 min-h-[100px]">
             <Script
                 async
                 src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9685248262342396"
@@ -47,7 +47,7 @@ export function AdSenseInFeed() {
             />
             <ins className="adsbygoogle"
                 ref={adRef}
-                style={{ display: adFilled ? "block" : "none" }}
+                style={{ display: "block" }}
                 data-ad-format="fluid"
                 data-ad-layout-key="-gw-3+1f-3d+2z"
                 data-ad-client="ca-pub-9685248262342396"

--- a/apps/client-fnp/components/layouts/site-header.tsx
+++ b/apps/client-fnp/components/layouts/site-header.tsx
@@ -1,14 +1,13 @@
 'use client'
 
+import { useSession } from "next-auth/react"
 import { MainNav } from "@/components/layouts/main-nav"
 import { MobileNav } from "@/components/layouts/mobile-nav"
-import {  AuthenticatedUser } from "@/lib/schemas"
+import { AuthenticatedUser } from "@/lib/schemas"
 
-interface SiteHeaderProps {
-  user: AuthenticatedUser | null
-}
-
-export function SiteHeader({ user }: SiteHeaderProps) {
+export function SiteHeader() {
+  const { data: session } = useSession()
+  const user = (session?.user as AuthenticatedUser) ?? undefined
 
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-background">

--- a/apps/client-fnp/components/providers/AuthSessionProvider.tsx
+++ b/apps/client-fnp/components/providers/AuthSessionProvider.tsx
@@ -1,0 +1,11 @@
+"use client"
+
+import { SessionProvider } from "next-auth/react"
+
+type AuthSessionProviderProps = {
+    children: React.ReactNode
+}
+
+export function AuthSessionProvider({ children }: AuthSessionProviderProps) {
+    return <SessionProvider>{children}</SessionProvider>
+}

--- a/apps/client-fnp/components/providers/QueryProvider.tsx
+++ b/apps/client-fnp/components/providers/QueryProvider.tsx
@@ -14,7 +14,8 @@ export function QueryProvider({ children }: QueryClientProps) {
     const [queryClient] = useState(() => new QueryClient({
         defaultOptions: {
             queries: {
-                staleTime: process.env.NODE_ENV === "production" ? 5 * 60 * 1000 : 0,
+                staleTime: process.env.NODE_ENV === "production" ? 30 * 60 * 1000 : 0,
+                gcTime: 60 * 60 * 1000,
                 refetchOnWindowFocus: false,
             },
         },

--- a/apps/client-fnp/components/structures/impersonation-banner.tsx
+++ b/apps/client-fnp/components/structures/impersonation-banner.tsx
@@ -1,15 +1,13 @@
 "use client"
 
-import { signOut } from "next-auth/react"
+import { useSession, signOut } from "next-auth/react"
 import { Icons } from "@/components/icons/lucide"
 import { Button } from "@/components/ui/button"
-import { AuthenticatedUser } from "@/lib/schemas"
 
-interface ImpersonationBannerProps {
-  user: AuthenticatedUser
-}
+export function ImpersonationBanner() {
+  const { data: session } = useSession()
+  const user = session?.user
 
-export function ImpersonationBanner({ user }: ImpersonationBannerProps) {
   if (!user?.impersonated_by) return null
 
   return (

--- a/apps/client-fnp/next.config.js
+++ b/apps/client-fnp/next.config.js
@@ -3,6 +3,7 @@ const nextConfig = {
   /* config options here */
   output: "standalone",
   images: {
+    minimumCacheTTL: 86400,
     dangerouslyAllowLocalIP: true,
     remotePatterns: [
       {

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",

--- a/apps/client-fnp/sentry.client.config.ts
+++ b/apps/client-fnp/sentry.client.config.ts
@@ -7,21 +7,8 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: "https://106493b0d84747b9b484020fe4c1c8a9@o144609.ingest.us.sentry.io/1212181",
 
-  // Add optional integrations for additional features
-  integrations: [
-    Sentry.replayIntegration(),
-  ],
-
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
-
-  // Define how likely Replay events are sampled.
-  // This sets the sample rate to be 10%. You may want this to be 100% while
-  // in development and sample at a lower rate in production
-  replaysSessionSampleRate: 0.1,
-
-  // Define how likely Replay events are sampled when an error occurs.
-  replaysOnErrorSampleRate: 1.0,
+  tracesSampleRate: 0.1,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/apps/client-fnp/sentry.edge.config.ts
+++ b/apps/client-fnp/sentry.edge.config.ts
@@ -9,7 +9,7 @@ Sentry.init({
   dsn: "https://106493b0d84747b9b484020fe4c1c8a9@o144609.ingest.us.sentry.io/1212181",
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
+  tracesSampleRate: 0.1,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/apps/client-fnp/sentry.server.config.ts
+++ b/apps/client-fnp/sentry.server.config.ts
@@ -8,7 +8,7 @@ Sentry.init({
   dsn: "https://106493b0d84747b9b484020fe4c1c8a9@o144609.ingest.us.sentry.io/1212181",
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: 1,
+  tracesSampleRate: 0.1,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,


### PR DESCRIPTION
## Summary
- Reduce Sentry tracing from 100% to 10% and remove replay integration to decrease client bundle and server overhead
- Remove blocking `auth()`/`retrieveUser()` calls from root, landing, and resources layouts — pages now render immediately
- Add `SessionProvider` + `useSession()` so SiteHeader and ImpersonationBanner hydrate user state client-side
- Add `loading.tsx` files for all route groups for instant navigation feedback
- Fix AdSense CLS by reserving min-height space for ad slots
- Increase React Query cache times and add 24h image cache TTL

## Test Plan
- [ ] Navigate between pages — loading spinner shows immediately
- [ ] Header renders instantly, user info hydrates client-side
- [ ] ImpersonationBanner still works when admin impersonates
- [ ] AdSense ads no longer cause visible layout shift
- [ ] Run PageSpeed Insights after deploy