### PR TITLE
fix(client): use fetch for animal health product slug SSR

### DIFF
--- a/apps/client-fnp/app/(landing)/animal-health-guides/[category]/[slug]/layout.tsx
+++ b/apps/client-fnp/app/(landing)/animal-health-guides/[category]/[slug]/layout.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next'
-import { queryAnimalHealthProduct } from '@/lib/query'
+import { BaseURL } from '@/lib/schemas'
 
 interface LayoutProps {
   children: React.ReactNode
@@ -13,8 +13,11 @@ export async function generateMetadata({ params }: LayoutProps): Promise<Metadat
   const { category, slug } = await params
 
   try {
-    const response = await queryAnimalHealthProduct(slug)
-    const product = response?.data
+    const fetchOptions: RequestInit = process.env.NODE_ENV === "production"
+      ? { next: { revalidate: 3600 } } as RequestInit
+      : { cache: "no-store" }
+    const res = await fetch(`${BaseURL}/animalhealth/${slug}`, fetchOptions)
+    const product = res.ok ? await res.json() : null
 
     if (!product) {
       return {

--- a/apps/client-fnp/app/(landing)/animal-health-guides/[category]/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/animal-health-guides/[category]/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { Beaker, AlertTriangle } from "lucide-react"
 import Link from "next/link"
 import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
 import { capitalizeFirstLetter, formatUnit } from "@/lib/utilities"
-import { queryAnimalHealthProduct } from "@/lib/query"
+import { BaseURL } from "@/lib/schemas"
 
 interface GuidePageProps {
     params: Promise<{
@@ -20,10 +20,14 @@ const overviewDesc: Record<string, string> = {
     "biosecurity-disinfectants": "a biosecurity disinfectant designed for cleaning and sanitizing poultry and livestock housing. It helps eliminate pathogens and maintain a healthy environment.",
 }
 
+const fetchOptions: RequestInit = process.env.NODE_ENV === "production"
+    ? { next: { revalidate: 3600 } } as RequestInit
+    : { cache: "no-store" }
+
 export default async function AnimalHealthGuidePage({ params }: GuidePageProps) {
     const { category, slug } = await params
-    const response = await queryAnimalHealthProduct(slug)
-    const product = response?.data
+    const res = await fetch(`${BaseURL}/animalhealth/${slug}`, fetchOptions)
+    const product = res.ok ? await res.json() : null
 
     if (!product) {
         return (


### PR DESCRIPTION
## Summary
- Replace axios `queryAnimalHealthProduct` with Next.js `fetch` in the `[category]/[slug]` page and layout server components
- Root cause: axios doesn't work correctly for SSR inside the Kubernetes pod (gets 404 from what appears to be the frontend itself, not the backend)
- All other animal health pages already use `fetch` with the same `revalidate: 3600` pattern — this aligns the slug page with that convention

## Test Plan
- [ ] Visit `/animal-health-guides/tick-flea-control/triatix` — should show full product page
- [ ] Verify metadata (title, OG tags) renders correctly