### PR TITLE
Move Product Overview field to after Name

### DIFF
--- a/apps/admin-fnp/components/structures/forms/agroChemicalForm.tsx
+++ b/apps/admin-fnp/components/structures/forms/agroChemicalForm.tsx
@@ -305,7 +305,7 @@ export function AgroChemicalForm({ agroChemical, mode = "create" }: AgroChemical
                                                 <Textarea
                                                     id="product_overview"
                                                     placeholder="Enter a custom product overview..."
-                                                    className="sm:max-w-2xl"
+                                                    className="sm:max-w-2xl px-3 py-2"
                                                     rows={4}
                                                     {...field}
                                                 />

--- a/apps/admin-fnp/components/structures/forms/agroChemicalForm.tsx
+++ b/apps/admin-fnp/components/structures/forms/agroChemicalForm.tsx
@@ -288,6 +288,35 @@ export function AgroChemicalForm({ agroChemical, mode = "create" }: AgroChemical
                             </div>
                         </div>
 
+                        <div className="sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6">
+                            <label
+                                htmlFor="product_overview"
+                                className="block text-sm/6 font-medium text-gray-900 sm:pt-1.5 dark:text-white"
+                            >
+                                Product Overview
+                            </label>
+                            <div className="mt-2 sm:col-span-2 sm:mt-0">
+                                <FormField
+                                    control={form.control}
+                                    name="product_overview"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormControl>
+                                                <Textarea
+                                                    id="product_overview"
+                                                    placeholder="Enter a custom product overview..."
+                                                    className="sm:max-w-2xl"
+                                                    rows={4}
+                                                    {...field}
+                                                />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                            </div>
+                        </div>
+
                         {isEditMode && agroChemical?.slug && (
                             <div className="sm:grid sm:grid-cols-3 sm:items-start sm:gap-4 sm:py-6">
                                 <label
@@ -709,35 +738,6 @@ export function AgroChemicalForm({ agroChemical, mode = "create" }: AgroChemical
                         >
                             + Add Pack Size
                         </Button>
-                    </div>
-                </div>
-
-                {/* Product Overview */}
-                <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
-                    <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
-                        Product Overview
-                    </h2>
-                    <p className="mt-1 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
-                        Custom overview text. If set, this replaces the auto-generated description on the product page.
-                    </p>
-                    <div className="mt-6">
-                        <FormField
-                            control={form.control}
-                            name="product_overview"
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormControl>
-                                        <Textarea
-                                            placeholder="Enter a custom product overview..."
-                                            className="sm:max-w-2xl"
-                                            rows={4}
-                                            {...field}
-                                        />
-                                    </FormControl>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
                     </div>
                 </div>
 

--- a/apps/admin-fnp/components/structures/forms/agroChemicalForm.tsx
+++ b/apps/admin-fnp/components/structures/forms/agroChemicalForm.tsx
@@ -499,7 +499,7 @@ export function AgroChemicalForm({ agroChemical, mode = "create" }: AgroChemical
                                     htmlFor="images"
                                     className="block text-sm/6 font-medium text-gray-900 dark:text-white"
                                 >
-                                    Product Images <span className="text-red-600">*</span>
+                                    Product Images
                                 </label>
                                 <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
                                     Upload product images to showcase this agrochemical.
@@ -525,7 +525,7 @@ export function AgroChemicalForm({ agroChemical, mode = "create" }: AgroChemical
                                             </FormControl>
                                             <FormMessage />
                                             <p className="mt-2 text-xs text-gray-500">
-                                                Upload up to 5 product images. At least 1 image is required.
+                                                Upload up to 5 product images.
                                             </p>
                                         </FormItem>
                                     )}

--- a/apps/admin-fnp/lib/schemas.ts
+++ b/apps/admin-fnp/lib/schemas.ts
@@ -472,7 +472,7 @@ export const AgroChemicalSchema = z.object({
   }).optional(),
   front_label: z.custom<ImageModel>().optional(),
   back_label: z.custom<ImageModel>().optional(),
-  images: z.array(z.custom<ImageModel>()).min(1, "At least one product image is required").max(5, "Maximum 5 images allowed"),
+  images: z.array(z.custom<ImageModel>()).max(5, "Maximum 5 images allowed"),
   active_ingredients: z.array(z.object({
     id: z.string(),
     name: z.string(),
@@ -737,7 +737,7 @@ export const AnimalHealthProductSchema = z.object({
   }).optional(),
   front_label: z.custom<ImageModel>().optional(),
   back_label: z.custom<ImageModel>().optional(),
-  images: z.array(z.custom<ImageModel>()).min(1, "At least one product image is required").max(5, "Maximum 5 images allowed"),
+  images: z.array(z.custom<ImageModel>()).max(5, "Maximum 5 images allowed"),
   active_ingredients: z.array(z.object({
     id: z.string(),
     name: z.string(),

--- a/apps/admin-fnp/package.json
+++ b/apps/admin-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin-farmnport",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3000",


### PR DESCRIPTION
Repositions the Product Overview textarea to appear directly after the Name field in the AgroChemical Information section.