### PR TITLE
feat: plant nutrition guides

### DIFF
--- a/.github/workflows/build-client.yml
+++ b/.github/workflows/build-client.yml
@@ -1,0 +1,45 @@
+name: Build & Push client-fnp
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build linux/arm64 image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: apps/client-fnp
+          platforms: linux/arm64
+          push: true
+          tags: |
+            ghcr.io/pajecha/frontend:${{ github.ref_name }}-arm64
+            ghcr.io/pajecha/frontend:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/apps/client-fnp/app/(landing)/guides/page.tsx
+++ b/apps/client-fnp/app/(landing)/guides/page.tsx
@@ -1,69 +1,28 @@
 import Link from "next/link"
-import {
-    Pill, Bug, Droplet, Rat, TrendingUp, Beaker, Shell, Shield,
-    ArrowRight, FlaskConical, Syringe, Heart, Scissors, Cross, Zap, Baby
-} from "lucide-react"
-import { BaseURL } from "@/lib/schemas"
+import { FlaskConical, Heart, Leaf } from "lucide-react"
 
-const fetchOptions: RequestInit = process.env.NODE_ENV === "production"
-    ? { next: { revalidate: 3600 } } as RequestInit
-    : { cache: "no-store" }
+const sections = [
+    {
+        title: "Agrochemical Guides",
+        description: "Pesticides, herbicides, and fungicides — active ingredients, targets, and usage by category.",
+        href: "/agrochemical-guides",
+        Icon: FlaskConical,
+    },
+    {
+        title: "Animal Health Guides",
+        description: "Vaccines, antibiotics, and supplements — dosage rates, withdrawal periods, and active ingredients for poultry and livestock.",
+        href: "/animal-health-guides",
+        Icon: Heart,
+    },
+    {
+        title: "Plant Nutrition Guides",
+        description: "Fertilizers, foliar feeds, biostimulants, and plant growth regulators — active ingredients and application rates.",
+        href: "/plant-nutrition-guides",
+        Icon: Leaf,
+    },
+]
 
