### PR TITLE
Fix missing variants and precautions in agrochemical create form

### DIFF
--- a/apps/admin-fnp/app/dashboard/farmnport/agrochemicals/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/agrochemicals/new/page.tsx
@@ -26,6 +26,8 @@ export default function CreateAgroChemicalPage() {
         images: [],
         active_ingredients: [],
         dosage_rates: [],
+        variants: [],
+        precautions: [],
         stock_level: 0,
         available_for_sale: false,
         show_price: true,


### PR DESCRIPTION
Adds missing `variants` and `precautions` fields to initial state in agrochemical create page, fixing TypeScript build error.