### PR TITLE
Disable Sentry tunnel route to reduce server CPU load

### DIFF
--- a/apps/client-fnp/next.config.js
+++ b/apps/client-fnp/next.config.js
@@ -70,7 +70,8 @@ module.exports = withSentryConfig(
     // This can increase your server load as well as your hosting bill.
     // Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
     // side errors will fail.
-    tunnelRoute: "/monitoring",
+    // tunnelRoute disabled — proxying Sentry through the server adds CPU load on a resource-constrained node
+    // tunnelRoute: "/monitoring",
 
     // Hides source maps from generated client bundles
     hideSourceMaps: true,


### PR DESCRIPTION
## Summary
- Disabled Sentry `tunnelRoute` that was proxying all monitoring traffic through the Next.js server
- Reduces CPU overhead on the server, Sentry reports directly from the client now

## Test plan
- [ ] Verify Sentry still receives error reports in the dashboard
- [ ] Confirm reduced CPU usage on the server