-const agroIcons: Record<string, any> = {
-    "insecticides": Bug,
-    "fungicides": Shield,
-    "herbicides": Droplet,
-    "acaricides": Bug,
-    "nematicides": Droplet,
-    "rodenticides": Rat,
-    "plant-growth-regulators": TrendingUp,
-    "adjuvants": Beaker,
-    "molluscicides": Shell,
-    "bactericides": Pill,
-}
-
-const animalHealthIcons: Record<string, any> = {
-    "vaccines": Syringe,
-    "antibiotics": Pill,
-    "nutrition-supplements": Heart,
-    "anti-protozoa": Shield,
-    "biosecurity-disinfectants": Shield,
-    "tick-flea-control": Bug,
-    "worm-fluke-control": Scissors,
-    "wound-remedies": Cross,
-    "fly-control": Zap,
-    "stud-management": Baby,
-    "equipment": Beaker,
-}
-
-async function getAgroCategories() {
-    try {
-        const res = await fetch(`${BaseURL}/agrochemicalcategories/`, fetchOptions)
-        if (!res.ok) return []
-        const data = await res.json()
-        return data?.data || []
-    } catch {
-        return []
-    }
-}
-
-async function getAnimalHealthCategories() {
-    try {
-        const res = await fetch(`${BaseURL}/animalhealthcategories/`, fetchOptions)
-        if (!res.ok) return []
-        const data = await res.json()
-        return data?.data || []
-    } catch {
-        return []
-    }
-}
-
-export default async function GuidesPage() {
-    const [agroCategories, animalHealthCategories] = await Promise.all([
-        getAgroCategories(),
-        getAnimalHealthCategories(),
-    ])
-
+export default function GuidesPage() {
     return (
         <main className="bg-gradient-to-b from-background to-muted/20">
             {/* Hero */}
@@ -76,115 +35,40 @@ export default async function GuidesPage() {
                             Your Farming Knowledge Hub
                         </div>
                         <h1 className="text-4xl font-bold tracking-tight sm:text-5xl lg:text-6xl font-heading mb-3">
-                            Agrochemical &{" "}
-                            <span className="text-primary">Animal Health Guides</span>
+                            Farming{" "}
+                            <span className="text-primary">Guides</span>
                         </h1>
                         <p className="text-lg text-muted-foreground leading-7 max-w-2xl mx-auto">
-                            Dosage rates, active ingredients, and application guidelines for crop protection and livestock health — all in one place.
+                            Dosage rates, active ingredients, and application guidelines for crop protection, plant nutrition, and livestock health — all in one place.
                         </p>
                     </div>
                 </div>
             </section>
 
-            {/* Agrochemical Categories */}
-            <section className="py-6 lg:py-8 bg-muted/30">
-                <div className="mx-auto max-w-7xl px-6 lg:px-8">
-                    <div className="flex items-end justify-between mb-5">
-                        <div>
-                            <h2 className="text-3xl font-bold tracking-tight font-heading">
-                                Agrochemical Guides
-                            </h2>
-                            <p className="text-muted-foreground mt-2 max-w-lg">
-                                Pesticides, herbicides, and fungicides — active ingredients, targets, and usage by category.
-                            </p>
-                        </div>
-                        <Link
-                            href="/agrochemical-guides"
-                            className="hidden sm:flex items-center gap-1 text-sm font-medium text-primary hover:underline"
-                        >
-                            View All Agrochemical Products
-                            <ArrowRight className="h-4 w-4" />
-                        </Link>
+            {/* Guide Sections */}
+            <section className="py-10 lg:py-14">
+                <div className="mx-auto max-w-4xl px-6 lg:px-8">
+                    <div className="grid gap-6 sm:grid-cols-3">
+                        {sections.map(({ title, description, href, Icon }) => (
+                            <Link
+                                key={href}
+                                href={href}
+                                className="flex flex-col gap-4 p-6 rounded-xl bg-card border border-border hover:border-primary hover:shadow-md transition-all group"
+                            >
+                                <div className="flex items-center justify-center w-12 h-12 rounded-xl bg-primary/10 group-hover:bg-primary/20 transition-colors">
+                                    <Icon className="w-6 h-6 text-primary" strokeWidth={2} />
+                                </div>
+                                <div>
+                                    <h2 className="text-base font-semibold text-foreground group-hover:text-primary transition-colors mb-1">
+                                        {title}
+                                    </h2>
+                                    <p className="text-sm text-muted-foreground leading-relaxed">
+                                        {description}
+                                    </p>
+                                </div>
+                            </Link>
+                        ))}
                     </div>
-
-                    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-                        {agroCategories.map((category: any) => {
-                            const Icon = agroIcons[category.slug] || Pill
-                            return (
-                                <Link
-                                    key={category.slug}
-                                    href={`/agrochemical-guides/${category.slug}`}
-                                    className="flex flex-col items-center gap-3 p-6 rounded-xl bg-card border border-border hover:border-primary hover:shadow-md transition-all group"
-                                >
-                                    <div className="flex items-center justify-center w-14 h-14 rounded-xl bg-primary/10 group-hover:bg-primary/20 transition-colors">
-                                        <Icon className="w-6 h-6 text-primary" strokeWidth={2} />
-                                    </div>
-                                    <span className="text-sm font-medium text-center text-foreground group-hover:text-primary transition-colors">
-                                        {category.name}
-                                    </span>
-                                </Link>
-                            )
-                        })}
-                    </div>
-
-                    <Link
-                        href="/agrochemical-guides"
-                        className="sm:hidden flex items-center justify-center gap-1 text-sm font-medium text-primary hover:underline mt-6"
-                    >
-                        View All Agrochemical Products
-                        <ArrowRight className="h-4 w-4" />
-                    </Link>
-                </div>
-            </section>
-
-            {/* Animal Health Categories */}
-            <section className="py-6 lg:py-8">
-                <div className="mx-auto max-w-7xl px-6 lg:px-8">
-                    <div className="flex items-end justify-between mb-5">
-                        <div>
-                            <h2 className="text-3xl font-bold tracking-tight font-heading">
-                                Animal Health Guides
-                            </h2>
-                            <p className="text-muted-foreground mt-2 max-w-lg">
-                                Vaccines, antibiotics, and supplements — dosage rates, withdrawal periods, and active ingredients for poultry and livestock.
-                            </p>
-                        </div>
-                        <Link
-                            href="/animal-health-guides"
-                            className="hidden sm:flex items-center gap-1 text-sm font-medium text-primary hover:underline"
-                        >
-                            View All Animal Health Products
-                            <ArrowRight className="h-4 w-4" />
-                        </Link>
-                    </div>
-
-                    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
-                        {animalHealthCategories.map((category: any) => {
-                            const Icon = animalHealthIcons[category.slug] || Pill
-                            return (
-                                <Link
-                                    key={category.slug}
-                                    href={`/animal-health-guides/${category.slug}`}
-                                    className="flex flex-col items-center gap-3 p-5 rounded-xl bg-card border border-border hover:border-primary hover:bg-accent transition-all group"
-                                >
-                                    <div className="flex items-center justify-center w-12 h-12 rounded-lg bg-primary/10 group-hover:bg-primary/20 transition-colors">
-                                        <Icon className="w-5 h-5 text-primary" strokeWidth={2} />
-                                    </div>
-                                    <span className="text-sm font-medium text-center text-foreground group-hover:text-primary transition-colors">
-                                        {category.name}
-                                    </span>
-                                </Link>
-                            )
-                        })}
-                    </div>
-
-                    <Link
-                        href="/animal-health-guides"
-                        className="sm:hidden flex items-center justify-center gap-1 text-sm font-medium text-primary hover:underline mt-6"
-                    >
-                        View All Animal Health Products
-                        <ArrowRight className="h-4 w-4" />
-                    </Link>
                 </div>
             </section>
         </main>

--- a/apps/client-fnp/app/(landing)/page.tsx
+++ b/apps/client-fnp/app/(landing)/page.tsx
@@ -16,38 +16,14 @@ export const metadata = {
   },
 }
 
-const baseUrl = process.env.NEXT_PUBLIC_BASE_URL
-
-async function getMarketplaceCounts() {
-  try {
-    const [buyerRes, farmerRes] = await Promise.all([
-      fetch(`${baseUrl}/v1/buyer/count`, { next: { revalidate: 3600 } }),
-      fetch(`${baseUrl}/v1/farmer/count`, { next: { revalidate: 3600 } }),
-    ])
-
-    const buyers = buyerRes.ok ? await buyerRes.json() : { total: 0 }
-    const farmers = farmerRes.ok ? await farmerRes.json() : { total: 0 }
-
-    return {
-      buyers: buyers.total || 0,
-      farmers: farmers.total || 0,
-    }
-  } catch {
-    return { buyers: 0, farmers: 0 }
-  }
-}
 
 export default async function LandingPage() {
-  const [session, counts] = await Promise.all([
-    auth(),
-    getMarketplaceCounts(),
-  ])
+  const session = await auth()
   const user = session?.user
 
-  // Show dashboard for logged-in users, landing page for visitors
   if (user) {
     return <LoggedInDashboard user={user} />
   }
 
-  return <LoggedOutLanding counts={counts} />
+  return <LoggedOutLanding />
 }

--- a/apps/client-fnp/app/(landing)/plant-nutrition-guides/[category]/PlantNutritionCategoryClient.tsx
+++ b/apps/client-fnp/app/(landing)/plant-nutrition-guides/[category]/PlantNutritionCategoryClient.tsx
@@ -1,0 +1,96 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+import { queryPlantNutritionProductsByCategory } from "@/lib/query"
+import { Button } from "@/components/ui/button"
+import { Leaf } from "lucide-react"
+import { PlantNutritionCard } from "@/components/plantnutrition/PlantNutritionCard"
+import { useQueryStates, parseAsArrayOf, parseAsString, parseAsInteger } from "nuqs"
+import Link from "next/link"
+
+interface PlantNutritionCategoryClientProps {
+    category: string
+    categoryName: string
+    initialProducts: any[]
+    initialTotal: number
+}
+
+export function PlantNutritionCategoryClient({ category, categoryName, initialProducts, initialTotal }: PlantNutritionCategoryClientProps) {
+    const [queryState, setQueryState] = useQueryStates({
+        brand: parseAsArrayOf(parseAsString),
+        p: parseAsInteger.withDefault(1),
+    })
+
+    const hasFilters = (queryState.brand && queryState.brand.length > 0) || queryState.p > 1
+
+    const { data: productsData, isLoading } = useQuery({
+        queryKey: ["plant-nutrition-category", category, queryState.p, queryState.brand],
+        queryFn: () => queryPlantNutritionProductsByCategory({
+            category,
+            p: queryState.p,
+            brand: queryState.brand || [],
+        }),
+        refetchOnWindowFocus: false,
+        placeholderData: !hasFilters ? { data: { data: initialProducts, total: initialTotal } } as any : undefined,
+    })
+
+    const products = productsData?.data?.data || []
+    const totalPages = Math.ceil((productsData?.data?.total || 0) / 20)
+
+    return (
+        <>
+            <div className="mb-8">
+                <h1 className="text-4xl font-bold tracking-tight font-heading mb-4 capitalize">
+                    {categoryName}
+                </h1>
+                <p className="text-muted-foreground">
+                    {productsData?.data?.total || initialTotal} product{(productsData?.data?.total || initialTotal) !== 1 ? 's' : ''} found
+                </p>
+            </div>
+
+            {isLoading ? (
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+                    {[...Array(8)].map((_, i) => (
+                        <div key={i} className="bg-card border border-border rounded-lg overflow-hidden animate-pulse">
+                            <div className="aspect-square bg-muted" />
+                            <div className="p-4 space-y-2">
+                                <div className="h-3 bg-muted rounded w-1/2" />
+                                <div className="h-4 bg-muted rounded" />
+                                <div className="h-4 bg-muted rounded w-3/4" />
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            ) : products.length === 0 ? (
+                <div className="text-center py-16">
+                    <Leaf className="w-12 h-12 text-muted-foreground/30 mx-auto mb-4" />
+                    <p className="text-muted-foreground">No products found in this category.</p>
+                    <Link href="/plant-nutrition-guides" className="mt-4 inline-block">
+                        <Button variant="outline" size="sm">Browse Categories</Button>
+                    </Link>
+                </div>
+            ) : (
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+                    {products.map((product: any) => (
+                        <PlantNutritionCard key={product.id} product={product} />
+                    ))}
+                </div>
+            )}
+
+            {totalPages > 1 && (
+                <div className="flex justify-center gap-2 mt-8">
+                    {Array.from({ length: totalPages }, (_, i) => i + 1).map(page => (
+                        <Button
+                            key={page}
+                            variant={queryState.p === page ? "default" : "outline"}
+                            size="sm"
+                            onClick={() => setQueryState({ p: page })}
+                        >
+                            {page}
+                        </Button>
+                    ))}
+                </div>
+            )}
+        </>
+    )
+}

--- a/apps/client-fnp/app/(landing)/plant-nutrition-guides/[category]/[slug]/layout.tsx
+++ b/apps/client-fnp/app/(landing)/plant-nutrition-guides/[category]/[slug]/layout.tsx
@@ -1,0 +1,3 @@
+export default function PlantNutritionGuideLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/apps/client-fnp/app/(landing)/plant-nutrition-guides/[category]/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/plant-nutrition-guides/[category]/[slug]/page.tsx
@@ -1,0 +1,324 @@
+import Image from "next/image"
+import { Beaker, AlertTriangle } from "lucide-react"
+import Link from "next/link"
+import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
+import { capitalizeFirstLetter } from "@/lib/utilities"
+import { BaseURL } from "@/lib/schemas"
+import { FertilizerApplicationRates } from "@/components/agrochemical/FertilizerApplicationRates"
+import { ActiveIngredientUnitsKey } from "@/components/shared/ActiveIngredientUnitsKey"
+
+interface GuidePageProps {
+    params: Promise<{
+        category: string
+        slug: string
+    }>
+}
+
+const fetchOptions: RequestInit = process.env.NODE_ENV === "production"
+    ? { next: { revalidate: 3600 } } as RequestInit
+    : { cache: "no-store" }
+
+export default async function PlantNutritionGuidePage({ params }: GuidePageProps) {
+    const { category, slug } = await params
+    const res = await fetch(`${BaseURL}/plantnutrition/${slug}`, fetchOptions)
+    const product = res.ok ? await res.json() : null
+
+    if (!product) {
+        return (
+            <div className="min-h-screen bg-background flex items-center justify-center px-4 pb-4">
+                <div className="text-center max-w-md">
+                    <div className="mb-6">
+                        <div className="mx-auto w-20 h-20 bg-muted rounded-full flex items-center justify-center">
+                            <Beaker className="w-10 h-10 text-muted-foreground" />
+                        </div>
+                    </div>
+                    <h2 className="text-2xl font-semibold mb-2">Guide Not Found</h2>
+                    <p className="text-muted-foreground mb-6">
+                        We couldn&apos;t find the plant nutrition guide you&apos;re looking for. It may have been removed or the link might be incorrect.
+                    </p>
+                    <div className="flex flex-col sm:flex-row gap-3 justify-center">
+                        <Link href="/plant-nutrition-guides/all">
+                            <button className="inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">
+                                Browse All Guides
+                            </button>
+                        </Link>
+                        <Link href="/plant-nutrition-guides">
+                            <button className="inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">
+                                Go to Categories
+                            </button>
+                        </Link>
+                    </div>
+                </div>
+            </div>
+        )
+    }
+
+    const categorySlug = product?.plant_nutrition_category?.slug || category
+
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://farmnport.com'
+    const url = `${baseUrl}/plant-nutrition-guides/${category}/${slug}`
+    const imageUrl = product.images?.[0]?.img?.src || `${baseUrl}/default-chemical.png`
+
+    const description = product.plant_nutrition_category?.name
+        ? `${product.name} is a ${product.plant_nutrition_category.name}. View active ingredients and application rates.`
+        : `Plant nutrition guide for ${product.name}. Complete information on active ingredients and application rates.`
+
+    const structuredData = {
+        "@context": "https://schema.org",
+        "@type": "Product",
+        "name": product.name,
+        "description": description,
+        "image": imageUrl,
+        "category": product.plant_nutrition_category?.name || "Plant Nutrition",
+        "url": url,
+        "additionalProperty": product.active_ingredients?.map((ai: any) => ({
+            "@type": "PropertyValue",
+            "name": "Active Ingredient",
+            "value": `${ai.name} (${ai.dosage_value} ${ai.dosage_unit})`
+        })) || [],
+        "brand": product.brand ? { "@type": "Brand", "name": product.brand.name } : undefined,
+    }
+
+    return (
+        <div className="min-h-screen bg-background">
+            <script
+                type="application/ld+json"
+                dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+            />
+
+            {/* Breadcrumb */}
+            <div className="border-b">
+                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+                    <nav className="flex text-sm text-muted-foreground">
+                        <Link href="/" className="hover:text-foreground">Home</Link>
+                        <span className="mx-2">/</span>
+                        <Link href="/plant-nutrition-guides/all" className="hover:text-foreground">Guides</Link>
+                        <span className="mx-2">/</span>
+                        <Link href={`/plant-nutrition-guides/${categorySlug}`} className="hover:text-foreground capitalize">{product.plant_nutrition_category?.name || category}</Link>
+                        <span className="mx-2">/</span>
+                        <span className="text-foreground capitalize">{product.name}</span>
+                    </nav>
+                </div>
+            </div>
+
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                {/* Header Section */}
+                <div className="grid lg:grid-cols-[450px,1fr] gap-12 mb-16">
+                    {/* Left - Image + Precautions */}
+                    <div className="space-y-4">
+                        <div className="relative aspect-square bg-white rounded-xl border overflow-hidden shadow-sm">
+                            {product.images && product.images[0] && product.images[0].img?.src ? (
+                                <Image
+                                    src={product.images[0].img.src}
+                                    alt={product.name}
+                                    fill
+                                    sizes="(max-width: 1024px) 100vw, 450px"
+                                    className="object-contain p-8"
+                                    priority
+                                />
+                            ) : (
+                                <div className="absolute inset-0 flex items-center justify-center">
+                                    <Beaker className="w-24 h-24 text-muted-foreground/30" />
+                                </div>
+                            )}
+                        </div>
+
+                        {/* Thumbnail Gallery */}
+                        {product.images && product.images.length > 1 && (
+                            <div className="grid grid-cols-4 gap-3">
+                                {product.images.slice(0, 4).map((img: any, idx: number) => (
+                                    <div key={idx} className="relative aspect-square bg-white rounded-lg border hover:border-primary transition-colors">
+                                        {img.img?.src && (
+                                            <Image
+                                                src={img.img.src}
+                                                alt={`${product.name} ${idx + 1}`}
+                                                fill
+                                                sizes="(max-width: 1024px) 25vw, 100px"
+                                                className="object-contain p-2"
+                                            />
+                                        )}
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+
+                        {/* Precautions */}
+                        {product.precautions && product.precautions.length > 0 && (
+                            <div className="rounded-lg border border-red-200 dark:border-red-900 bg-red-50/50 dark:bg-red-950/30 px-3 py-2">
+                                <h2 className="text-xs font-semibold uppercase tracking-wide text-red-700 dark:text-red-400 mb-1.5 flex items-center gap-1.5">
+                                    <AlertTriangle className="w-3.5 h-3.5" />
+                                    Precautions
+                                </h2>
+                                <ul className="space-y-0.5">
+                                    {product.precautions.map((precaution: string, idx: number) => (
+                                        <li key={idx} className="flex items-start gap-1.5 text-xs text-red-800 dark:text-red-300">
+                                            <span className="h-1 w-1 rounded-full bg-red-500 dark:bg-red-400 flex-shrink-0 mt-1.5" />
+                                            <span>{precaution}</span>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                        )}
+                    </div>
+
+                    {/* Right - Product Info */}
+                    <div className="space-y-6">
+                        <h1 className="text-3xl lg:text-4xl font-bold capitalize leading-tight">
+                            {product.name}
+                        </h1>
+
+                        {/* Category Badge */}
+                        <div className="flex items-center gap-3 flex-wrap">
+                            {product.plant_nutrition_category && (
+                                <div className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300">
+                                    {product.plant_nutrition_category.name}
+                                </div>
+                            )}
+                        </div>
+
+                        {/* Variants / Pack Sizes */}
+                        {product.variants && product.variants.length > 0 && (
+                            <div>
+                                <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground mb-3">Pack Sizes & Pricing</h2>
+                                <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                                    {product.variants.map((variant: any, idx: number) => (
+                                        <div key={idx} className="rounded-lg border bg-card p-3 flex flex-col gap-1">
+                                            <span className="text-sm font-medium text-foreground">{variant.name}</span>
+                                            {variant.sale_price > 0 && (
+                                                <div className="flex items-baseline gap-1.5">
+                                                    {variant.was_price > 0 && variant.was_price > variant.sale_price && (
+                                                        <span className="text-xs text-muted-foreground line-through">${(variant.was_price / 100).toFixed(2)}</span>
+                                                    )}
+                                                    <span className="text-base font-bold text-primary">${(variant.sale_price / 100).toFixed(2)}</span>
+                                                </div>
+                                            )}
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        )}
+
+                        {(!product.variants || product.variants.length === 0) && product.show_price && product.sale_price > 0 && (
+                            <div className="flex items-center gap-3">
+                                <span className="text-sm text-muted-foreground">Guide Price:</span>
+                                {product.was_price > 0 && product.was_price > product.sale_price && (
+                                    <span className="text-lg text-muted-foreground line-through">${(product.was_price / 100).toFixed(2)}</span>
+                                )}
+                                <span className="text-2xl font-bold text-primary">${(product.sale_price / 100).toFixed(2)}</span>
+                            </div>
+                        )}
+
+                        <div className="h-px bg-border" />
+
+                        {/* Overview */}
+                        <div>
+                            <h2 className="text-lg font-semibold mb-3 text-foreground">Overview</h2>
+                            <p className="text-muted-foreground leading-relaxed text-sm">
+                                {product.description ? (
+                                    product.description
+                                ) : (
+                                    <><span className="font-medium text-foreground">{capitalizeFirstLetter(product.name)}</span> is a {product.plant_nutrition_category?.name?.toLowerCase() || 'plant nutrition product'} designed to support crop health and productivity.</>
+                                )}
+                            </p>
+                        </div>
+
+                        {/* Active Ingredients */}
+                        <div>
+                            <h2 className="text-lg font-semibold mb-1 text-foreground">Active Ingredients</h2>
+                            {product.active_ingredients && product.active_ingredients.length > 0 ? (
+                                <>
+                                    <ActiveIngredientUnitsKey activeIngredients={product.active_ingredients} />
+                                    <div className="grid grid-cols-2 gap-1.5 mt-3">
+                                        {product.active_ingredients.map((ai: any, idx: number) => (
+                                            <div key={idx} className="flex items-center justify-between px-3 py-2 bg-gradient-to-r from-purple-50/50 to-transparent dark:from-purple-950/30 rounded-lg border border-purple-100 dark:border-purple-900">
+                                                <div className="font-medium capitalize text-sm text-foreground">{ai.name}</div>
+                                                <div className="font-bold text-purple-600 dark:text-purple-400 text-sm ml-2 shrink-0">{ai.dosage_value} {ai.dosage_unit}</div>
+                                            </div>
+                                        ))}
+                                    </div>
+                                </>
+                            ) : (
+                                <p className="text-sm text-muted-foreground p-4 bg-muted/30 rounded-lg border">No active ingredient information available.</p>
+                            )}
+                        </div>
+
+                        <AdSenseInFeed />
+
+                        {/* Used On */}
+                        {product.dosage_rates && product.dosage_rates.length > 0 && (
+                            <div className="rounded-xl border bg-card p-4">
+                                <h2 className="text-sm font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-400 mb-3">
+                                    Used On
+                                </h2>
+                                <ul className="space-y-1.5">
+                                    {Array.from(new Set(product.dosage_rates.map((rate: any) => rate.crop_group))).map((crop: any, idx: number) => (
+                                        <li key={idx} className="flex items-center gap-2 text-sm text-foreground">
+                                            <span className="h-1.5 w-1.5 rounded-full bg-amber-500 dark:bg-amber-400 flex-shrink-0" />
+                                            <span className="capitalize">{crop}</span>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                        )}
+                    </div>
+                </div>
+
+                {/* Application Rates */}
+                {product.dosage_rates && product.dosage_rates.length > 0 && (
+                    <FertilizerApplicationRates dosageRates={product.dosage_rates} />
+                )}
+
+                {/* Product Labels */}
+                {(product.front_label?.img?.src || product.back_label?.img?.src) && (
+                    <div className="mb-12">
+                        <h2 className="text-2xl font-bold mb-6">Product Labels</h2>
+                        <div className="grid md:grid-cols-2 gap-6">
+                            {product.front_label?.img?.src && (
+                                <div className="space-y-3">
+                                    <h3 className="text-lg font-semibold">Front Label</h3>
+                                    <div className="relative aspect-[3/4] bg-white rounded-lg border overflow-hidden">
+                                        <Image
+                                            src={product.front_label.img.src}
+                                            alt={`${product.name} - Front Label`}
+                                            fill
+                                            sizes="(max-width: 768px) 100vw, 50vw"
+                                            className="object-contain p-4"
+                                        />
+                                    </div>
+                                </div>
+                            )}
+                            {product.back_label?.img?.src && (
+                                <div className="space-y-3">
+                                    <h3 className="text-lg font-semibold">Back Label</h3>
+                                    <div className="relative aspect-[3/4] bg-white rounded-lg border overflow-hidden">
+                                        <Image
+                                            src={product.back_label.img.src}
+                                            alt={`${product.name} - Back Label`}
+                                            fill
+                                            sizes="(max-width: 768px) 100vw, 50vw"
+                                            className="object-contain p-4"
+                                        />
+                                    </div>
+                                </div>
+                            )}
+                        </div>
+                    </div>
+                )}
+
+                {/* Safety Warning */}
+                <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-lg p-6">
+                    <div className="flex items-start gap-3">
+                        <AlertTriangle className="w-6 h-6 text-yellow-600 dark:text-yellow-500 flex-shrink-0" />
+                        <div>
+                            <h3 className="font-semibold mb-2 text-yellow-900 dark:text-yellow-100">Safety Information</h3>
+                            <p className="text-sm text-yellow-800 dark:text-yellow-200">
+                                Always read and follow label directions. Wear appropriate personal protective equipment (PPE) when handling plant nutrition products.
+                                Store in original containers in a secure location away from children and animals. Dispose of containers properly according to local regulations.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/apps/client-fnp/app/(landing)/plant-nutrition-guides/[category]/layout.tsx
+++ b/apps/client-fnp/app/(landing)/plant-nutrition-guides/[category]/layout.tsx
@@ -1,0 +1,3 @@
+export default function PlantNutritionCategoryLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/apps/client-fnp/app/(landing)/plant-nutrition-guides/[category]/page.tsx
+++ b/apps/client-fnp/app/(landing)/plant-nutrition-guides/[category]/page.tsx
@@ -1,0 +1,54 @@
+import Link from "next/link"
+import { BaseURL } from "@/lib/schemas"
+import { PlantNutritionCategoryClient } from "./PlantNutritionCategoryClient"
+
+const fetchOptions: RequestInit = process.env.NODE_ENV === "production"
+    ? { next: { revalidate: 3600 } } as RequestInit
+    : { cache: "no-store" }
+
+async function getCategoryProducts(category: string) {
+    try {
+        const res = await fetch(`${BaseURL}/plantnutrition/category/${category}`, fetchOptions)
+        if (!res.ok) return { data: [], total: 0 }
+        const json = await res.json()
+        return { data: json?.data || [], total: json?.total || 0 }
+    } catch {
+        return { data: [], total: 0 }
+    }
+}
+
+interface CategoryPageProps {
+    params: Promise<{ category: string }>
+}
+
+export default async function PlantNutritionCategoryPage({ params }: CategoryPageProps) {
+    const { category } = await params
+    const { data: products, total } = await getCategoryProducts(category)
+
+    const categoryName = products[0]?.plant_nutrition_category?.name || category.replace(/-/g, ' ')
+
+    return (
+        <div className="min-h-screen bg-gradient-to-b from-background to-muted/20">
+            <div className="border-b">
+                <div className="max-w-7xl mx-auto px-6 lg:px-8 py-3">
+                    <nav className="flex text-sm text-muted-foreground">
+                        <Link href="/" className="hover:text-foreground">Home</Link>
+                        <span className="mx-2">/</span>
+                        <Link href="/plant-nutrition-guides" className="hover:text-foreground">Plant Nutrition</Link>
+                        <span className="mx-2">/</span>
+                        <span className="text-foreground capitalize">{categoryName}</span>
+                    </nav>
+                </div>
+            </div>
+
+            <div className="mx-auto max-w-7xl px-6 lg:px-8 py-12">
+                <PlantNutritionCategoryClient
+                    category={category}
+                    categoryName={categoryName}
+                    initialProducts={products}
+                    initialTotal={total}
+                />
+            </div>
+        </div>
+    )
+}

--- a/apps/client-fnp/app/(landing)/plant-nutrition-guides/all/page.tsx
+++ b/apps/client-fnp/app/(landing)/plant-nutrition-guides/all/page.tsx
@@ -1,0 +1,51 @@
+import { BaseURL } from "@/lib/schemas"
+import Link from "next/link"
+import { PlantNutritionCard } from "@/components/plantnutrition/PlantNutritionCard"
+
+const fetchOptions: RequestInit = process.env.NODE_ENV === "production"
+    ? { next: { revalidate: 3600 } } as RequestInit
+    : { cache: "no-store" }
+
+async function getAllProducts() {
+    try {
+        const res = await fetch(`${BaseURL}/plantnutrition/all`, fetchOptions)
+        if (!res.ok) return { data: [], total: 0 }
+        const json = await res.json()
+        return { data: json?.data || [], total: json?.total || 0 }
+    } catch {
+        return { data: [], total: 0 }
+    }
+}
+
+export default async function AllPlantNutritionPage() {
+    const { data: products, total } = await getAllProducts()
+
+    return (
+        <div className="min-h-screen bg-gradient-to-b from-background to-muted/20">
+            <div className="border-b">
+                <div className="max-w-7xl mx-auto px-6 lg:px-8 py-3">
+                    <nav className="flex text-sm text-muted-foreground">
+                        <Link href="/" className="hover:text-foreground">Home</Link>
+                        <span className="mx-2">/</span>
+                        <Link href="/plant-nutrition-guides" className="hover:text-foreground">Plant Nutrition</Link>
+                        <span className="mx-2">/</span>
+                        <span className="text-foreground">All</span>
+                    </nav>
+                </div>
+            </div>
+
+            <div className="mx-auto max-w-7xl px-6 lg:px-8 py-12">
+                <div className="mb-8">
+                    <h1 className="text-4xl font-bold tracking-tight font-heading mb-2">All Plant Nutrition Guides</h1>
+                    <p className="text-muted-foreground">{total} product{total !== 1 ? 's' : ''}</p>
+                </div>
+
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+                    {products.map((product: any) => (
+                        <PlantNutritionCard key={product.id} product={product} />
+                    ))}
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/apps/client-fnp/app/(landing)/plant-nutrition-guides/layout.tsx
+++ b/apps/client-fnp/app/(landing)/plant-nutrition-guides/layout.tsx
@@ -1,0 +1,39 @@
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Plant Nutrition Guides - Fertilizers, Foliar Feeds & Biostimulants | farmnport',
+  description: 'Comprehensive plant nutrition product guides covering fertilizers, foliar feeds, biostimulants, and plant growth regulators. Find application rates and active ingredients.',
+  keywords: 'plant nutrition guides, fertilizers, foliar feeds, biostimulants, plant growth regulators, application rates, active ingredients',
+  authors: [{ name: 'farmnport' }],
+  openGraph: {
+    title: 'Plant Nutrition Guides - Fertilizers, Foliar Feeds & Biostimulants',
+    description: 'Comprehensive plant nutrition product guides. Find application rates and active ingredients for fertilizers, foliar feeds, and more.',
+    url: `${process.env.NEXT_PUBLIC_BASE_URL || 'https://farmnport.com'}/plant-nutrition-guides`,
+    siteName: 'farmnport',
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Plant Nutrition Guides - Complete Fertilizer & Foliar Feed Resource',
+    description: 'Comprehensive guides for fertilizers, foliar feeds, biostimulants, and plant nutrition products.',
+  },
+  alternates: {
+    canonical: `${process.env.NEXT_PUBLIC_BASE_URL || 'https://farmnport.com'}/plant-nutrition-guides`,
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-video-preview': -1,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+    },
+  },
+}
+
+export default function PlantNutritionGuidesRootLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/apps/client-fnp/app/(landing)/plant-nutrition-guides/page.tsx
+++ b/apps/client-fnp/app/(landing)/plant-nutrition-guides/page.tsx
@@ -1,0 +1,77 @@
+import Link from "next/link"
+import { Leaf, Droplets, Zap, TrendingUp, ArrowRight, Beaker } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { BaseURL } from "@/lib/schemas"
+
+const fetchOptions: RequestInit = process.env.NODE_ENV === "production"
+    ? { next: { revalidate: 3600 } } as RequestInit
+    : { cache: "no-store" }
+
+const categoryIcons: Record<string, any> = {
+    "fertilizers": Leaf,
+    "foliar-feeds": Droplets,
+    "biostimulants": Zap,
+    "plant-growth-regulators": TrendingUp,
+}
+
+async function getCategories() {
+    try {
+        const res = await fetch(`${BaseURL}/plantnutritioncategories/`, fetchOptions)
+        if (!res.ok) return []
+        const data = await res.json()
+        return data?.data || []
+    } catch {
+        return []
+    }
+}
+
+export default async function PlantNutritionGuidesPage() {
+    const categories = await getCategories()
+
+    return (
+        <main className="bg-gradient-to-b from-background to-muted/20">
+            <section className="py-12 lg:py-16 relative overflow-hidden">
+                <div className="mx-auto max-w-7xl px-6 lg:px-8">
+                    <div className="text-center max-w-3xl mx-auto mb-12">
+                        <h1 className="text-4xl font-bold tracking-tight sm:text-5xl font-heading mb-4">
+                            Plant Nutrition Guides
+                        </h1>
+                        <p className="text-lg text-muted-foreground leading-7 mb-6">
+                            Application rates, active ingredients, and usage guidelines for fertilizers, foliar feeds, biostimulants, and plant growth regulators.
+                        </p>
+                        <Button
+                            size="lg"
+                            asChild
+                            className="text-base px-6 py-5 h-auto font-semibold shadow-lg hover:shadow-xl transition-all group"
+                        >
+                            <Link href="/plant-nutrition-guides/all" className="flex items-center gap-2">
+                                Browse All Guides
+                                <ArrowRight className="h-5 w-5 transition-transform group-hover:translate-x-1" />
+                            </Link>
+                        </Button>
+                    </div>
+
+                    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+                        {categories.map((category: any) => {
+                            const Icon = categoryIcons[category.slug] || Beaker
+                            return (
+                                <Link
+                                    key={category.slug}
+                                    href={`/plant-nutrition-guides/${category.slug}`}
+                                    className="flex flex-col items-center gap-3 p-5 rounded-xl bg-card border border-border hover:border-primary hover:bg-accent transition-all group"
+                                >
+                                    <div className="flex items-center justify-center w-12 h-12 rounded-lg bg-primary/10 group-hover:bg-primary/20 transition-colors">
+                                        <Icon className="w-5 h-5 text-primary" strokeWidth={2} />
+                                    </div>
+                                    <span className="text-sm font-medium text-center text-foreground group-hover:text-primary transition-colors">
+                                        {category.name}
+                                    </span>
+                                </Link>
+                            )
+                        })}
+                    </div>
+                </div>
+            </section>
+        </main>
+    )
+}

--- a/apps/client-fnp/components/plantnutrition/PlantNutritionCard.tsx
+++ b/apps/client-fnp/components/plantnutrition/PlantNutritionCard.tsx
@@ -1,0 +1,82 @@
+import Link from "next/link"
+import Image from "next/image"
+import { Beaker, Leaf } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { sendGTMEvent } from '@next/third-parties/google'
+
+interface PlantNutritionCardProps {
+  product: any
+}
+
+export function PlantNutritionCard({ product }: PlantNutritionCardProps) {
+  const categorySlug = product.plant_nutrition_category?.slug || 'all'
+  const href = `/plant-nutrition-guides/${categorySlug}/${product.slug}`
+
+  return (
+    <div className="bg-card border border-border rounded-lg overflow-hidden transition-all duration-200 hover:shadow-lg hover:border-primary/50 group">
+      <Link href={href} className="block">
+        <div className="relative aspect-square bg-white">
+          {product.images && product.images[0] && product.images[0].img?.src ? (
+            <Image
+              src={product.images[0].img.src}
+              alt={product.name}
+              fill
+              sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
+              className="object-contain transition-transform duration-200 group-hover:scale-105"
+            />
+          ) : (
+            <div className="absolute inset-0 flex items-center justify-center bg-muted/30">
+              <Leaf className="w-16 h-16 text-muted-foreground/30" />
+            </div>
+          )}
+        </div>
+      </Link>
+
+      <div className="p-4 space-y-3 border-t">
+        {product.brand && (
+          <p className="text-xs text-muted-foreground uppercase tracking-wide font-medium">
+            {product.brand.name}
+          </p>
+        )}
+
+        <Link href={href}>
+          <h3 className="font-semibold text-sm leading-tight capitalize line-clamp-2 min-h-[2.5rem] group-hover:text-primary transition-colors">
+            {product.name}
+          </h3>
+        </Link>
+
+        <div className="flex items-center gap-4 text-xs text-muted-foreground pt-2 border-t">
+          <div className="flex items-center gap-1.5">
+            <Beaker className="w-3.5 h-3.5" />
+            <span>{product.active_ingredients?.length || 0} active</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <Leaf className="w-3.5 h-3.5" />
+            <span>{product.plant_nutrition_category?.name || 'Plant Nutrition'}</span>
+          </div>
+        </div>
+
+        {product.show_price && product.sale_price > 0 && (
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-muted-foreground">Guide Price:</span>
+            {product.was_price > 0 && product.was_price > product.sale_price && (
+              <span className="text-xs text-muted-foreground line-through">${product.was_price.toFixed(2)}</span>
+            )}
+            <span className="text-sm font-semibold text-primary">${product.sale_price.toFixed(2)}</span>
+          </div>
+        )}
+
+        <Link href={href} className="block pt-2">
+          <Button
+            variant="outline"
+            className="w-full"
+            size="sm"
+            onClick={() => sendGTMEvent({ event: 'link', value: 'ViewPlantNutritionGuide' })}
+          >
+            View Guide
+          </Button>
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/apps/client-fnp/components/shared/ActiveIngredientUnitsKey.tsx
+++ b/apps/client-fnp/components/shared/ActiveIngredientUnitsKey.tsx
@@ -1,0 +1,34 @@
+const unitLabels: Record<string, string> = {
+    "g/L": "grams per litre",
+    "g/l": "grams per litre",
+    "mg/L": "milligrams per litre",
+    "mg/ml": "milligrams per millilitre",
+    "mg/kg": "milligrams per kilogram",
+    "g/kg": "grams per kilogram",
+    "g/bolus": "grams per bolus",
+    "%": "percentage by weight",
+    "% m/m": "mass per mass percentage",
+    "% m/v": "mass per volume percentage",
+    "% w/v": "weight per volume percentage",
+}
+
+interface ActiveIngredientUnitsKeyProps {
+    activeIngredients: { dosage_unit: string }[]
+}
+
+export function ActiveIngredientUnitsKey({ activeIngredients }: ActiveIngredientUnitsKeyProps) {
+    const units = Array.from(new Set(activeIngredients.map(ai => ai.dosage_unit))) as string[]
+    const knownUnits = units.filter(u => unitLabels[u])
+
+    if (knownUnits.length === 0) return null
+
+    return (
+        <div className="flex flex-wrap gap-x-4 gap-y-1 mt-2">
+            {knownUnits.map(unit => (
+                <span key={unit} className="text-xs text-muted-foreground">
+                    <span className="font-medium text-foreground">{unit}</span> = {unitLabels[unit]}
+                </span>
+            ))}
+        </div>
+    )
+}

--- a/apps/client-fnp/lib/query.ts
+++ b/apps/client-fnp/lib/query.ts
@@ -509,3 +509,36 @@ export function queryCdmPricesByClient(clientId: string, pagination?: Pagination
 
   return api.get(url)
 }
+
+// Plant Nutrition
+export function queryPlantNutritionCategories() {
+  return api.get(`${BaseURL}/plantnutritioncategories/`)
+}
+
+export function queryAllPlantNutritionProducts(pagination?: PaginationModel & { brand?: string[] }) {
+  const params = new URLSearchParams()
+  if (pagination?.p !== undefined && pagination.p >= 2) {
+    params.set('p', pagination.p.toString())
+  }
+  if (pagination?.brand && pagination.brand.length > 0) {
+    pagination.brand.forEach(b => params.append('brand', b))
+  }
+  const qs = params.toString()
+  return api.get(qs ? `${BaseURL}/plantnutrition/all?${qs}` : `${BaseURL}/plantnutrition/all`)
+}
+
+export function queryPlantNutritionProductsByCategory(options: { category: string } & PaginationModel & { brand?: string[] }) {
+  const params = new URLSearchParams()
+  if (options.p !== undefined && options.p >= 2) {
+    params.set('p', options.p.toString())
+  }
+  if (options.brand && options.brand.length > 0) {
+    options.brand.forEach(b => params.append('brand', b))
+  }
+  const qs = params.toString()
+  return api.get(qs ? `${BaseURL}/plantnutrition/category/${options.category}?${qs}` : `${BaseURL}/plantnutrition/category/${options.category}`)
+}
+
+export function queryPlantNutritionFilterAggregates() {
+  return api.get(`${BaseURL}/plantnutrition/aggregates/filters`)
+}


### PR DESCRIPTION
## Summary
- New /plant-nutrition-guides pages: index, category listing, product detail
- ActiveIngredientUnitsKey shared component for units legend
- /guides page simplified to 3 top-level sections (Agrochem, Animal Health, Plant Nutrition)
- Landing page cleaned up: removed counts, Featured section, Quick Links card added
- Plant nutrition API queries added to lib/query.ts

## Test Plan
- [ ] /plant-nutrition-guides loads categories
- [ ] /plant-nutrition-guides/biostimulants/fresh-p loads with active ingredients and dosage rates
- [ ] /plant-nutrition-guides/foliar-feeds/calsap loads correctly
- [ ] /guides shows 3 clean section cards