### PR TITLE
refactor: simplify contact-views UI for clarity and actionability

### DIFF
--- a/apps/admin-fnp/app/dashboard/farmnport/contact-views/all-contacts/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/contact-views/all-contacts/page.tsx
@@ -8,8 +8,6 @@ import { ArrowLeft, ChevronLeft, ChevronRight } from "lucide-react"
 
 import { queryTopViewedContacts } from "@/lib/query"
 import { formatDate } from "@/lib/utilities"
-import { Card, CardContent } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Button } from "@/components/ui/button"
 
@@ -29,20 +27,18 @@ export default function AllContactsPage() {
   const total: number = data?.data?.total || 0
   const totalPages: number = data?.data?.total_pages || 1
 
+  const maxViews = contacts.reduce((m: number, c: any) => Math.max(m, c.view_count), 0)
+
   if (isLoading) {
     return (
-      <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-4">
         <Skeleton className="h-5 w-32" />
         <Skeleton className="h-9 w-64" />
-        <Card>
-          <CardContent className="pt-6">
-            <div className="space-y-3">
-              {Array.from({ length: PAGE_SIZE }).map((_, i) => (
-                <Skeleton key={i} className="h-10 w-full" />
-              ))}
-            </div>
-          </CardContent>
-        </Card>
+        <div className="space-y-2">
+          {Array.from({ length: PAGE_SIZE }).map((_, i) => (
+            <Skeleton key={i} className="h-14 w-full rounded-lg" />
+          ))}
+        </div>
       </div>
     )
   }
@@ -58,78 +54,66 @@ export default function AllContactsPage() {
       </button>
 
       <div>
-        <h2 className="text-3xl font-bold tracking-tight">Viewed Contacts</h2>
-        <p className="text-muted-foreground">
-          {total} contacts sorted by view count
-        </p>
+        <h2 className="text-3xl font-bold tracking-tight">Most Viewed Contacts</h2>
+        <p className="text-muted-foreground">{total} profiles sorted by views — click any to see who viewed them</p>
       </div>
 
-      <Card>
-        <CardContent className="pt-6">
-          {contacts.length === 0 ? (
-            <p className="text-sm text-muted-foreground py-4 text-center">No data yet</p>
-          ) : (
-            <div className="space-y-2">
-              <div className="grid grid-cols-[2rem_1fr_5rem_5rem_5rem_9rem_3.5rem] gap-2 text-xs font-medium text-muted-foreground pb-1 border-b">
-                <span>#</span>
-                <span>Name</span>
-                <span>Type</span>
-                <span>City</span>
-                <span>Channel</span>
-                <span>Last View</span>
-                <span className="text-right">Views</span>
-              </div>
-              {contacts.map((contact: any, i: number) => (
-                <Link
-                  key={contact.viewed_id || i}
-                  href={`/dashboard/farmnport/contact-views/contact/${contact.viewed_id}`}
-                  className="grid grid-cols-[2rem_1fr_5rem_5rem_5rem_9rem_3.5rem] gap-2 items-center rounded-lg p-2 text-sm hover:bg-muted/50 transition-colors"
-                >
-                  <span className="text-muted-foreground text-xs">{(page - 1) * PAGE_SIZE + i + 1}</span>
-                  <span className="font-medium truncate capitalize">{contact.name}</span>
-                  <Badge variant="secondary" className="text-xs w-fit capitalize">
-                    {contact.type}
-                  </Badge>
-                  <span className="text-muted-foreground text-xs truncate capitalize">{contact.city || "—"}</span>
-                  <Badge variant="outline" className="text-xs w-fit capitalize">
-                    {contact.contact_type || "—"}
-                  </Badge>
-                  <span className="text-muted-foreground text-xs">{formatDate(contact.last_date) || "—"}</span>
-                  <span className="text-right font-semibold">{contact.view_count}</span>
-                </Link>
-              ))}
+      {contacts.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-8 text-center">No data yet</p>
+      ) : (
+        <div className="space-y-1">
+          {contacts.map((contact: any, i: number) => {
+            const pct = maxViews > 0 ? (contact.view_count / maxViews) * 100 : 0
+            return (
+              <Link
+                key={contact.viewed_id || i}
+                href={`/dashboard/farmnport/contact-views/contact/${contact.viewed_id}`}
+                className="flex items-center gap-4 rounded-lg px-4 py-3 hover:bg-muted/50 transition-colors group"
+              >
+                <span className="text-xs text-muted-foreground w-5 shrink-0 text-right">
+                  {(page - 1) * PAGE_SIZE + i + 1}
+                </span>
 
-              {totalPages > 1 && (
-                <div className="flex items-center justify-between pt-3 border-t">
-                  <span className="text-xs text-muted-foreground">
-                    Page {page} of {totalPages} ({total} total)
-                  </span>
-                  <div className="flex gap-1">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="h-7 px-2"
-                      disabled={page <= 1}
-                      onClick={() => setPage(page - 1)}
-                    >
-                      <ChevronLeft className="h-4 w-4" />
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="h-7 px-2"
-                      disabled={page >= totalPages}
-                      onClick={() => setPage(page + 1)}
-                    >
-                      <ChevronRight className="h-4 w-4" />
-                    </Button>
+                <div className="flex-1 min-w-0">
+                  <p className="font-medium text-sm capitalize truncate">{contact.name}</p>
+                  <div className="flex items-center gap-2 mt-1">
+                    <div className="h-1 rounded-full bg-muted flex-1 max-w-32">
+                      <div
+                        className="h-1 rounded-full bg-orange-400"
+                        style={{ width: `${pct}%` }}
+                      />
+                    </div>
+                    <span className="text-xs text-muted-foreground capitalize shrink-0">
+                      {contact.type}{contact.city ? ` · ${contact.city}` : ""}
+                    </span>
                   </div>
                 </div>
-              )}
+
+                <div className="shrink-0 text-right">
+                  <p className="text-sm font-bold">{contact.view_count} views</p>
+                  <p className="text-xs text-muted-foreground">{formatDate(contact.last_date) || "—"}</p>
+                </div>
+              </Link>
+            )
+          })}
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between pt-4 border-t">
+              <span className="text-xs text-muted-foreground">
+                Page {page} of {totalPages} ({total} total)
+              </span>
+              <div className="flex gap-1">
+                <Button variant="outline" size="sm" className="h-7 px-2" disabled={page <= 1} onClick={() => setPage(page - 1)}>
+                  <ChevronLeft className="h-4 w-4" />
+                </Button>
+                <Button variant="outline" size="sm" className="h-7 px-2" disabled={page >= totalPages} onClick={() => setPage(page + 1)}>
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              </div>
             </div>
           )}
-        </CardContent>
-      </Card>
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/admin-fnp/app/dashboard/farmnport/contact-views/all-viewers/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/contact-views/all-viewers/page.tsx
@@ -8,8 +8,6 @@ import { ArrowLeft, ChevronLeft, ChevronRight } from "lucide-react"
 
 import { queryTopViewers } from "@/lib/query"
 import { formatDate } from "@/lib/utilities"
-import { Card, CardContent } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Button } from "@/components/ui/button"
 
@@ -29,20 +27,18 @@ export default function AllViewersPage() {
   const total: number = data?.data?.total || 0
   const totalPages: number = data?.data?.total_pages || 1
 
+  const maxViewed = viewers.reduce((m: number, v: any) => Math.max(m, v.contacts_viewed), 0)
+
   if (isLoading) {
     return (
-      <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-4">
         <Skeleton className="h-5 w-32" />
         <Skeleton className="h-9 w-64" />
-        <Card>
-          <CardContent className="pt-6">
-            <div className="space-y-3">
-              {Array.from({ length: PAGE_SIZE }).map((_, i) => (
-                <Skeleton key={i} className="h-10 w-full" />
-              ))}
-            </div>
-          </CardContent>
-        </Card>
+        <div className="space-y-2">
+          {Array.from({ length: PAGE_SIZE }).map((_, i) => (
+            <Skeleton key={i} className="h-14 w-full rounded-lg" />
+          ))}
+        </div>
       </div>
     )
   }
@@ -58,76 +54,61 @@ export default function AllViewersPage() {
       </button>
 
       <div>
-        <h2 className="text-3xl font-bold tracking-tight">Active Viewers</h2>
-        <p className="text-muted-foreground">
-          {total} viewers sorted by contacts viewed
-        </p>
+        <h2 className="text-3xl font-bold tracking-tight">Most Active Viewers</h2>
+        <p className="text-muted-foreground">{total} users sorted by contacts viewed — click any to see their history</p>
       </div>
 
-      <Card>
-        <CardContent className="pt-6">
-          {viewers.length === 0 ? (
-            <p className="text-sm text-muted-foreground py-4 text-center">No data yet</p>
-          ) : (
-            <div className="space-y-2">
-              <div className="grid grid-cols-[2rem_1fr_5rem_5rem_9rem_4rem] gap-2 text-xs font-medium text-muted-foreground pb-1 border-b">
-                <span>#</span>
-                <span>Name</span>
-                <span>Type</span>
-                <span>Channel</span>
-                <span>Last View</span>
-                <span className="text-right">Viewed</span>
-              </div>
-              {viewers.map((viewer: any, i: number) => (
-                <Link
-                  key={viewer.user_id || i}
-                  href={`/dashboard/farmnport/contact-views/viewer/${viewer.user_id}`}
-                  className="grid grid-cols-[2rem_1fr_5rem_5rem_9rem_4rem] gap-2 items-center rounded-lg p-2 text-sm hover:bg-muted/50 transition-colors"
-                >
-                  <span className="text-muted-foreground text-xs">{(page - 1) * PAGE_SIZE + i + 1}</span>
-                  <span className="font-medium truncate capitalize">{viewer.name}</span>
-                  <Badge variant="secondary" className="text-xs w-fit capitalize">
-                    {viewer.type}
-                  </Badge>
-                  <Badge variant="outline" className="text-xs w-fit capitalize">
-                    {viewer.contact_type || "—"}
-                  </Badge>
-                  <span className="text-muted-foreground text-xs">{formatDate(viewer.last_date) || "—"}</span>
-                  <span className="text-right font-semibold">{viewer.contacts_viewed}</span>
-                </Link>
-              ))}
+      {viewers.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-8 text-center">No data yet</p>
+      ) : (
+        <div className="space-y-1">
+          {viewers.map((viewer: any, i: number) => {
+            const pct = maxViewed > 0 ? (viewer.contacts_viewed / maxViewed) * 100 : 0
+            return (
+              <Link
+                key={viewer.user_id || i}
+                href={`/dashboard/farmnport/contact-views/viewer/${viewer.user_id}`}
+                className="flex items-center gap-4 rounded-lg px-4 py-3 hover:bg-muted/50 transition-colors"
+              >
+                <span className="text-xs text-muted-foreground w-5 shrink-0 text-right">
+                  {(page - 1) * PAGE_SIZE + i + 1}
+                </span>
 
-              {totalPages > 1 && (
-                <div className="flex items-center justify-between pt-3 border-t">
-                  <span className="text-xs text-muted-foreground">
-                    Page {page} of {totalPages} ({total} total)
-                  </span>
-                  <div className="flex gap-1">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="h-7 px-2"
-                      disabled={page <= 1}
-                      onClick={() => setPage(page - 1)}
-                    >
-                      <ChevronLeft className="h-4 w-4" />
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="h-7 px-2"
-                      disabled={page >= totalPages}
-                      onClick={() => setPage(page + 1)}
-                    >
-                      <ChevronRight className="h-4 w-4" />
-                    </Button>
+                <div className="flex-1 min-w-0">
+                  <p className="font-medium text-sm capitalize truncate">{viewer.name}</p>
+                  <div className="flex items-center gap-2 mt-1">
+                    <div className="h-1 rounded-full bg-muted flex-1 max-w-32">
+                      <div className="h-1 rounded-full bg-orange-400" style={{ width: `${pct}%` }} />
+                    </div>
+                    <span className="text-xs text-muted-foreground capitalize shrink-0">{viewer.type}</span>
                   </div>
                 </div>
-              )}
+
+                <div className="shrink-0 text-right">
+                  <p className="text-sm font-bold">{viewer.contacts_viewed} viewed</p>
+                  <p className="text-xs text-muted-foreground">{formatDate(viewer.last_date) || "—"}</p>
+                </div>
+              </Link>
+            )
+          })}
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between pt-4 border-t">
+              <span className="text-xs text-muted-foreground">
+                Page {page} of {totalPages} ({total} total)
+              </span>
+              <div className="flex gap-1">
+                <Button variant="outline" size="sm" className="h-7 px-2" disabled={page <= 1} onClick={() => setPage(page - 1)}>
+                  <ChevronLeft className="h-4 w-4" />
+                </Button>
+                <Button variant="outline" size="sm" className="h-7 px-2" disabled={page >= totalPages} onClick={() => setPage(page + 1)}>
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              </div>
             </div>
           )}
-        </CardContent>
-      </Card>
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/admin-fnp/app/dashboard/farmnport/contact-views/contact/[id]/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/contact-views/contact/[id]/page.tsx
@@ -4,11 +4,10 @@ import { useState } from "react"
 import { useParams, useRouter } from "next/navigation"
 import { useQuery } from "@tanstack/react-query"
 import Link from "next/link"
-import { ArrowLeft, Eye, ChevronLeft, ChevronRight } from "lucide-react"
+import { ArrowLeft, ChevronLeft, ChevronRight } from "lucide-react"
 
 import { queryContactViewDetail } from "@/lib/query"
 import { formatDate } from "@/lib/utilities"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Button } from "@/components/ui/button"
@@ -38,22 +37,12 @@ export default function ContactDetailPage() {
     return (
       <div className="flex flex-col gap-6">
         <Skeleton className="h-5 w-32" />
-        <div>
-          <Skeleton className="h-9 w-64" />
-          <Skeleton className="h-4 w-48 mt-2" />
+        <Skeleton className="h-9 w-64" />
+        <div className="space-y-2">
+          {Array.from({ length: PAGE_SIZE }).map((_, i) => (
+            <Skeleton key={i} className="h-14 w-full rounded-lg" />
+          ))}
         </div>
-        <Card>
-          <CardHeader>
-            <Skeleton className="h-5 w-48" />
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-3">
-              {Array.from({ length: PAGE_SIZE }).map((_, i) => (
-                <Skeleton key={i} className="h-10 w-full" />
-              ))}
-            </div>
-          </CardContent>
-        </Card>
       </div>
     )
   }
@@ -72,85 +61,64 @@ export default function ContactDetailPage() {
 
       <div>
         <h2 className="text-3xl font-bold tracking-tight capitalize">{contact.name}</h2>
-        <div className="flex items-center gap-2 mt-1">
-          <Badge variant="secondary" className="capitalize">{contact.type}</Badge>
-          {contact.city && <span className="text-sm text-muted-foreground">{contact.city}</span>}
-          <span className="text-sm text-muted-foreground">
-            &middot; {total} viewer{total !== 1 ? "s" : ""}
-          </span>
-        </div>
+        <p className="text-muted-foreground capitalize">
+          {contact.type}{contact.city ? ` · ${contact.city}` : ""} &middot; {total} viewer{total !== 1 ? "s" : ""}
+        </p>
       </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base flex items-center gap-2">
-            <Eye className="h-4 w-4" />
-            Who viewed this contact
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          {viewers.length === 0 ? (
-            <p className="text-sm text-muted-foreground py-4 text-center">No viewers yet</p>
-          ) : (
-            <div className="space-y-2">
-              <div className="grid grid-cols-[2rem_1fr_5rem_5rem_5rem_9rem] gap-2 text-xs font-medium text-muted-foreground pb-1 border-b">
-                <span>#</span>
-                <span>Name</span>
-                <span>Type</span>
-                <span>City</span>
-                <span>Channel</span>
-                <span className="text-right">Last View</span>
-              </div>
-              {viewers.map((viewer: any, i: number) => (
-                <Link
-                  key={`${viewer.user_id}-${viewer.date}-${i}`}
-                  href={`/dashboard/farmnport/contact-views/viewer/${viewer.user_id}`}
-                  className="grid grid-cols-[2rem_1fr_5rem_5rem_5rem_9rem] gap-2 items-center rounded-lg p-2 text-sm hover:bg-muted/50 transition-colors"
-                >
-                  <span className="text-muted-foreground text-xs">{(page - 1) * PAGE_SIZE + i + 1}</span>
-                  <span className="font-medium truncate capitalize">{viewer.name}</span>
-                  <Badge variant="secondary" className="text-xs w-fit capitalize">
-                    {viewer.client_type}
-                  </Badge>
-                  <span className="text-muted-foreground text-xs truncate capitalize">{viewer.city || "—"}</span>
-                  <Badge variant="outline" className="text-xs w-fit capitalize">
-                    {viewer.type || "—"}
-                  </Badge>
-                  <span className="text-right text-muted-foreground text-xs">{formatDate(viewer.date) || "—"}</span>
-                </Link>
-              ))}
+      <div>
+        <p className="text-sm font-medium text-muted-foreground mb-2">Who viewed this contact</p>
 
-              {totalPages > 1 && (
-                <div className="flex items-center justify-between pt-3 border-t">
-                  <span className="text-xs text-muted-foreground">
-                    Page {page} of {totalPages} ({total} total)
-                  </span>
-                  <div className="flex gap-1">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="h-7 px-2"
-                      disabled={page <= 1}
-                      onClick={() => setPage(page - 1)}
-                    >
-                      <ChevronLeft className="h-4 w-4" />
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="h-7 px-2"
-                      disabled={page >= totalPages}
-                      onClick={() => setPage(page + 1)}
-                    >
-                      <ChevronRight className="h-4 w-4" />
-                    </Button>
-                  </div>
+        {viewers.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-8 text-center">No viewers yet</p>
+        ) : (
+          <div className="space-y-1">
+            {viewers.map((viewer: any, i: number) => (
+              <Link
+                key={`${viewer.user_id}-${viewer.date}-${i}`}
+                href={`/dashboard/farmnport/contact-views/viewer/${viewer.user_id}`}
+                className="flex items-center gap-4 rounded-lg px-4 py-3 hover:bg-muted/50 transition-colors"
+              >
+                <span className="text-xs text-muted-foreground w-5 shrink-0 text-right">
+                  {(page - 1) * PAGE_SIZE + i + 1}
+                </span>
+
+                <div className="flex-1 min-w-0">
+                  <p className="font-medium text-sm capitalize truncate">{viewer.name}</p>
+                  <p className="text-xs text-muted-foreground capitalize">
+                    {viewer.client_type}{viewer.city ? ` · ${viewer.city}` : ""}
+                  </p>
                 </div>
-              )}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+
+                <div className="shrink-0 text-right">
+                  {viewer.type && (
+                    <Badge variant="outline" className="text-xs capitalize mb-1">
+                      {viewer.type}
+                    </Badge>
+                  )}
+                  <p className="text-xs text-muted-foreground">{formatDate(viewer.date) || "—"}</p>
+                </div>
+              </Link>
+            ))}
+
+            {totalPages > 1 && (
+              <div className="flex items-center justify-between pt-4 border-t">
+                <span className="text-xs text-muted-foreground">
+                  Page {page} of {totalPages} ({total} total)
+                </span>
+                <div className="flex gap-1">
+                  <Button variant="outline" size="sm" className="h-7 px-2" disabled={page <= 1} onClick={() => setPage(page - 1)}>
+                    <ChevronLeft className="h-4 w-4" />
+                  </Button>
+                  <Button variant="outline" size="sm" className="h-7 px-2" disabled={page >= totalPages} onClick={() => setPage(page + 1)}>
+                    <ChevronRight className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/apps/admin-fnp/app/dashboard/farmnport/contact-views/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/contact-views/page.tsx
@@ -77,7 +77,7 @@ export default function ContactViewsPage() {
       <div>
         <h2 className="text-3xl font-bold tracking-tight">Contact Views</h2>
         <p className="text-muted-foreground">
-          Analytics on who is viewing contact details
+          Track which profiles are being viewed and which users are viewing them
         </p>
       </div>
 
@@ -136,6 +136,7 @@ export default function ContactViewsPage() {
         <Card>
           <CardHeader>
             <CardTitle className="text-base">Most Viewed Contacts</CardTitle>
+            <p className="text-xs text-muted-foreground">Profiles whose contact info was viewed most often</p>
           </CardHeader>
           <CardContent>
             {topViewed.length === 0 ? (
@@ -147,7 +148,7 @@ export default function ContactViewsPage() {
                   <span>Name</span>
                   <span>Type</span>
                   <span>City</span>
-                  <span>Last View</span>
+                  <span>Last Viewed</span>
                   <span className="text-right">Views</span>
                 </div>
                 {visibleViewed.map((contact: any, i: number) => (
@@ -181,6 +182,7 @@ export default function ContactViewsPage() {
         <Card>
           <CardHeader>
             <CardTitle className="text-base">Most Active Viewers</CardTitle>
+            <p className="text-xs text-muted-foreground">Users who have viewed the most contact profiles</p>
           </CardHeader>
           <CardContent>
             {topViewers.length === 0 ? (
@@ -191,7 +193,7 @@ export default function ContactViewsPage() {
                   <span>#</span>
                   <span>Name</span>
                   <span>Type</span>
-                  <span>Last View</span>
+                  <span>Last Active</span>
                   <span className="text-right">Viewed</span>
                 </div>
                 {visibleViewers.map((viewer: any, i: number) => (

--- a/apps/admin-fnp/app/dashboard/farmnport/contact-views/viewer/[id]/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/contact-views/viewer/[id]/page.tsx
@@ -4,12 +4,10 @@ import { useState } from "react"
 import { useParams, useRouter } from "next/navigation"
 import { useQuery } from "@tanstack/react-query"
 import Link from "next/link"
-import { ArrowLeft, Users, ChevronLeft, ChevronRight } from "lucide-react"
+import { ArrowLeft, ChevronLeft, ChevronRight } from "lucide-react"
 
 import { queryViewerDetail } from "@/lib/query"
 import { formatDate } from "@/lib/utilities"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Button } from "@/components/ui/button"
 
@@ -38,22 +36,12 @@ export default function ViewerDetailPage() {
     return (
       <div className="flex flex-col gap-6">
         <Skeleton className="h-5 w-32" />
-        <div>
-          <Skeleton className="h-9 w-64" />
-          <Skeleton className="h-4 w-48 mt-2" />
+        <Skeleton className="h-9 w-64" />
+        <div className="space-y-2">
+          {Array.from({ length: PAGE_SIZE }).map((_, i) => (
+            <Skeleton key={i} className="h-14 w-full rounded-lg" />
+          ))}
         </div>
-        <Card>
-          <CardHeader>
-            <Skeleton className="h-5 w-48" />
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-3">
-              {Array.from({ length: PAGE_SIZE }).map((_, i) => (
-                <Skeleton key={i} className="h-10 w-full" />
-              ))}
-            </div>
-          </CardContent>
-        </Card>
       </div>
     )
   }
@@ -72,85 +60,57 @@ export default function ViewerDetailPage() {
 
       <div>
         <h2 className="text-3xl font-bold tracking-tight capitalize">{viewer.name}</h2>
-        <div className="flex items-center gap-2 mt-1">
-          <Badge variant="secondary" className="capitalize">{viewer.type}</Badge>
-          {viewer.city && <span className="text-sm text-muted-foreground">{viewer.city}</span>}
-          <span className="text-sm text-muted-foreground">
-            &middot; Viewed {total} contact{total !== 1 ? "s" : ""}
-          </span>
-        </div>
+        <p className="text-muted-foreground capitalize">
+          {viewer.type}{viewer.city ? ` · ${viewer.city}` : ""} &middot; viewed {total} contact{total !== 1 ? "s" : ""}
+        </p>
       </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base flex items-center gap-2">
-            <Users className="h-4 w-4" />
-            Contacts viewed by this person
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          {viewed.length === 0 ? (
-            <p className="text-sm text-muted-foreground py-4 text-center">No contacts viewed yet</p>
-          ) : (
-            <div className="space-y-2">
-              <div className="grid grid-cols-[2rem_1fr_5rem_5rem_5rem_9rem] gap-2 text-xs font-medium text-muted-foreground pb-1 border-b">
-                <span>#</span>
-                <span>Name</span>
-                <span>Type</span>
-                <span>City</span>
-                <span>Channel</span>
-                <span className="text-right">Last View</span>
-              </div>
-              {viewed.map((contact: any, i: number) => (
-                <Link
-                  key={`${contact.viewed_id}-${contact.date}-${i}`}
-                  href={`/dashboard/farmnport/contact-views/contact/${contact.viewed_id}`}
-                  className="grid grid-cols-[2rem_1fr_5rem_5rem_5rem_9rem] gap-2 items-center rounded-lg p-2 text-sm hover:bg-muted/50 transition-colors"
-                >
-                  <span className="text-muted-foreground text-xs">{(page - 1) * PAGE_SIZE + i + 1}</span>
-                  <span className="font-medium truncate capitalize">{contact.name}</span>
-                  <Badge variant="secondary" className="text-xs w-fit capitalize">
-                    {contact.type}
-                  </Badge>
-                  <span className="text-muted-foreground text-xs truncate capitalize">{contact.city || "—"}</span>
-                  <Badge variant="outline" className="text-xs w-fit capitalize">
-                    {contact.contact_type || "—"}
-                  </Badge>
-                  <span className="text-right text-muted-foreground text-xs">{formatDate(contact.date) || "—"}</span>
-                </Link>
-              ))}
+      <div>
+        <p className="text-sm font-medium text-muted-foreground mb-2">Contacts this person viewed</p>
 
-              {totalPages > 1 && (
-                <div className="flex items-center justify-between pt-3 border-t">
-                  <span className="text-xs text-muted-foreground">
-                    Page {page} of {totalPages} ({total} total)
-                  </span>
-                  <div className="flex gap-1">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="h-7 px-2"
-                      disabled={page <= 1}
-                      onClick={() => setPage(page - 1)}
-                    >
-                      <ChevronLeft className="h-4 w-4" />
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="h-7 px-2"
-                      disabled={page >= totalPages}
-                      onClick={() => setPage(page + 1)}
-                    >
-                      <ChevronRight className="h-4 w-4" />
-                    </Button>
-                  </div>
+        {viewed.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-8 text-center">No contacts viewed yet</p>
+        ) : (
+          <div className="space-y-1">
+            {viewed.map((contact: any, i: number) => (
+              <Link
+                key={`${contact.viewed_id}-${contact.date}-${i}`}
+                href={`/dashboard/farmnport/contact-views/contact/${contact.viewed_id}`}
+                className="flex items-center gap-4 rounded-lg px-4 py-3 hover:bg-muted/50 transition-colors"
+              >
+                <span className="text-xs text-muted-foreground w-5 shrink-0 text-right">
+                  {(page - 1) * PAGE_SIZE + i + 1}
+                </span>
+
+                <div className="flex-1 min-w-0">
+                  <p className="font-medium text-sm capitalize truncate">{contact.name}</p>
+                  <p className="text-xs text-muted-foreground capitalize">
+                    {contact.type}{contact.city ? ` · ${contact.city}` : ""}
+                  </p>
                 </div>
-              )}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+
+                <p className="text-xs text-muted-foreground shrink-0">{formatDate(contact.date) || "—"}</p>
+              </Link>
+            ))}
+
+            {totalPages > 1 && (
+              <div className="flex items-center justify-between pt-4 border-t">
+                <span className="text-xs text-muted-foreground">
+                  Page {page} of {totalPages} ({total} total)
+                </span>
+                <div className="flex gap-1">
+                  <Button variant="outline" size="sm" className="h-7 px-2" disabled={page <= 1} onClick={() => setPage(page - 1)}>
+                    <ChevronLeft className="h-4 w-4" />
+                  </Button>
+                  <Button variant="outline" size="sm" className="h-7 px-2" disabled={page >= totalPages} onClick={() => setPage(page + 1)}>
+                    <ChevronRight className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/apps/admin-fnp/package.json
+++ b/apps/admin-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin-farmnport",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3000",


### PR DESCRIPTION
## Summary
- Replace dense grid-column tables with clean scannable rows across all contact-views pages
- Add orange bar charts on list pages to show relative activity at a glance
- Add subtitles to dashboard cards clarifying viewed vs viewer direction
- Bump admin-fnp to v1.2.0

## Pages changed
- `/contact-views` — dashboard cards with subtitles
- `/contact-views/all-contacts` — clean list with bar chart
- `/contact-views/all-viewers` — clean list with bar chart
- `/contact-views/contact/[id]` — simplified viewer list
- `/contact-views/viewer/[id]` — simplified contacts list