### PR TITLE
Add product_overview field to agrochemical form and guide page

### DIFF
--- a/apps/admin-fnp/app/dashboard/farmnport/agrochemicals/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/agrochemicals/new/page.tsx
@@ -28,6 +28,7 @@ export default function CreateAgroChemicalPage() {
         dosage_rates: [],
         variants: [],
         precautions: [],
+        product_overview: "",
         stock_level: 0,
         available_for_sale: false,
         show_price: true,

--- a/apps/admin-fnp/components/structures/forms/agroChemicalForm.tsx
+++ b/apps/admin-fnp/components/structures/forms/agroChemicalForm.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/ui/form"
 
 import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
 import { toast } from "@/components/ui/use-toast"
 import { Icons } from "@/components/icons/lucide"
 import {
@@ -73,6 +74,7 @@ export function AgroChemicalForm({ agroChemical, mode = "create" }: AgroChemical
                 wholesale_price: v.wholesale_price ? v.wholesale_price / 100 : 0,
             })),
             precautions: agroChemical?.precautions || [],
+            product_overview: agroChemical?.product_overview || "",
             stock_level: agroChemical?.stock_level ?? 0,
             available_for_sale: agroChemical?.available_for_sale ?? false,
             show_price: agroChemical?.show_price ?? true,
@@ -707,6 +709,35 @@ export function AgroChemicalForm({ agroChemical, mode = "create" }: AgroChemical
                         >
                             + Add Pack Size
                         </Button>
+                    </div>
+                </div>
+
+                {/* Product Overview */}
+                <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
+                    <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                        Product Overview
+                    </h2>
+                    <p className="mt-1 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
+                        Custom overview text. If set, this replaces the auto-generated description on the product page.
+                    </p>
+                    <div className="mt-6">
+                        <FormField
+                            control={form.control}
+                            name="product_overview"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormControl>
+                                        <Textarea
+                                            placeholder="Enter a custom product overview..."
+                                            className="sm:max-w-2xl"
+                                            rows={4}
+                                            {...field}
+                                        />
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
                     </div>
                 </div>
 

--- a/apps/admin-fnp/components/structures/forms/productCreate.tsx
+++ b/apps/admin-fnp/components/structures/forms/productCreate.tsx
@@ -61,6 +61,7 @@ export function CreateAgroChemicalForm({ product }: EditFormProps) {
             images: product?.images || [],
             active_ingredients: product?.active_ingredients || [],
             dosage_rates: product?.dosage_rates || [],
+            product_overview: product?.product_overview || "",
         },
         resolver: zodResolver(FormAgroChemicalSchema),
     })

--- a/apps/admin-fnp/lib/schemas.ts
+++ b/apps/admin-fnp/lib/schemas.ts
@@ -513,6 +513,7 @@ export const AgroChemicalSchema = z.object({
     stock_level: z.coerce.number().int().nonnegative().default(0),
   })).optional().default([]),
   precautions: z.array(z.string()).optional().default([]),
+  product_overview: z.string().optional().default(""),
   stock_level: z.coerce.number().int().nonnegative().default(0),
   available_for_sale: z.boolean().default(false),
   show_price: z.boolean().default(true),

--- a/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/[slug]/page.tsx
@@ -267,7 +267,9 @@ export default async function AgroChemicalGuidePage({ params }: GuidePageProps) 
                         <div>
                             <h2 className="text-lg font-semibold mb-3 text-foreground">Overview</h2>
                             <p className="text-muted-foreground leading-relaxed text-sm">
-                                {chemical.agrochemical_category?.slug ? (
+                                {chemical.product_overview ? (
+                                    chemical.product_overview
+                                ) : chemical.agrochemical_category?.slug ? (
                                     <><span className="font-medium text-foreground">{capitalizeFirstLetter(chemical.name)}</span> is {overviewDesc[chemical.agrochemical_category.slug] || `a ${chemical.agrochemical_category.name.toLowerCase().replace(/s$/, '')} for effective crop protection. It provides targeted action while ensuring crop safety when used according to recommended guidelines.`}</>
                                 ) : (
                                     <><span className="font-medium text-foreground">{chemical.name}</span> is a professional agrochemical solution for crop protection and management in agricultural applications.</>


### PR DESCRIPTION
## Summary
- Add product_overview field to AgroChemical schema, form defaultValues, and create page initial state
- Add Product Overview textarea section to agroChemicalForm (shows before Precautions)
- Update client-fnp guide page to display custom product_overview when set, falling back to auto-generated text

## Test Plan
- [ ] Edit an agrochemical in admin, set product overview text, save
- [ ] Verify guide page shows custom text instead of auto-generated
- [ ] Verify empty product_overview falls back to auto-generated text