### PR TITLE
Add city field to restaurant locations and standardize form padding

### DIFF
--- a/apps/admin-fnp/app/dashboard/restaurants/[id]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/[id]/edit/page.tsx
@@ -92,7 +92,7 @@ function EditRestaurantForm({ restaurant }: { restaurant: Restaurant }) {
     }
 
     return (
-        <div className="space-y-10">
+        <div className="space-y-10 px-4 py-6 sm:px-6 lg:px-8">
             <div className="flex items-center justify-between">
                 <div>
                     <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">

--- a/apps/admin-fnp/app/dashboard/restaurants/cuisine-categories/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/cuisine-categories/[slug]/edit/page.tsx
@@ -101,7 +101,7 @@ export default function EditCuisineCategoryPage() {
     }
 
     return (
-        <div className="space-y-10">
+        <div className="space-y-10 px-4 py-6 sm:px-6 lg:px-8">
             <div className="flex items-center justify-between">
                 <div>
                     <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">

--- a/apps/admin-fnp/app/dashboard/restaurants/cuisine-categories/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/cuisine-categories/new/page.tsx
@@ -54,7 +54,7 @@ export default function NewCuisineCategoryPage() {
     }
 
     return (
-        <div className="space-y-10">
+        <div className="space-y-10 px-4 py-6 sm:px-6 lg:px-8">
             <div className="flex items-center justify-between">
                 <div>
                     <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">

--- a/apps/admin-fnp/app/dashboard/restaurants/locations/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/locations/[slug]/edit/page.tsx
@@ -9,6 +9,7 @@ import { useRouter } from "next/navigation"
 import dynamic from "next/dynamic"
 
 import { updateRestaurantLocation, queryRestaurantLocation, queryRestaurants, queryCuisineCategories } from "@/lib/query"
+import { z } from "zod"
 import { RestaurantLocationSchema, RestaurantLocation, Restaurant, CuisineCategory } from "@/lib/schemas"
 import { cn } from "@/lib/utilities"
 import { buttonVariants } from "@/components/ui/button"
@@ -45,6 +46,7 @@ const EditFormSchema = RestaurantLocationSchema.pick({
     restaurant_id: true,
     name: true,
     address: true,
+    city: true,
     phone: true,
     email: true,
     latitude: true,
@@ -56,6 +58,8 @@ const EditFormSchema = RestaurantLocationSchema.pick({
     is_main: true,
     whatsapp_available: true,
     show_number: true,
+}).extend({
+    city: z.string().min(1, "City is required"),
 })
 
 type EditFormModel = typeof EditFormSchema._type
@@ -83,7 +87,7 @@ export default function EditRestaurantLocationPage({ params }: { params: Promise
 
     const { data: restaurantsData, isLoading: isLoadingRestaurants } = useQuery({
         queryKey: ["restaurants-for-select"],
-        queryFn: () => queryRestaurants({}),
+        queryFn: () => queryRestaurants({ limit: 200 }),
         refetchOnWindowFocus: false,
     })
 
@@ -128,6 +132,7 @@ function EditLocationForm({ location, restaurants, cuisineCategories }: { locati
             restaurant_id: location.restaurant_id,
             name: location.name,
             address: location.address,
+            city: location.city ?? "",
             phone: location.phone,
             email: location.email ?? "",
             latitude: Number(location.latitude) || 0,
@@ -168,7 +173,7 @@ function EditLocationForm({ location, restaurants, cuisineCategories }: { locati
     }
 
     return (
-        <div className="space-y-10">
+        <div className="space-y-10 px-4 py-6 sm:px-6 lg:px-8">
             <div className="flex items-center justify-between">
                 <div>
                     <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
@@ -211,7 +216,7 @@ function EditLocationForm({ location, restaurants, cuisineCategories }: { locati
                                             name="restaurant_id"
                                             render={({ field }) => (
                                                 <FormItem>
-                                                    <Select onValueChange={field.onChange} defaultValue={field.value}>
+                                                    <Select onValueChange={field.onChange} value={field.value}>
                                                         <FormControl>
                                                             <SelectTrigger className="w-full">
                                                                 <SelectValue placeholder="Select a restaurant" />
@@ -242,7 +247,7 @@ function EditLocationForm({ location, restaurants, cuisineCategories }: { locati
                                             name="status"
                                             render={({ field }) => (
                                                 <FormItem>
-                                                    <Select onValueChange={field.onChange} defaultValue={field.value}>
+                                                    <Select onValueChange={field.onChange} value={field.value}>
                                                         <FormControl>
                                                             <SelectTrigger className="w-full">
                                                                 <SelectValue placeholder="Select status" />
@@ -406,6 +411,9 @@ function EditLocationForm({ location, restaurants, cuisineCategories }: { locati
                                             if (data.address) {
                                                 form.setValue("address", data.address)
                                             }
+                                            if (data.city) {
+                                                form.setValue("city", data.city)
+                                            }
                                             form.setValue("latitude", data.latitude)
                                             form.setValue("longitude", data.longitude)
                                             if (data.place_id) {
@@ -522,6 +530,34 @@ function EditLocationForm({ location, restaurants, cuisineCategories }: { locati
                                                 )}
                                             />
                                         </div>
+                                    </div>
+
+                                    <div className="sm:col-span-3">
+                                        <label htmlFor="city" className="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                                            City
+                                        </label>
+                                        <div className="mt-2">
+                                            <FormField
+                                                control={form.control}
+                                                name="city"
+                                                render={({ field }) => (
+                                                    <FormItem>
+                                                        <FormControl>
+                                                            <Input
+                                                                id="city"
+                                                                placeholder="e.g. Harare, Bulawayo"
+                                                                className={inputClass}
+                                                                {...field}
+                                                            />
+                                                        </FormControl>
+                                                        <FormMessage />
+                                                    </FormItem>
+                                                )}
+                                            />
+                                        </div>
+                                        <p className="mt-2 text-sm/6 text-gray-500 dark:text-gray-400">
+                                            Auto-filled from Google Places. You can edit it.
+                                        </p>
                                     </div>
                                 </div>
                             </div>

--- a/apps/admin-fnp/app/dashboard/restaurants/locations/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/locations/new/page.tsx
@@ -44,7 +44,7 @@ export default function NewRestaurantLocationPage() {
 
     const { data: restaurantsData } = useQuery({
         queryKey: ["restaurants-for-select"],
-        queryFn: () => queryRestaurants({}),
+        queryFn: () => queryRestaurants({ limit: 200 }),
         refetchOnWindowFocus: false,
     })
 
@@ -63,6 +63,7 @@ export default function NewRestaurantLocationPage() {
             restaurant_id: "",
             name: "",
             address: "",
+            city: "",
             phone: "",
             email: "",
             latitude: 0,
@@ -108,7 +109,7 @@ export default function NewRestaurantLocationPage() {
     }
 
     return (
-        <div className="space-y-10">
+        <div className="space-y-10 px-4 py-6 sm:px-6 lg:px-8">
             <div className="flex items-center justify-between">
                 <div>
                     <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
@@ -268,6 +269,9 @@ export default function NewRestaurantLocationPage() {
                                             if (data.address) {
                                                 form.setValue("address", data.address)
                                             }
+                                            if (data.city) {
+                                                form.setValue("city", data.city)
+                                            }
                                             form.setValue("latitude", data.latitude)
                                             form.setValue("longitude", data.longitude)
                                             if (data.place_id) {
@@ -320,6 +324,34 @@ export default function NewRestaurantLocationPage() {
                                                             <Input
                                                                 id="address"
                                                                 placeholder="Enter full address"
+                                                                className={inputClass}
+                                                                {...field}
+                                                            />
+                                                        </FormControl>
+                                                        <FormMessage />
+                                                    </FormItem>
+                                                )}
+                                            />
+                                        </div>
+                                        <p className="mt-2 text-sm/6 text-gray-500 dark:text-gray-400">
+                                            Auto-filled from Google Places. You can edit it.
+                                        </p>
+                                    </div>
+
+                                    <div className="sm:col-span-3">
+                                        <label htmlFor="city" className="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                                            City
+                                        </label>
+                                        <div className="mt-2">
+                                            <FormField
+                                                control={form.control}
+                                                name="city"
+                                                render={({ field }) => (
+                                                    <FormItem>
+                                                        <FormControl>
+                                                            <Input
+                                                                id="city"
+                                                                placeholder="e.g. Harare, Bulawayo"
                                                                 className={inputClass}
                                                                 {...field}
                                                             />

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-item-add-ons/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-item-add-ons/[slug]/edit/page.tsx
@@ -195,7 +195,7 @@ export default function EditMenuItemAddOnPage() {
     }
 
     return (
-        <div className="space-y-10">
+        <div className="space-y-10 px-4 py-6 sm:px-6 lg:px-8">
             <div className="flex items-center justify-between">
                 <div>
                     <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-item-add-ons/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-item-add-ons/new/page.tsx
@@ -148,7 +148,7 @@ export default function NewMenuItemAddOnPage() {
     }
 
     return (
-        <div className="space-y-10">
+        <div className="space-y-10 px-4 py-6 sm:px-6 lg:px-8">
             <div className="flex items-center justify-between">
                 <div>
                     <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-item-categories/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-item-categories/[slug]/edit/page.tsx
@@ -97,7 +97,7 @@ export default function EditMenuItemCategoryPage() {
     }
 
     return (
-        <div className="space-y-10">
+        <div className="space-y-10 px-4 py-6 sm:px-6 lg:px-8">
             <div className="flex items-center justify-between">
                 <div>
                     <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-item-categories/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-item-categories/new/page.tsx
@@ -52,7 +52,7 @@ export default function NewMenuItemCategoryPage() {
     }
 
     return (
-        <div className="space-y-10">
+        <div className="space-y-10 px-4 py-6 sm:px-6 lg:px-8">
             <div className="flex items-center justify-between">
                 <div>
                     <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-item-components/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-item-components/[slug]/edit/page.tsx
@@ -99,7 +99,7 @@ export default function EditMenuItemComponentPage() {
     }
 
     return (
-        <div className="space-y-10">
+        <div className="space-y-10 px-4 py-6 sm:px-6 lg:px-8">
             <div className="flex items-center justify-between">
                 <div>
                     <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-item-components/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-item-components/new/page.tsx
@@ -52,7 +52,7 @@ export default function NewMenuItemComponentPage() {
     }
 
     return (
-        <div className="space-y-10">
+        <div className="space-y-10 px-4 py-6 sm:px-6 lg:px-8">
             <div className="flex items-center justify-between">
                 <div>
                     <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-items/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-items/[slug]/edit/page.tsx
@@ -223,7 +223,7 @@ export default function EditMenuItemPage() {
     }
 
     return (
-        <div className="space-y-10">
+        <div className="space-y-10 px-4 py-6 sm:px-6 lg:px-8">
 <div className="flex items-center justify-between">
                 <div>
                     <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-items/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-items/new/page.tsx
@@ -169,7 +169,7 @@ export default function NewMenuItemPage() {
     }
 
     return (
-        <div className="space-y-10">
+        <div className="space-y-10 px-4 py-6 sm:px-6 lg:px-8">
             <div className="flex items-center justify-between">
                 <div>
                     <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">

--- a/apps/admin-fnp/app/dashboard/restaurants/menus/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menus/[slug]/edit/page.tsx
@@ -143,7 +143,7 @@ export default function EditMenuPage() {
     }
 
     return (
-        <div className="space-y-10">
+        <div className="space-y-10 px-4 py-6 sm:px-6 lg:px-8">
             <div className="flex items-center justify-between">
                 <div>
                     <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">

--- a/apps/admin-fnp/app/dashboard/restaurants/menus/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menus/new/page.tsx
@@ -100,7 +100,7 @@ export default function NewMenuPage() {
     }
 
     return (
-        <div className="space-y-10">
+        <div className="space-y-10 px-4 py-6 sm:px-6 lg:px-8">
             <div className="flex items-center justify-between">
                 <div>
                     <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">

--- a/apps/admin-fnp/app/dashboard/restaurants/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/new/page.tsx
@@ -60,7 +60,7 @@ export default function NewRestaurantPage() {
     }
 
     return (
-        <div className="space-y-10">
+        <div className="space-y-10 px-4 py-6 sm:px-6 lg:px-8">
             <div className="flex items-center justify-between">
                 <div>
                     <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">

--- a/apps/admin-fnp/components/structures/columns/restaurant-locations.tsx
+++ b/apps/admin-fnp/components/structures/columns/restaurant-locations.tsx
@@ -42,6 +42,13 @@ export const restaurantLocationColumns: ColumnDef<RestaurantLocation>[] = [
     ),
   },
   {
+    accessorKey: "city",
+    header: "City",
+    cell: ({ row }) => (
+      <span className="capitalize">{row.original.city || "-"}</span>
+    ),
+  },
+  {
     accessorKey: "phone",
     header: "Phone",
   },

--- a/apps/admin-fnp/components/ui/location-picker.tsx
+++ b/apps/admin-fnp/components/ui/location-picker.tsx
@@ -8,6 +8,7 @@ interface PlaceResult {
     place_id: string
     address: string
     name: string
+    city: string
 }
 
 interface LocationPickerProps {
@@ -100,6 +101,7 @@ export function LocationPicker({ onSelect, latitude, longitude, defaultValue }: 
                 place_id: "",
                 address: "",
                 name: "",
+                city: "",
             })
         })
     }, [loaded])
@@ -111,7 +113,7 @@ export function LocationPicker({ onSelect, latitude, longitude, defaultValue }: 
         const autocomplete = new google.maps.places.Autocomplete(inputRef.current, {
             types: ["establishment", "geocode"],
             componentRestrictions: { country: "zw" },
-            fields: ["geometry", "place_id", "formatted_address", "name"],
+            fields: ["geometry", "place_id", "formatted_address", "name", "address_components"],
         })
 
         autocomplete.addListener("place_changed", () => {
@@ -123,12 +125,17 @@ export function LocationPicker({ onSelect, latitude, longitude, defaultValue }: 
 
             updateMapMarker(lat, lng)
 
+            const cityComponent = place.address_components?.find((c: { types: string[] }) =>
+                c.types.includes("locality")
+            )
+
             onSelectRef.current({
                 latitude: lat,
                 longitude: lng,
                 place_id: place.place_id || "",
                 address: place.formatted_address || "",
                 name: place.name || "",
+                city: cityComponent?.long_name || "",
             })
         })
     }, [loaded, updateMapMarker])

--- a/apps/admin-fnp/lib/query.ts
+++ b/apps/admin-fnp/lib/query.ts
@@ -1045,6 +1045,9 @@ export function queryRestaurants(pagination?: pagination) {
   if (pagination?.search !== undefined && pagination.search.length >= 2) {
     params.set("search", pagination.search)
   }
+  if (pagination?.limit !== undefined) {
+    params.set("limit", String(pagination.limit))
+  }
   const qs = params.toString()
   const url = `${baseUrl}/restaurants/list${qs ? `?${qs}` : ""}`
   return api.get(url)

--- a/apps/admin-fnp/lib/schemas.ts
+++ b/apps/admin-fnp/lib/schemas.ts
@@ -1103,6 +1103,7 @@ export const RestaurantLocationSchema = z.object({
   restaurant_name: z.string().optional(),
   name: z.string().min(1, "Location name is required").max(120, "Name cannot exceed 120 characters"),
   address: z.string().min(1, "Address is required"),
+  city: z.string().default(""),
   phone: z.string().min(1, "Phone number is required"),
   email: z.string().email().optional().or(z.literal("")),
   latitude: z.coerce.number().optional().default(0),
@@ -1125,6 +1126,7 @@ export const FormRestaurantLocationSchema = RestaurantLocationSchema.pick({
   restaurant_id: true,
   name: true,
   address: true,
+  city: true,
   phone: true,
   email: true,
   latitude: true,
@@ -1133,6 +1135,8 @@ export const FormRestaurantLocationSchema = RestaurantLocationSchema.pick({
   cuisine_categories: true,
   operating_hours: true,
   status: true,
+}).extend({
+  city: z.string().min(1, "City is required"),
 })
 
 export type OperatingHour = z.infer<typeof OperatingHourSchema>


### PR DESCRIPTION
## Summary
- Add mandatory city field to restaurant locations (auto-populated from Google Places)
- Add city column to locations table and include city in search
- Add limit param support to restaurant select dropdowns
- Fix controlled select values on edit page
- Standardize padding across all restaurant form pages

## Test Plan
- [x] Tested location create with city auto-fill
- [x] Tested location edit with city field
- [x] Verified all restaurant forms have consistent padding