### PR TITLE
Add menu categories page and size descriptions

### DIFF
--- a/apps/admin-fnp/app/dashboard/restaurants/menu-categories/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-categories/page.tsx
@@ -1,0 +1,15 @@
+import { DashboardHeader } from "@/components/state/dashboardHeader"
+import { DashboardShell } from "@/components/state/dashboardShell"
+import { MenuCategoriesTable } from "@/components/structures/tables/menu-categories"
+
+export default async function MenuCategoriesPage() {
+  return (
+    <DashboardShell>
+      <DashboardHeader
+        heading="Menu Categories"
+        text="Manage menu categories."
+      ></DashboardHeader>
+      <MenuCategoriesTable />
+    </DashboardShell>
+  )
+}

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-items/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-items/[slug]/edit/page.tsx
@@ -54,7 +54,7 @@ export default function EditMenuItemPage() {
     const [searchComponent, setSearchComponent] = useState("")
     const [openComponents, setOpenComponents] = useState(false)
     const [selectedTags, setSelectedTags] = useState<string[]>([])
-    const [sizes, setSizes] = useState<{ name: string; price_cents: string }[]>([])
+    const [sizes, setSizes] = useState<{ name: string; description: string; price_cents: string }[]>([])
     const [initialized, setInitialized] = useState(false)
 
     const availableTags = ["Vegetarian", "Vegetarian On Request", "Gluten Free", "Scrambled", "Fried", "Grilled"]
@@ -99,6 +99,7 @@ export default function EditMenuItemPage() {
             setSelectedTags(menuItem.tags || [])
             setSizes((menuItem.sizes || []).map(s => ({
                 name: s.name,
+                description: s.description || "",
                 price_cents: String(centsToDollarsFormInputs(s.price_cents || 0)),
             })))
             setInitialized(true)
@@ -198,6 +199,7 @@ export default function EditMenuItemPage() {
             composition: selectedComponents,
             sizes: sizes.filter(s => s.name.trim()).map(s => ({
                 name: s.name.trim(),
+                description: s.description.trim(),
                 price_cents: dollarsToCents(parseFloat(s.price_cents || "0")),
             })),
             tags: selectedTags,
@@ -386,54 +388,70 @@ export default function EditMenuItemPage() {
 
                             <div className="col-span-full">
                                 <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
-                                    Size Options
+                                    Options / Variants
                                 </label>
                                 <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
-                                    Add size variants if this item comes in multiple sizes (e.g. Small, Medium, Large).
+                                    Add options if this item has variants (e.g. On its own, + Single Side, Small, Large).
                                 </p>
-                                <div className="mt-3 space-y-3">
+                                <div className="mt-3 space-y-4">
                                     {sizes.map((size, index) => (
-                                        <div key={index} className="flex items-center gap-3">
-                                            <Input
-                                                placeholder="Size name (e.g. Medium)"
-                                                value={size.name}
-                                                onChange={(e) => {
-                                                    const updated = [...sizes]
-                                                    updated[index] = { ...updated[index], name: e.target.value }
-                                                    setSizes(updated)
-                                                }}
-                                                className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
-                                            />
-                                            <Input
-                                                type="number"
-                                                step="0.01"
-                                                min="0"
-                                                placeholder="Price ($)"
-                                                value={size.price_cents}
-                                                onChange={(e) => {
-                                                    const updated = [...sizes]
-                                                    updated[index] = { ...updated[index], price_cents: e.target.value }
-                                                    setSizes(updated)
-                                                }}
-                                                className="block w-40 rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
-                                            />
-                                            <button
-                                                type="button"
-                                                onClick={() => setSizes(sizes.filter((_, i) => i !== index))}
-                                                className="text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
-                                            >
-                                                <Icons.close className="w-4 h-4" />
-                                            </button>
+                                        <div key={index} className="rounded-lg border border-gray-200 p-4 dark:border-white/10">
+                                            <div className="flex items-start gap-3">
+                                                <div className="flex-1 space-y-3">
+                                                    <div className="flex items-center gap-3">
+                                                        <Input
+                                                            placeholder="Option name (e.g. On its own, + Single Side)"
+                                                            value={size.name}
+                                                            onChange={(e) => {
+                                                                const updated = [...sizes]
+                                                                updated[index] = { ...updated[index], name: e.target.value }
+                                                                setSizes(updated)
+                                                            }}
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                        />
+                                                        <Input
+                                                            type="number"
+                                                            step="0.01"
+                                                            min="0"
+                                                            placeholder="Price ($)"
+                                                            value={size.price_cents}
+                                                            onChange={(e) => {
+                                                                const updated = [...sizes]
+                                                                updated[index] = { ...updated[index], price_cents: e.target.value }
+                                                                setSizes(updated)
+                                                            }}
+                                                            className="block w-36 rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                        />
+                                                    </div>
+                                                    <Input
+                                                        placeholder="Description (e.g. Single Chips & a Nando's Roll)"
+                                                        value={size.description}
+                                                        onChange={(e) => {
+                                                            const updated = [...sizes]
+                                                            updated[index] = { ...updated[index], description: e.target.value }
+                                                            setSizes(updated)
+                                                        }}
+                                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                    />
+                                                </div>
+                                                <button
+                                                    type="button"
+                                                    onClick={() => setSizes(sizes.filter((_, i) => i !== index))}
+                                                    className="mt-1.5 text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+                                                >
+                                                    <Icons.close className="w-4 h-4" />
+                                                </button>
+                                            </div>
                                         </div>
                                     ))}
                                     <Button
                                         type="button"
                                         variant="outline"
                                         size="sm"
-                                        onClick={() => setSizes([...sizes, { name: "", price_cents: "" }])}
+                                        onClick={() => setSizes([...sizes, { name: "", description: "", price_cents: "" }])}
                                     >
                                         <Icons.add className="w-4 h-4 mr-1" />
-                                        Add Size
+                                        Add Option
                                     </Button>
                                 </div>
                             </div>

--- a/apps/admin-fnp/app/dashboard/restaurants/menu-items/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menu-items/new/page.tsx
@@ -51,7 +51,7 @@ export default function NewMenuItemPage() {
     const [searchComponent, setSearchComponent] = useState("")
     const [openComponents, setOpenComponents] = useState(false)
     const [selectedTags, setSelectedTags] = useState<string[]>([])
-    const [sizes, setSizes] = useState<{ name: string; price_cents: string }[]>([])
+    const [sizes, setSizes] = useState<{ name: string; description: string; price_cents: string }[]>([])
 
     const availableTags = ["Vegetarian", "Vegetarian On Request", "Gluten Free", "Scrambled", "Fried", "Grilled"]
 
@@ -161,6 +161,7 @@ export default function NewMenuItemPage() {
             composition: selectedComponents,
             sizes: sizes.filter(s => s.name.trim()).map(s => ({
                 name: s.name.trim(),
+                description: s.description.trim(),
                 price_cents: dollarsToCents(parseFloat(s.price_cents || "0")),
             })),
             tags: selectedTags,
@@ -332,54 +333,70 @@ export default function NewMenuItemPage() {
 
                             <div className="col-span-full">
                                 <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
-                                    Size Options
+                                    Options / Variants
                                 </label>
                                 <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
-                                    Add size variants if this item comes in multiple sizes (e.g. Small, Medium, Large).
+                                    Add options if this item has variants (e.g. On its own, + Single Side, Small, Large).
                                 </p>
-                                <div className="mt-3 space-y-3">
+                                <div className="mt-3 space-y-4">
                                     {sizes.map((size, index) => (
-                                        <div key={index} className="flex items-center gap-3">
-                                            <Input
-                                                placeholder="Size name (e.g. Medium)"
-                                                value={size.name}
-                                                onChange={(e) => {
-                                                    const updated = [...sizes]
-                                                    updated[index] = { ...updated[index], name: e.target.value }
-                                                    setSizes(updated)
-                                                }}
-                                                className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
-                                            />
-                                            <Input
-                                                type="number"
-                                                step="0.01"
-                                                min="0"
-                                                placeholder="Price ($)"
-                                                value={size.price_cents}
-                                                onChange={(e) => {
-                                                    const updated = [...sizes]
-                                                    updated[index] = { ...updated[index], price_cents: e.target.value }
-                                                    setSizes(updated)
-                                                }}
-                                                className="block w-40 rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
-                                            />
-                                            <button
-                                                type="button"
-                                                onClick={() => setSizes(sizes.filter((_, i) => i !== index))}
-                                                className="text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
-                                            >
-                                                <Icons.close className="w-4 h-4" />
-                                            </button>
+                                        <div key={index} className="rounded-lg border border-gray-200 p-4 dark:border-white/10">
+                                            <div className="flex items-start gap-3">
+                                                <div className="flex-1 space-y-3">
+                                                    <div className="flex items-center gap-3">
+                                                        <Input
+                                                            placeholder="Option name (e.g. On its own, + Single Side)"
+                                                            value={size.name}
+                                                            onChange={(e) => {
+                                                                const updated = [...sizes]
+                                                                updated[index] = { ...updated[index], name: e.target.value }
+                                                                setSizes(updated)
+                                                            }}
+                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                        />
+                                                        <Input
+                                                            type="number"
+                                                            step="0.01"
+                                                            min="0"
+                                                            placeholder="Price ($)"
+                                                            value={size.price_cents}
+                                                            onChange={(e) => {
+                                                                const updated = [...sizes]
+                                                                updated[index] = { ...updated[index], price_cents: e.target.value }
+                                                                setSizes(updated)
+                                                            }}
+                                                            className="block w-36 rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                        />
+                                                    </div>
+                                                    <Input
+                                                        placeholder="Description (e.g. Single Chips & a Nando's Roll)"
+                                                        value={size.description}
+                                                        onChange={(e) => {
+                                                            const updated = [...sizes]
+                                                            updated[index] = { ...updated[index], description: e.target.value }
+                                                            setSizes(updated)
+                                                        }}
+                                                        className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                    />
+                                                </div>
+                                                <button
+                                                    type="button"
+                                                    onClick={() => setSizes(sizes.filter((_, i) => i !== index))}
+                                                    className="mt-1.5 text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+                                                >
+                                                    <Icons.close className="w-4 h-4" />
+                                                </button>
+                                            </div>
                                         </div>
                                     ))}
                                     <Button
                                         type="button"
                                         variant="outline"
                                         size="sm"
-                                        onClick={() => setSizes([...sizes, { name: "", price_cents: "" }])}
+                                        onClick={() => setSizes([...sizes, { name: "", description: "", price_cents: "" }])}
                                     >
                                         <Icons.add className="w-4 h-4 mr-1" />
-                                        Add Size
+                                        Add Option
                                     </Button>
                                 </div>
                             </div>

--- a/apps/admin-fnp/app/dashboard/restaurants/menus/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menus/new/page.tsx
@@ -41,6 +41,8 @@ import {
 } from "@/components/ui/command"
 import { Badge } from "@/components/ui/badge"
 
+const inputClass = "block w-full rounded-md bg-white px-3.5 py-2.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+
 export default function NewMenuPage() {
     const router = useRouter()
     const [locationsOpen, setLocationsOpen] = useState(false)
@@ -122,111 +124,19 @@ export default function NewMenuPage() {
             <Form {...form}>
                 <form onSubmit={form.handleSubmit(onSubmit)}>
                     <div className="space-y-12">
+
+                        {/* Section 1: Menu Details */}
                         <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
                             <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
-                                Menu Information
+                                Menu Details
                             </h2>
                             <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
-                                e.g. Breakfast Menu, Lunch Menu, Weekend Special
+                                Basic information about this menu.
                             </p>
 
                             <div className="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
-                                <div className="sm:col-span-4 px-1">
-                                    <label
-                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
-                                    >
-                                        Locations
-                                    </label>
-                                    <div className="mt-2">
-                                        <FormField
-                                            control={form.control}
-                                            name="locations"
-                                            render={({ field }) => (
-                                                <FormItem>
-                                                    <Popover open={locationsOpen} onOpenChange={setLocationsOpen}>
-                                                        <PopoverTrigger asChild>
-                                                            <button
-                                                                type="button"
-                                                                role="combobox"
-                                                                aria-expanded={locationsOpen}
-                                                                className="flex w-full items-center justify-between rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 hover:bg-gray-50 dark:border-white/10 dark:bg-white/5 dark:text-white dark:hover:bg-white/10"
-                                                            >
-                                                                <span className="text-gray-400 dark:text-gray-500">
-                                                                    {field.value?.length
-                                                                        ? `${field.value.length} location${field.value.length > 1 ? "s" : ""} selected`
-                                                                        : "Select locations"}
-                                                                </span>
-                                                                <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                                                            </button>
-                                                        </PopoverTrigger>
-                                                        <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
-                                                            <Command>
-                                                                <CommandInput placeholder="Search locations..." />
-                                                                <CommandList>
-                                                                    <CommandEmpty>No locations found.</CommandEmpty>
-                                                                    <CommandGroup>
-                                                                        {locations.map((loc) => {
-                                                                            const isSelected = field.value?.some(
-                                                                                (l) => l.location_id === loc.id
-                                                                            )
-                                                                            return (
-                                                                                <CommandItem
-                                                                                    key={loc.id}
-                                                                                    value={loc.name}
-                                                                                    onSelect={() => {
-                                                                                        field.onChange(
-                                                                                            toggleLocation(loc, field.value || [])
-                                                                                        )
-                                                                                    }}
-                                                                                >
-                                                                                    <Check
-                                                                                        className={cn(
-                                                                                            "mr-2 h-4 w-4",
-                                                                                            isSelected ? "opacity-100" : "opacity-0"
-                                                                                        )}
-                                                                                    />
-                                                                                    <span className="capitalize">{loc.name}</span>
-                                                                                </CommandItem>
-                                                                            )
-                                                                        })}
-                                                                    </CommandGroup>
-                                                                </CommandList>
-                                                            </Command>
-                                                        </PopoverContent>
-                                                    </Popover>
-                                                    {field.value && field.value.length > 0 && (
-                                                        <div className="flex flex-wrap gap-1.5 mt-2">
-                                                            {field.value.map((loc) => (
-                                                                <Badge
-                                                                    key={loc.location_id}
-                                                                    variant="secondary"
-                                                                    className="capitalize cursor-pointer"
-                                                                    onClick={() => {
-                                                                        field.onChange(
-                                                                            field.value?.filter(
-                                                                                (l) => l.location_id !== loc.location_id
-                                                                            ) || []
-                                                                        )
-                                                                    }}
-                                                                >
-                                                                    {loc.location_name}
-                                                                    <X className="ml-1 h-3 w-3" />
-                                                                </Badge>
-                                                            ))}
-                                                        </div>
-                                                    )}
-                                                    <FormMessage />
-                                                </FormItem>
-                                            )}
-                                        />
-                                    </div>
-                                </div>
-
-                                <div className="sm:col-span-4 px-1">
-                                    <label
-                                        htmlFor="name"
-                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
-                                    >
+                                <div className="sm:col-span-3">
+                                    <label htmlFor="name" className="block text-sm/6 font-medium text-gray-900 dark:text-white">
                                         Menu Name
                                     </label>
                                     <div className="mt-2">
@@ -238,8 +148,8 @@ export default function NewMenuPage() {
                                                     <FormControl>
                                                         <Input
                                                             id="name"
-                                                            placeholder="Enter menu name"
-                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                            placeholder="e.g. Breakfast Menu, Lunch Menu"
+                                                            className={inputClass}
                                                             {...field}
                                                         />
                                                     </FormControl>
@@ -250,38 +160,8 @@ export default function NewMenuPage() {
                                     </div>
                                 </div>
 
-                                <div className="sm:col-span-4 px-1">
-                                    <label
-                                        htmlFor="note"
-                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
-                                    >
-                                        Note
-                                    </label>
-                                    <div className="mt-2">
-                                        <FormField
-                                            control={form.control}
-                                            name="note"
-                                            render={({ field }) => (
-                                                <FormItem>
-                                                    <FormControl>
-                                                        <Input
-                                                            id="note"
-                                                            placeholder="e.g. Served until 11:00 AM"
-                                                            className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
-                                                            {...field}
-                                                        />
-                                                    </FormControl>
-                                                    <FormMessage />
-                                                </FormItem>
-                                            )}
-                                        />
-                                    </div>
-                                </div>
-
-                                <div className="sm:col-span-4 px-1">
-                                    <label
-                                        className="block text-sm/6 font-medium text-gray-900 dark:text-white"
-                                    >
+                                <div className="sm:col-span-3">
+                                    <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">
                                         Status
                                     </label>
                                     <div className="mt-2">
@@ -307,29 +187,151 @@ export default function NewMenuPage() {
                                         />
                                     </div>
                                 </div>
+
+                                <div className="col-span-full">
+                                    <label htmlFor="note" className="block text-sm/6 font-medium text-gray-900 dark:text-white">
+                                        Note <span className="text-gray-400 font-normal">(optional)</span>
+                                    </label>
+                                    <div className="mt-2">
+                                        <FormField
+                                            control={form.control}
+                                            name="note"
+                                            render={({ field }) => (
+                                                <FormItem>
+                                                    <FormControl>
+                                                        <Input
+                                                            id="note"
+                                                            placeholder="e.g. Served until 11:00 AM"
+                                                            className={inputClass}
+                                                            {...field}
+                                                        />
+                                                    </FormControl>
+                                                    <FormMessage />
+                                                </FormItem>
+                                            )}
+                                        />
+                                    </div>
+                                </div>
                             </div>
                         </div>
 
+                        {/* Section 2: Locations */}
+                        <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
+                            <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                                Locations
+                            </h2>
+                            <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                                Select which restaurant locations this menu is available at.
+                            </p>
+
+                            <div className="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">
+                                <div className="sm:col-span-4">
+                                    <FormField
+                                        control={form.control}
+                                        name="locations"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <Popover open={locationsOpen} onOpenChange={setLocationsOpen}>
+                                                    <PopoverTrigger asChild>
+                                                        <button
+                                                            type="button"
+                                                            role="combobox"
+                                                            aria-expanded={locationsOpen}
+                                                            className="flex w-full items-center justify-between rounded-md bg-white px-3.5 py-2.5 text-sm text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 hover:bg-gray-50 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:hover:bg-white/10"
+                                                        >
+                                                            <span className="text-gray-400 dark:text-gray-500">
+                                                                {field.value?.length
+                                                                    ? `${field.value.length} location${field.value.length > 1 ? "s" : ""} selected`
+                                                                    : "Select locations"}
+                                                            </span>
+                                                            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                                                        </button>
+                                                    </PopoverTrigger>
+                                                    <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+                                                        <Command>
+                                                            <CommandInput placeholder="Search locations..." />
+                                                            <CommandList>
+                                                                <CommandEmpty>No locations found.</CommandEmpty>
+                                                                <CommandGroup>
+                                                                    {locations.map((loc) => {
+                                                                        const isSelected = field.value?.some(
+                                                                            (l) => l.location_id === loc.id
+                                                                        )
+                                                                        return (
+                                                                            <CommandItem
+                                                                                key={loc.id}
+                                                                                value={loc.name}
+                                                                                onSelect={() => {
+                                                                                    field.onChange(
+                                                                                        toggleLocation(loc, field.value || [])
+                                                                                    )
+                                                                                }}
+                                                                            >
+                                                                                <Check
+                                                                                    className={cn(
+                                                                                        "mr-2 h-4 w-4",
+                                                                                        isSelected ? "opacity-100" : "opacity-0"
+                                                                                    )}
+                                                                                />
+                                                                                <span className="capitalize">{loc.name}</span>
+                                                                            </CommandItem>
+                                                                        )
+                                                                    })}
+                                                                </CommandGroup>
+                                                            </CommandList>
+                                                        </Command>
+                                                    </PopoverContent>
+                                                </Popover>
+                                                {field.value && field.value.length > 0 && (
+                                                    <div className="flex flex-wrap gap-1.5 mt-3">
+                                                        {field.value.map((loc) => (
+                                                            <Badge
+                                                                key={loc.location_id}
+                                                                variant="secondary"
+                                                                className="capitalize cursor-pointer"
+                                                                onClick={() => {
+                                                                    field.onChange(
+                                                                        field.value?.filter(
+                                                                            (l) => l.location_id !== loc.location_id
+                                                                        ) || []
+                                                                    )
+                                                                }}
+                                                            >
+                                                                {loc.location_name}
+                                                                <X className="ml-1 h-3 w-3" />
+                                                            </Badge>
+                                                        ))}
+                                                    </div>
+                                                )}
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+                                </div>
+                            </div>
+                        </div>
+
+                        {/* Section 3: Category Notes */}
                         {categories.length > 0 && (
                             <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
-                                <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
-                                    Category Notes
-                                </h2>
-                                <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
-                                    Add notes for specific categories on this menu. e.g. &quot;All steaks are 14-day aged and served with your choice of sides&quot;
-                                </p>
+                                <div className="sticky top-0 z-10 bg-background pb-4 pt-2">
+                                    <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                                        Category Notes
+                                    </h2>
+                                    <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">
+                                        Add optional notes for specific menu categories, e.g. &quot;All steaks are 14-day aged and served with your choice of sides&quot;
+                                    </p>
+                                </div>
 
-                                <div className="mt-10 grid grid-cols-1 gap-x-6 gap-y-6 sm:grid-cols-6">
+                                <div className="mt-6 grid grid-cols-1 gap-x-6 gap-y-6 sm:grid-cols-6">
                                     {categories.map((cat) => (
-                                        <div key={cat.id} className="sm:col-span-4 px-1">
-                                            <label
-                                                className="block text-sm/6 font-medium text-gray-900 dark:text-white capitalize"
-                                            >
+                                        <div key={cat.id} className="sm:col-span-3">
+                                            <label className="block text-sm/6 font-medium text-gray-900 dark:text-white capitalize">
                                                 {cat.name}
                                             </label>
                                             <div className="mt-2">
                                                 <Input
-                                                    placeholder={`Note for ${cat.name} (optional)`}
+                                                    placeholder={`Note for ${cat.name}`}
                                                     value={form.watch("category_notes")?.[cat.id] || ""}
                                                     onChange={(e) => {
                                                         const current = form.getValues("category_notes") || {}
@@ -340,7 +342,7 @@ export default function NewMenuPage() {
                                                             form.setValue("category_notes", { ...current, [cat.id]: e.target.value }, { shouldDirty: true })
                                                         }
                                                     }}
-                                                    className="block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500 dark:focus:outline-indigo-500"
+                                                    className={inputClass}
                                                 />
                                             </div>
                                         </div>
@@ -361,7 +363,7 @@ export default function NewMenuPage() {
                         <button
                             type="submit"
                             disabled={isPending}
-                            className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-indigo-500 dark:shadow-none dark:hover:bg-indigo-400 dark:focus-visible:outline-indigo-500"
+                            className="inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600 disabled:opacity-50 disabled:cursor-not-allowed"
                         >
                             {isPending && <Icons.spinner className="w-4 h-4 mr-2 animate-spin" />}
                             Save

--- a/apps/admin-fnp/components/navigation/sidebar.tsx
+++ b/apps/admin-fnp/components/navigation/sidebar.tsx
@@ -25,7 +25,7 @@ export function SidebarNavigation({ navigationGroups }: SidebarNavigationProps) 
       const hasActiveItem = group.items.some(
         (item) => item.href && isActive(item.href)
       )
-      acc[index] = hasActiveItem || group.items.length <= 1
+      acc[index] = hasActiveItem || group.items.length <= 1 || !!group.alwaysOpen
       return acc
     },
     {}
@@ -40,7 +40,7 @@ export function SidebarNavigation({ navigationGroups }: SidebarNavigationProps) 
       const hasActiveItem = group.items.some(
         (item) => item.href && isActive(item.href)
       )
-      next[index] = hasActiveItem || group.items.length <= 1
+      next[index] = hasActiveItem || group.items.length <= 1 || !!group.alwaysOpen
     })
     setOpenGroups(next)
   }, [path])

--- a/apps/admin-fnp/components/structures/columns/menu-categories.tsx
+++ b/apps/admin-fnp/components/structures/columns/menu-categories.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import { ColumnDef } from "@tanstack/react-table"
+import { MenuCategory } from "@/lib/schemas"
+import { Checkbox } from "@/components/ui/checkbox"
+import { MenuCategoryDropDown } from "@/components/structures/dropdowns/menu-category-dropdown"
+
+export const menuCategoryColumns: ColumnDef<MenuCategory>[] = [
+  {
+    id: "select",
+    header: ({ table }) => (
+      <Checkbox
+        checked={table.getIsAllPageRowsSelected()}
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Select all"
+        className="translate-y-[2px]"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label="Select row"
+        className="translate-y-[2px]"
+      />
+    ),
+    enableSorting: false,
+    enableHiding: false,
+  },
+  {
+    accessorKey: "name",
+    header: "Name",
+  },
+  {
+    accessorKey: "slug",
+    header: "Slug",
+  },
+  {
+    accessorKey: "created",
+    header: "Date Added",
+    cell: ({ row }) => {
+      const date = row.original.created
+      if (!date) return "-"
+      return new Date(date).toLocaleDateString("en-GB", {
+        day: "numeric",
+        month: "short",
+        year: "numeric",
+      })
+    },
+  },
+  {
+    id: "actions",
+    cell: ({ row }) => <MenuCategoryDropDown category={row.original} />,
+  },
+]

--- a/apps/admin-fnp/components/structures/dropdowns/menu-category-dropdown.tsx
+++ b/apps/admin-fnp/components/structures/dropdowns/menu-category-dropdown.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import Link from "next/link"
+import { MoreHorizontal } from "lucide-react"
+
+import { MenuCategory } from "@/lib/schemas"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+interface MenuCategoryDropDownProps {
+  category?: MenuCategory
+}
+
+export function MenuCategoryDropDown({
+  category,
+}: MenuCategoryDropDownProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className="w-8 h-8 p-0">
+          <span className="sr-only">Open menu</span>
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Actions</DropdownMenuLabel>
+        <DropdownMenuItem>
+          <Link
+            className="w-full"
+            href={`/dashboard/restaurants/menu-categories/${category?.id}/edit`}
+          >
+            Edit
+          </Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/apps/admin-fnp/components/structures/tables/menu-categories.tsx
+++ b/apps/admin-fnp/components/structures/tables/menu-categories.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import { useState, useEffect, useRef } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { PaginationState } from "@tanstack/react-table"
+
+import { queryMenuCategories } from "@/lib/query"
+import { MenuCategory } from "@/lib/schemas"
+import { handleFetchError } from "@/lib/error-handler"
+import { Placeholder } from "@/components/state/placeholder"
+import { DataTable } from "@/components/structures/data-table"
+import { menuCategoryColumns } from "@/components/structures/columns/menu-categories"
+
+export function MenuCategoriesTable() {
+  const [search, setSearch] = useState("")
+
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 10,
+  })
+
+  const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
+    queryKey: ["dashboard-menu-categories", { p: pagination.pageIndex + 1, search }],
+    queryFn: () =>
+      queryMenuCategories({
+        p: pagination.pageIndex + 1,
+        search: search,
+      }),
+    refetchOnWindowFocus: false
+  })
+
+  const categories = data?.data?.data as MenuCategory[]
+  const total = data?.data?.total as number
+
+  const hasShownError = useRef(false)
+  useEffect(() => {
+    if (isError && !hasShownError.current) {
+      hasShownError.current = true
+      handleFetchError(error, {
+        onRetry: () => {
+          hasShownError.current = false
+          refetch()
+        },
+        context: "menu categories"
+      })
+    }
+    if (!isError) {
+      hasShownError.current = false
+    }
+  }, [isError, error, refetch])
+
+  if (isError) {
+    return (
+      <Placeholder>
+        <Placeholder.Icon name="close" />
+        <Placeholder.Title>Error Fetching Categories</Placeholder.Title>
+        <Placeholder.Description>
+          Error fetching menu categories from the database
+        </Placeholder.Description>
+      </Placeholder>
+    )
+  }
+
+  if (isLoading || isFetching) {
+    return (
+      <Placeholder>
+        <Placeholder.Title>Fetching Categories</Placeholder.Title>
+      </Placeholder>
+    )
+  }
+
+  return (
+    <DataTable
+      columns={menuCategoryColumns}
+      data={categories}
+      newUrl="/dashboard/restaurants/menu-categories/new"
+      tableName="Category"
+      total={total}
+      pagination={pagination}
+      setPagination={setPagination}
+      search={search}
+      setSearch={setSearch}
+    />
+  )
+}

--- a/apps/admin-fnp/config/restaurants-dashboard.ts
+++ b/apps/admin-fnp/config/restaurants-dashboard.ts
@@ -24,26 +24,12 @@ export const restaurantsDashboardConfig: DashboardConfig = {
       ],
     },
     {
-      label: "Sales",
-      items: [
-        {
-          title: "Overview",
-          href: "/dashboard/restaurants/sales",
-          icon: "barChart",
-        },
-        {
-          title: "Orders",
-          href: "/dashboard/restaurants/sales/orders",
-          icon: "shoppingCart",
-        },
-      ],
-    },
-    {
       label: "Menu Catalog",
+      alwaysOpen: true,
       items: [
         {
           title: "Menu Categories",
-          href: "/dashboard/restaurants/menu-categories",
+          href: "/dashboard/restaurants/menu-item-categories",
           icon: "layers",
         },
         {
@@ -57,11 +43,6 @@ export const restaurantsDashboardConfig: DashboardConfig = {
           icon: "utensilsCrossed",
         },
         {
-          title: "Categories",
-          href: "/dashboard/restaurants/menu-item-categories",
-          icon: "tag",
-        },
-        {
           title: "Add-Ons",
           href: "/dashboard/restaurants/menu-item-add-ons",
           icon: "sparkles",
@@ -70,6 +51,22 @@ export const restaurantsDashboardConfig: DashboardConfig = {
           title: "Components",
           href: "/dashboard/restaurants/menu-item-components",
           icon: "egg",
+        },
+      ],
+    },
+    {
+      label: "Sales",
+      alwaysOpen: true,
+      items: [
+        {
+          title: "Overview",
+          href: "/dashboard/restaurants/sales",
+          icon: "barChart",
+        },
+        {
+          title: "Orders",
+          href: "/dashboard/restaurants/sales/orders",
+          icon: "shoppingCart",
         },
       ],
     },

--- a/apps/admin-fnp/lib/schemas.ts
+++ b/apps/admin-fnp/lib/schemas.ts
@@ -1208,6 +1208,29 @@ export type MenuItemCategoryResponse = {
   data: MenuItemCategory[]
 }
 
+// Menu Category
+export const MenuCategorySchema = z.object({
+  id: z.string(),
+  name: z.string().min(1, "Name is required").max(120, "Name cannot exceed 120 characters"),
+  description: z.string().default(""),
+  slug: z.string().optional(),
+  created: z.string().optional(),
+  updated: z.string().optional(),
+})
+
+export const FormMenuCategorySchema = MenuCategorySchema.pick({
+  name: true,
+  description: true,
+})
+
+export type MenuCategory = z.infer<typeof MenuCategorySchema>
+export type FormMenuCategoryModel = z.infer<typeof FormMenuCategorySchema>
+
+export type MenuCategoryResponse = {
+  total: number
+  data: MenuCategory[]
+}
+
 // Cuisine Category
 export const CuisineCategorySchema = z.object({
   id: z.string(),
@@ -1260,6 +1283,7 @@ export const CompositionEntrySchema = z.object({
 
 export const MenuItemSizeSchema = z.object({
   name: z.string().min(1),
+  description: z.string().default(""),
   price_cents: z.number().default(0),
 })
 

--- a/apps/admin-fnp/types/index.d.ts
+++ b/apps/admin-fnp/types/index.d.ts
@@ -19,6 +19,7 @@ export type SidebarNavigationItem = {
 export type SidebarNavigationGroup = {
   label: string
   items: SidebarNavigationItem[]
+  alwaysOpen?: boolean
 }
 
 export type NavigationItem = {

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- Add menu categories listing page with table, columns, and dropdown
- Add MenuCategory schema and types
- Add description field to menu item sizes across new/edit forms
- Bump client-fnp to v3.11.0

## Test Plan
- [ ] Menu categories page loads at /dashboard/restaurants/menu-categories
- [ ] Menu item size description field works on new and edit pages