### PR TITLE
fix: auth UX — reset flow confirmation + login error nudge

### DIFF
--- a/apps/client-fnp/app/(landing)/request-pickup/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/request-pickup/[slug]/page.tsx
@@ -1,0 +1,240 @@
+"use client"
+
+import { useState } from "react"
+import { useSession } from "next-auth/react"
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { useRouter, useParams } from "next/navigation"
+import { Loader2, MapPin, Clock, CalendarDays, ChevronDown } from "lucide-react"
+import { format } from "date-fns"
+import Link from "next/link"
+import { toast } from "sonner"
+
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { Calendar } from "@/components/ui/calendar"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { GoodsPicker, EMPTY_GOODS_ITEM, type GoodsItem } from "@/components/booking/goods-picker"
+import { queryClient as fetchClient, createBooking } from "@/lib/query"
+import { capitalizeFirstLetter } from "@/lib/utilities"
+
+export default function RequestPickupPage() {
+  const params = useParams()
+  const slug = params.slug as string
+  const buyerName = slug.replace(/-/g, " ")
+
+  const { data: session } = useSession()
+  const user = session?.user as any
+  const router = useRouter()
+  const qc = useQueryClient()
+
+  const [date, setDate] = useState<Date | undefined>(undefined)
+  const [calOpen, setCalOpen] = useState(false)
+  const [timeSlot, setTimeSlot] = useState("")
+  const [farmAddress, setFarmAddress] = useState("")
+  const [goodsItems, setGoodsItems] = useState<GoodsItem[]>([EMPTY_GOODS_ITEM()])
+  const [notes, setNotes] = useState("")
+
+  // Fetch logged-in user profile for phone + address
+  const { data: profileData } = useQuery({
+    queryKey: ["my-profile", user?.username],
+    queryFn: () => fetchClient(user.username.replace(/ /g, "-")).then((r) => r.data),
+    enabled: !!user?.username,
+  })
+  const phone: string = profileData?.phone ?? ""
+
+  // Pre-fill farm address from profile if available
+  const profileAddress: string = profileData?.address ?? ""
+
+  // Fetch buyer profile
+  const { data: buyerData, isLoading: buyerLoading } = useQuery({
+    queryKey: ["buyer-profile", slug],
+    queryFn: () => fetchClient(slug).then((r) => r.data),
+  })
+  const buyerId: string = buyerData?.id ?? ""
+
+  // Common time slots for pickup
+  const timeSlots = ["06:00 - 09:00", "09:00 - 12:00", "12:00 - 15:00", "15:00 - 18:00"]
+
+  const validItems = goodsItems.filter((g) => g.produce_name && g.quantity > 0)
+  const effectiveFarmAddress = farmAddress || profileAddress
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      createBooking({
+        type: "pickup",
+        buyer_id: buyerId,
+        farm_address: effectiveFarmAddress,
+        booking_date: date!.toISOString(),
+        time_slot: timeSlot || undefined,
+        goods_items: validItems,
+        phone,
+        notes: notes || undefined,
+      }),
+    onSuccess: () => {
+      toast.success("Pickup request submitted successfully")
+      qc.invalidateQueries({ queryKey: ["my-bookings"] })
+      router.push("/account/bookings")
+    },
+    onError: () => {
+      toast.error("Failed to submit pickup request. Please try again.")
+    },
+  })
+
+  const canSubmit = !!session && !!buyerId && !!date && validItems.length > 0 && !!phone && !!effectiveFarmAddress
+
+  if (buyerLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <Loader2 className="w-8 h-8 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      {/* Breadcrumb */}
+      <div className="border-b">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+          <nav className="flex text-sm text-muted-foreground">
+            <Link href="/" className="hover:text-foreground">Home</Link>
+            <span className="mx-2">/</span>
+            <Link href={`/buy/${slug}`} className="hover:text-foreground capitalize">{buyerName}</Link>
+            <span className="mx-2">/</span>
+            <span className="text-foreground">Request Pickup</span>
+          </nav>
+        </div>
+      </div>
+
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+        <div className="mb-8">
+          <h1 className="text-2xl font-bold">Request Pickup from {capitalizeFirstLetter(buyerName)}</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Request {capitalizeFirstLetter(buyerName)} to collect goods directly from your farm.
+          </p>
+        </div>
+
+        {!session ? (
+          <div className="border rounded-xl p-8 text-center space-y-4">
+            <CalendarDays className="w-10 h-10 mx-auto text-muted-foreground/40" />
+            <div>
+              <p className="font-semibold">Sign in to request a pickup</p>
+              <p className="text-xs text-muted-foreground mt-1">You need an account to submit a pickup request</p>
+            </div>
+            <Link
+              href={`/login?next=/request-pickup/${slug}`}
+              className="inline-block bg-primary text-primary-foreground text-sm font-semibold px-6 py-2.5 rounded-xl hover:bg-primary/90 transition-colors"
+            >
+              Sign In
+            </Link>
+          </div>
+        ) : (
+          <div className="grid gap-6">
+            <div className="border rounded-xl divide-y">
+
+              {/* Date + time slot */}
+              <div className="p-5">
+                <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-3 flex items-center gap-1.5">
+                  <CalendarDays className="w-3.5 h-3.5" /> Pickup Date & Time
+                </p>
+                <div className="grid sm:grid-cols-2 gap-4">
+                  <div className="space-y-1.5">
+                    <label className="text-xs font-medium text-muted-foreground">Pickup Date *</label>
+                    <Popover open={calOpen} onOpenChange={setCalOpen}>
+                      <PopoverTrigger asChild>
+                        <button
+                          type="button"
+                          className={`flex h-9 w-full items-center justify-between rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${!date ? "text-muted-foreground" : ""}`}
+                        >
+                          <span>{date ? format(date, "d/M/yyyy") : "Pick a date"}</span>
+                          <ChevronDown className="w-4 h-4 opacity-50" />
+                        </button>
+                      </PopoverTrigger>
+                      <PopoverContent className="w-auto p-0" align="start">
+                        <Calendar
+                          mode="single"
+                          selected={date}
+                          onSelect={(d) => { setDate(d); setCalOpen(false) }}
+                          disabled={(d) => d < new Date(new Date().setHours(0, 0, 0, 0))}
+                        />
+                      </PopoverContent>
+                    </Popover>
+                  </div>
+                  <div className="space-y-1.5">
+                    <label className="text-xs font-medium text-muted-foreground">Preferred Time</label>
+                    <Select value={timeSlot} onValueChange={setTimeSlot}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select a time" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {timeSlots.map((s) => (
+                          <SelectItem key={s} value={s}>{s}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+              </div>
+
+              {/* Farm address */}
+              <div className="p-5">
+                <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-3 flex items-center gap-1.5">
+                  <MapPin className="w-3.5 h-3.5" /> Farm Address
+                </p>
+                <input
+                  type="text"
+                  value={farmAddress || profileAddress}
+                  onChange={(e) => setFarmAddress(e.target.value)}
+                  placeholder="Enter your farm address"
+                  className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                />
+              </div>
+
+              {/* Goods + notes */}
+              <div className="p-5 space-y-4">
+                <div className="space-y-2">
+                  <label className="text-xs font-medium text-muted-foreground">Goods *</label>
+                  <GoodsPicker items={goodsItems} onChange={setGoodsItems} />
+                </div>
+
+                <div className="space-y-1.5">
+                  <label className="text-xs font-medium text-muted-foreground">Phone Number</label>
+                  <input
+                    type="tel"
+                    value={phone}
+                    readOnly
+                    className="flex h-9 w-full rounded-md border border-input bg-muted px-3 py-1 text-sm shadow-sm text-muted-foreground cursor-not-allowed"
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <label className="text-xs font-medium text-muted-foreground">Notes</label>
+                  <textarea
+                    value={notes}
+                    onChange={(e) => setNotes(e.target.value)}
+                    rows={2}
+                    placeholder="Any special requirements or directions..."
+                    className="flex w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-none"
+                  />
+                </div>
+              </div>
+
+              {/* Submit */}
+              <div className="p-5 flex items-center justify-between">
+                <Link href={`/buy/${slug}`} className="text-sm text-muted-foreground hover:text-foreground">
+                  Cancel
+                </Link>
+                <button
+                  onClick={() => mutation.mutate()}
+                  disabled={mutation.isPending || !canSubmit}
+                  className="inline-flex items-center gap-2 bg-primary text-primary-foreground font-semibold py-2.5 px-6 rounded-xl hover:bg-primary/90 transition-colors disabled:opacity-50 text-sm"
+                >
+                  {mutation.isPending && <Loader2 className="w-4 h-4 animate-spin" />}
+                  Request Pickup
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/client-fnp/components/forms/login.tsx
+++ b/apps/client-fnp/components/forms/login.tsx
@@ -35,7 +35,7 @@ export function AuthForm({ className, ...props }: AuthFormProps) {
 
     const { errors } = formState
 
-    const { mutate, isPending, isSuccess } = useMutation({
+    const { mutate, isPending, isSuccess, isError } = useMutation({
         mutationFn: loginUser,
         onSuccess: (data) => {
             toast("Success", {
@@ -54,7 +54,7 @@ export function AuthForm({ className, ...props }: AuthFormProps) {
         onError: async (error) => {
 
             toast("Failed to login", {
-                description: "System Failure or Network Failure Please Try Again"
+                description: "Incorrect email or password."
             })
 
             await logtail.error(error)
@@ -121,6 +121,16 @@ export function AuthForm({ className, ...props }: AuthFormProps) {
                         )}
                         Login
                     </button>
+
+                    {isError && (
+                        <div className="rounded-md bg-orange-50 border border-orange-200 p-3 text-sm text-center">
+                            <p className="text-orange-800">Forgot your password?{" "}
+                                <Link href="/reset" className="font-semibold underline text-orange-600 hover:text-orange-500">
+                                    Reset it here
+                                </Link>
+                            </p>
+                        </div>
+                    )}
                 </div>
             </form>
 

--- a/apps/client-fnp/components/forms/reset.tsx
+++ b/apps/client-fnp/components/forms/reset.tsx
@@ -1,15 +1,15 @@
 "use client"
 
-import { useRouter, useSearchParams } from "next/navigation"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useMutation } from "@tanstack/react-query"
 import { isAxiosError } from "axios"
 
 import { useForm } from "react-hook-form"
 import { toast } from "sonner"
+import Link from "next/link"
 import { ResetSchema, ResetFormData } from "@/lib/schemas"
 import { cn } from "@/lib/utilities"
-import { clientReset} from "@/lib/query"
+import { clientReset } from "@/lib/query"
 
 import { buttonVariants } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -18,64 +18,57 @@ import { Label } from "@/components/ui/label"
 import { Icons } from "@/components/icons/lucide"
 
 
-
 interface RessetFormProps extends React.HTMLAttributes<HTMLDivElement> { }
 
 
 export function ResetAuthForm({ className, ...props }: RessetFormProps) {
 
-    const { register, handleSubmit, formState } = useForm<ResetFormData>({
+    const { register, handleSubmit, formState, getValues } = useForm<ResetFormData>({
         resolver: zodResolver(ResetSchema),
     })
-
-    const router = useRouter()
 
     const { errors } = formState
 
     const { mutate, isPending, isSuccess } = useMutation({
         mutationFn: clientReset,
-        onSuccess: (data) => {
-            toast("Success", {
-                description: "Reset email sent successfully, please check your email",
-            })
-            router.push("/login")
+        onSuccess: () => {
+            // isSuccess state drives the confirmation UI below
         },
         onError: (error) => {
-            if (isAxiosError(error)) {
-                switch (error.code) {
-                    case "ERR_NETWORK":
-                        toast("Network Issues", {
-                            description: "There seems to be a network error."
-                        })
-                        break
-
-                    default:
-                        toast("Unsuccesful", {
-                            description: "There was a problem with your request."
-                        })
-                        break
-                }
-            } else {
-
-                toast("Failed send reset password link", {
-                    description: 'System Failure or Network Failure Please Try Again'
+            if (isAxiosError(error) && error.code === "ERR_NETWORK") {
+                toast("Network Issues", {
+                    description: "There seems to be a network error."
                 })
-                
+            } else {
+                toast("Something went wrong", {
+                    description: "Please try again."
+                })
             }
-
-            console.log(error)
-
         },
     })
 
-
-    const submitLoginForm = async (payload: ResetFormData) => {
-        mutate(payload)
+    if (isSuccess) {
+        return (
+            <div className={cn("text-center", className)} {...props}>
+                <div className="rounded-md bg-orange-50 border border-orange-200 p-6 space-y-3">
+                    <Icons.mail className="w-8 h-8 mx-auto text-orange-600" />
+                    <p className="font-semibold text-orange-900">Check your email</p>
+                    <p className="text-sm text-orange-700">
+                        If an account exists for <span className="font-medium">{getValues("email")}</span>, a password reset link has been sent. Check your inbox and spam folder.
+                    </p>
+                </div>
+                <div className="mt-6 text-sm">
+                    <Link href="/login" className="font-semibold text-orange-600 hover:text-orange-500">
+                        Back to login
+                    </Link>
+                </div>
+            </div>
+        )
     }
 
     return (
         <div className={cn("", className)} {...props}>
-            <form onSubmit={handleSubmit((data) => submitLoginForm(data))}>
+            <form onSubmit={handleSubmit((data) => mutate(data))}>
                 <div className="grid gap-2">
                     <div className="grid gap-1">
                         <Label className="sr-only" htmlFor="email">
@@ -99,13 +92,13 @@ export function ResetAuthForm({ className, ...props }: RessetFormProps) {
                     </div>
                     <button
                         className={cn(buttonVariants())}
-                        disabled={isPending || isSuccess}
+                        disabled={isPending}
                         type="submit"
                     >
                         {isPending && (
                             <Icons.spinner className="w-4 h-4 mr-2 animate-spin" />
                         )}
-                        Reset Password
+                        Send Reset Link
                     </button>
                 </div>
             </form>

--- a/apps/client-fnp/components/structures/produce-grade-board.tsx
+++ b/apps/client-fnp/components/structures/produce-grade-board.tsx
@@ -143,6 +143,10 @@ export function ProduceGradeBoard({
     name: string
     slug: string
     province: string
+    latest_price_relation?: {
+      effective_date: string
+      price_data: Record<string, { pricing?: { delivered?: number } }>
+    }
   }
   const buyerRelations: BuyerEntry[] = buyersData?.data?.data ?? []
   const buyersTotal: number = buyersData?.data?.total ?? 0
@@ -288,22 +292,36 @@ export function ProduceGradeBoard({
                 <tr className="border-b text-xs text-muted-foreground">
                   <th className="text-left py-2 pr-8 font-medium w-8 tabular-nums">#</th>
                   <th className="text-left py-2 font-medium">Buyer</th>
+                  <th className="text-right py-2 font-medium">Latest Price</th>
                 </tr>
               </thead>
               <tbody>
-                {buyerRelations.map((b, i) => (
+                {buyerRelations.map((b, i) => {
+                  const rel = b.latest_price_relation
+                  const latestDelivered = rel
+                    ? Object.values(rel.price_data ?? {}).find(
+                        (v: any) => v !== null && typeof v === "object" && !Array.isArray(v) && (v?.pricing?.delivered ?? 0) > 0
+                      )?.pricing?.delivered
+                    : undefined
+                  return (
                   <tr key={i} className="border-b border-border/50 last:border-0 hover:bg-muted/40 transition-colors">
                     <td className="py-3 pr-8 text-muted-foreground tabular-nums text-xs">{(buyersPage - 1) * 20 + i + 1}</td>
                     <td className="py-3 pr-8 font-medium text-foreground capitalize">
                       <span className="inline-flex items-center gap-2">
-                        <span className="border border-border text-xs font-mono text-muted-foreground px-1.5 py-0.5 rounded shrink-0">
+                        <span className="inline-flex items-center justify-center border border-border text-xs font-mono text-muted-foreground w-7 h-6 rounded shrink-0">
                           {makeAbbveriation(b.name).toUpperCase().slice(0, 2)}
                         </span>
                         {b.name}
                       </span>
                     </td>
+                    <td className="py-3 text-right tabular-nums text-sm font-semibold">
+                      {latestDelivered
+                        ? <>${toDollars(latestDelivered)}<span className="text-xs font-normal text-muted-foreground">/kg</span></>
+                        : <span className="text-muted-foreground font-normal text-xs">—</span>}
+                    </td>
                   </tr>
-                ))}
+                  )
+                })}
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
## Summary

Companion frontend changes to backend v6.16.1 security update.

- **Login form**: after a failed attempt, show an inline orange banner with a direct link to `/reset` — guides users who've forgotten their password instead of showing a generic error
- **Login form**: error toast changed from "System Failure or Network Failure" to "Incorrect email or password"  
- **Reset form**: on success, show an inline confirmation ("Check your email") with the submitted address shown — no longer redirects to `/login` which was confusing
- **Reset form**: button label changed from "Reset Password" to "Send Reset Link" (clearer intent)

## Why

The backend now returns `200` for all reset requests (prevents email enumeration). The old `onSuccess` redirected to `/login` which left users wondering if anything happened. The new flow keeps them on the page with a clear confirmation.

## Test Plan

- [ ] Login with wrong password → toast says "Incorrect email or password" + orange reset banner appears
- [ ] Click "Reset it here" in banner → goes to `/reset`
- [ ] Submit reset form with any email → shows "Check your email" confirmation with email address shown
- [ ] "Back to login" link works from confirmation state
- [ ] Login with correct credentials still works normally