### PR TITLE
feat: menus orders and reservations admin pages

### DIFF
--- a/apps/admin-fnp/app/dashboard/restaurants/menus-orders/[id]/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menus-orders/[id]/page.tsx
@@ -1,0 +1,263 @@
+"use client"
+
+import { useParams, useRouter } from "next/navigation"
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { format } from "date-fns"
+import { ArrowLeft, Package, Truck, UtensilsCrossed, CheckCircle2, XCircle, Clock } from "lucide-react"
+import { queryMenusOrder, updateMenusOrderStatus } from "@/lib/query"
+import { DashboardShell } from "@/components/state/dashboardShell"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
+import { useToast } from "@/components/ui/use-toast"
+
+const STATUS_COLORS: Record<string, string> = {
+  pending:          "bg-yellow-100 text-yellow-800",
+  confirmed:        "bg-blue-100 text-blue-800",
+  preparing:        "bg-purple-100 text-purple-800",
+  ready:            "bg-teal-100 text-teal-800",
+  out_for_delivery: "bg-indigo-100 text-indigo-800",
+  delivered:        "bg-green-100 text-green-800",
+  completed:        "bg-green-100 text-green-800",
+  cancelled:        "bg-red-100 text-red-800",
+}
+
+const PICKUP_STEPS = ["pending", "confirmed", "preparing", "ready", "completed"]
+const DELIVERY_STEPS = ["pending", "confirmed", "preparing", "out_for_delivery", "delivered"]
+const DINE_IN_STEPS = ["pending", "confirmed", "preparing", "completed"]
+
+const TYPE_ICONS: Record<string, React.ReactNode> = {
+  pickup:   <Package className="h-4 w-4" />,
+  delivery: <Truck className="h-4 w-4" />,
+  dine_in:  <UtensilsCrossed className="h-4 w-4" />,
+}
+
+function getNextActions(status: string, type: string) {
+  const actions: { label: string; status: string; variant: "default" | "destructive" }[] = []
+  switch (status) {
+    case "pending":
+      actions.push({ label: "Confirm Order", status: "confirmed", variant: "default" })
+      break
+    case "confirmed":
+      actions.push({ label: "Start Preparing", status: "preparing", variant: "default" })
+      break
+    case "preparing":
+      if (type === "delivery") {
+        actions.push({ label: "Out for Delivery", status: "out_for_delivery", variant: "default" })
+      } else {
+        actions.push({ label: "Mark Ready", status: "ready", variant: "default" })
+      }
+      break
+    case "ready":
+      actions.push({ label: "Mark Completed", status: "completed", variant: "default" })
+      break
+    case "out_for_delivery":
+      actions.push({ label: "Mark Delivered", status: "delivered", variant: "default" })
+      break
+  }
+  if (!["completed", "delivered", "cancelled"].includes(status)) {
+    actions.push({ label: "Cancel Order", status: "cancelled", variant: "destructive" })
+  }
+  return actions
+}
+
+export default function MenusOrderDetailPage() {
+  const { id } = useParams<{ id: string }>()
+  const router = useRouter()
+  const qc = useQueryClient()
+  const { toast } = useToast()
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["menus-order", id],
+    queryFn: () => queryMenusOrder(id),
+    refetchOnWindowFocus: false,
+  })
+
+  const statusMutation = useMutation({
+    mutationFn: (status: string) => updateMenusOrderStatus(id, status),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["menus-order", id] })
+      qc.invalidateQueries({ queryKey: ["menus-orders"] })
+      qc.invalidateQueries({ queryKey: ["notifications"] })
+      toast({ title: "Order status updated" })
+    },
+    onError: () => toast({ title: "Failed to update status", variant: "destructive" }),
+  })
+
+  if (isLoading) {
+    return (
+      <DashboardShell>
+        <div className="space-y-4">
+          {[1,2,3].map(n => <div key={n} className="h-32 rounded-lg bg-muted animate-pulse" />)}
+        </div>
+      </DashboardShell>
+    )
+  }
+
+  const order = data?.data
+  if (!order) {
+    return (
+      <DashboardShell>
+        <p className="text-muted-foreground">Order not found</p>
+      </DashboardShell>
+    )
+  }
+
+  const steps = order.type === "delivery" ? DELIVERY_STEPS
+    : order.type === "dine_in" ? DINE_IN_STEPS
+    : PICKUP_STEPS
+  const currentStep = steps.indexOf(order.status)
+  const actions = getNextActions(order.status, order.type)
+
+  return (
+    <DashboardShell>
+      {/* Header */}
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="icon" onClick={() => router.back()}>
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+        <div className="flex-1">
+          <div className="flex items-center gap-3 flex-wrap">
+            <h2 className="text-2xl font-bold font-mono">{order.order_ref}</h2>
+            <Badge className={STATUS_COLORS[order.status] ?? ""} variant="outline">
+              {order.status}
+            </Badge>
+            <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
+              {TYPE_ICONS[order.type]}
+              {order.type === "pickup" ? "Pickup" : order.type === "delivery" ? "Delivery" : "Dine-in"}
+            </span>
+          </div>
+          <p className="text-sm text-muted-foreground mt-0.5 capitalize">
+            {order.restaurant_name} — {order.location_name}
+          </p>
+          <p className="text-xs text-muted-foreground">{format(new Date(order.created), "PPp")}</p>
+        </div>
+      </div>
+
+      {/* Status stepper */}
+      {order.status !== "cancelled" && (
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              {steps.map((step, i) => {
+                const done = i <= currentStep
+                const current = i === currentStep
+                return (
+                  <div key={step} className="flex flex-1 items-center">
+                    <div className="flex flex-col items-center gap-1">
+                      <div className={`flex h-7 w-7 items-center justify-center rounded-full border-2 text-xs font-medium ${done ? "border-primary bg-primary text-primary-foreground" : "border-muted-foreground/30 text-muted-foreground/30"} ${current ? "ring-2 ring-primary/20" : ""}`}>
+                        {done ? <CheckCircle2 className="h-3.5 w-3.5" /> : <Clock className="h-3.5 w-3.5" />}
+                      </div>
+                      <span className={`text-[11px] capitalize ${done ? "font-medium" : "text-muted-foreground/50"}`}>
+                        {step.replace("_", " ")}
+                      </span>
+                    </div>
+                    {i < steps.length - 1 && (
+                      <div className={`mx-1 h-0.5 flex-1 ${i < currentStep ? "bg-primary" : "bg-muted"}`} />
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Action buttons */}
+      {actions.length > 0 && (
+        <div className="flex gap-2 flex-wrap">
+          {actions.map((a) => (
+            <Button
+              key={a.status}
+              variant={a.variant}
+              onClick={() => statusMutation.mutate(a.status)}
+              disabled={statusMutation.isPending}
+            >
+              {a.label}
+            </Button>
+          ))}
+        </div>
+      )}
+
+      <div className="grid gap-6 md:grid-cols-2">
+        {/* Customer */}
+        <Card>
+          <CardHeader><CardTitle className="text-base">Customer</CardTitle></CardHeader>
+          <CardContent className="space-y-1.5 text-sm">
+            <p><span className="text-muted-foreground">Name:</span> {order.full_name}</p>
+            <p><span className="text-muted-foreground">Contact:</span> {order.contact}</p>
+          </CardContent>
+        </Card>
+
+        {/* Fulfillment */}
+        <Card>
+          <CardHeader><CardTitle className="text-base">Fulfillment</CardTitle></CardHeader>
+          <CardContent className="space-y-1.5 text-sm">
+            <p><span className="text-muted-foreground">Type:</span> {order.type === "pickup" ? "Pickup" : order.type === "delivery" ? "Delivery" : "Dine-in"}</p>
+            {(order.pickup_date || order.arrival_date) && (
+              <p><span className="text-muted-foreground">Date/Time:</span> {order.pickup_date || order.arrival_date} at {order.pickup_time || order.arrival_time}</p>
+            )}
+            {order.delivery_address && (
+              <p><span className="text-muted-foreground">Address:</span> {order.delivery_address}, {order.delivery_city}</p>
+            )}
+            {order.number_of_guests && (
+              <p><span className="text-muted-foreground">Guests:</span> {order.number_of_guests}</p>
+            )}
+            {order.notes && (
+              <p><span className="text-muted-foreground">Notes:</span> {order.notes}</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Items */}
+      <Card>
+        <CardHeader><CardTitle className="text-base">Items</CardTitle></CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            {(order.items ?? []).map((item: any, i: number) => (
+              <div key={i} className="flex items-center justify-between rounded-lg border p-3 text-sm">
+                <div>
+                  <p className="font-medium capitalize">{item.menu_item_name}{item.size_name ? ` (${item.size_name})` : ""}</p>
+                  {item.notes && <p className="text-xs text-muted-foreground">{item.notes}</p>}
+                  <p className="text-xs text-muted-foreground">{item.quantity} × ${((item.unit_price ?? 0) / 100).toFixed(2)}</p>
+                </div>
+                <span className="font-medium">${((item.line_total ?? item.unit_price * item.quantity ?? 0) / 100).toFixed(2)}</span>
+              </div>
+            ))}
+          </div>
+          <Separator className="my-4" />
+          <div className="flex justify-between font-bold">
+            <span>Total</span>
+            <span>${((order.total ?? 0) / 100).toFixed(2)}</span>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Status history */}
+      {order.status_history?.length > 0 && (
+        <Card>
+          <CardHeader><CardTitle className="text-base">Timeline</CardTitle></CardHeader>
+          <CardContent>
+            <div className="space-y-3">
+              {order.status_history.map((h: any, i: number) => (
+                <div key={i} className="flex gap-3">
+                  <div className="flex flex-col items-center">
+                    <div className="h-2 w-2 rounded-full bg-primary mt-1.5" />
+                    {i < order.status_history.length - 1 && <div className="w-px flex-1 bg-border mt-1" />}
+                  </div>
+                  <div className="pb-3">
+                    <p className="text-sm font-medium capitalize">{h.to}</p>
+                    <p className="text-xs text-muted-foreground">{format(new Date(h.timestamp), "PPp")}</p>
+                    {h.admin_notes && <p className="text-xs text-muted-foreground mt-0.5 italic">{h.admin_notes}</p>}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </DashboardShell>
+  )
+}

--- a/apps/admin-fnp/app/dashboard/restaurants/menus-orders/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/menus-orders/page.tsx
@@ -1,0 +1,156 @@
+"use client"
+
+import { useState } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { useRouter } from "next/navigation"
+import { format } from "date-fns"
+import { queryMenusOrders } from "@/lib/query"
+import { DashboardHeader } from "@/components/state/dashboardHeader"
+import { DashboardShell } from "@/components/state/dashboardShell"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+
+const STATUS_COLORS: Record<string, string> = {
+  pending:          "bg-yellow-100 text-yellow-800",
+  confirmed:        "bg-blue-100 text-blue-800",
+  preparing:        "bg-purple-100 text-purple-800",
+  ready:            "bg-teal-100 text-teal-800",
+  out_for_delivery: "bg-indigo-100 text-indigo-800",
+  delivered:        "bg-green-100 text-green-800",
+  completed:        "bg-green-100 text-green-800",
+  cancelled:        "bg-red-100 text-red-800",
+}
+
+const TYPE_LABELS: Record<string, string> = {
+  pickup:   "Pickup",
+  delivery: "Delivery",
+  dine_in:  "Dine-in",
+}
+
+export default function MenusOrdersPage() {
+  const router = useRouter()
+  const [statusFilter, setStatusFilter] = useState("all")
+  const [typeFilter, setTypeFilter] = useState("all")
+  const [page, setPage] = useState(1)
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["menus-orders", { status: statusFilter, type: typeFilter, p: page }],
+    queryFn: () => queryMenusOrders({
+      status: statusFilter === "all" ? undefined : statusFilter,
+      type: typeFilter === "all" ? undefined : typeFilter,
+      p: page,
+    }),
+    refetchOnWindowFocus: false,
+  })
+
+  const orders = data?.data?.orders ?? []
+  const total: number = data?.data?.total ?? 0
+  const pageSize = 20
+  const totalPages = Math.ceil(total / pageSize)
+
+  return (
+    <DashboardShell>
+      <DashboardHeader heading="Food Orders" text="Manage orders placed through menus.co.zw." />
+
+      {/* Filters */}
+      <div className="flex gap-3 flex-wrap">
+        <Select value={statusFilter} onValueChange={(v) => { setStatusFilter(v); setPage(1) }}>
+          <SelectTrigger className="w-40">
+            <SelectValue placeholder="All statuses" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All statuses</SelectItem>
+            <SelectItem value="pending">Pending</SelectItem>
+            <SelectItem value="confirmed">Confirmed</SelectItem>
+            <SelectItem value="preparing">Preparing</SelectItem>
+            <SelectItem value="ready">Ready</SelectItem>
+            <SelectItem value="out_for_delivery">Out for delivery</SelectItem>
+            <SelectItem value="completed">Completed</SelectItem>
+            <SelectItem value="cancelled">Cancelled</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Select value={typeFilter} onValueChange={(v) => { setTypeFilter(v); setPage(1) }}>
+          <SelectTrigger className="w-40">
+            <SelectValue placeholder="All types" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All types</SelectItem>
+            <SelectItem value="pickup">Pickup</SelectItem>
+            <SelectItem value="delivery">Delivery</SelectItem>
+            <SelectItem value="dine_in">Dine-in</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Table */}
+      {isLoading ? (
+        <div className="space-y-2">
+          {[1,2,3].map(n => <div key={n} className="h-14 rounded-lg bg-muted animate-pulse" />)}
+        </div>
+      ) : orders.length === 0 ? (
+        <div className="rounded-lg border p-12 text-center text-sm text-muted-foreground">
+          No orders found
+        </div>
+      ) : (
+        <div className="rounded-lg border overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="border-b bg-muted/50">
+              <tr>
+                <th className="px-4 py-3 text-left font-medium">Ref</th>
+                <th className="px-4 py-3 text-left font-medium">Restaurant</th>
+                <th className="px-4 py-3 text-left font-medium">Customer</th>
+                <th className="px-4 py-3 text-left font-medium">Type</th>
+                <th className="px-4 py-3 text-left font-medium">Total</th>
+                <th className="px-4 py-3 text-left font-medium">Status</th>
+                <th className="px-4 py-3 text-left font-medium">Date</th>
+                <th className="px-4 py-3" />
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {orders.map((order: any) => (
+                <tr key={order.id} className="hover:bg-muted/30 transition-colors">
+                  <td className="px-4 py-3 font-mono text-xs">{order.order_ref}</td>
+                  <td className="px-4 py-3 capitalize">{order.restaurant_name}</td>
+                  <td className="px-4 py-3">{order.full_name}</td>
+                  <td className="px-4 py-3">{TYPE_LABELS[order.type] ?? order.type}</td>
+                  <td className="px-4 py-3">${((order.total ?? 0) / 100).toFixed(2)}</td>
+                  <td className="px-4 py-3">
+                    <Badge className={STATUS_COLORS[order.status] ?? ""} variant="outline">
+                      {order.status}
+                    </Badge>
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground text-xs">
+                    {format(new Date(order.created), "dd MMM, HH:mm")}
+                  </td>
+                  <td className="px-4 py-3">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => router.push(`/dashboard/restaurants/menus-orders/${order.id}`)}
+                    >
+                      View
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between text-sm text-muted-foreground">
+          <span>{total} orders total</span>
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" onClick={() => setPage(p => p - 1)} disabled={page === 1}>Previous</Button>
+            <span className="flex items-center px-2">Page {page} of {totalPages}</span>
+            <Button variant="outline" size="sm" onClick={() => setPage(p => p + 1)} disabled={page >= totalPages}>Next</Button>
+          </div>
+        </div>
+      )}
+    </DashboardShell>
+  )
+}

--- a/apps/admin-fnp/app/dashboard/restaurants/reservations/[id]/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/reservations/[id]/page.tsx
@@ -1,0 +1,204 @@
+"use client"
+
+import { useParams, useRouter } from "next/navigation"
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { format } from "date-fns"
+import { ArrowLeft, CheckCircle2, Clock, Users, Calendar } from "lucide-react"
+import { queryMenusReservation, updateMenusReservationStatus } from "@/lib/query"
+import { DashboardShell } from "@/components/state/dashboardShell"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { useToast } from "@/components/ui/use-toast"
+
+const STATUS_COLORS: Record<string, string> = {
+  pending:   "bg-yellow-100 text-yellow-800",
+  confirmed: "bg-blue-100 text-blue-800",
+  seated:    "bg-purple-100 text-purple-800",
+  completed: "bg-green-100 text-green-800",
+  cancelled: "bg-red-100 text-red-800",
+  no_show:   "bg-zinc-100 text-zinc-700",
+}
+
+const STEPS = ["pending", "confirmed", "seated", "completed"]
+
+function getNextActions(status: string) {
+  const actions: { label: string; status: string; variant: "default" | "destructive" | "outline" }[] = []
+  switch (status) {
+    case "pending":
+      actions.push({ label: "Confirm Reservation", status: "confirmed", variant: "default" })
+      break
+    case "confirmed":
+      actions.push({ label: "Mark Seated", status: "seated", variant: "default" })
+      break
+    case "seated":
+      actions.push({ label: "Mark Completed", status: "completed", variant: "default" })
+      break
+  }
+  if (!["completed", "cancelled", "no_show"].includes(status)) {
+    actions.push({ label: "Mark No-show", status: "no_show", variant: "outline" })
+    actions.push({ label: "Cancel", status: "cancelled", variant: "destructive" })
+  }
+  return actions
+}
+
+export default function ReservationDetailPage() {
+  const { id } = useParams<{ id: string }>()
+  const router = useRouter()
+  const qc = useQueryClient()
+  const { toast } = useToast()
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["menus-reservation", id],
+    queryFn: () => queryMenusReservation(id),
+    refetchOnWindowFocus: false,
+  })
+
+  const statusMutation = useMutation({
+    mutationFn: (status: string) => updateMenusReservationStatus(id, status),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["menus-reservation", id] })
+      qc.invalidateQueries({ queryKey: ["menus-reservations"] })
+      qc.invalidateQueries({ queryKey: ["notifications"] })
+      toast({ title: "Reservation updated" })
+    },
+    onError: () => toast({ title: "Failed to update reservation", variant: "destructive" }),
+  })
+
+  if (isLoading) {
+    return (
+      <DashboardShell>
+        <div className="space-y-4">
+          {[1,2].map(n => <div key={n} className="h-32 rounded-lg bg-muted animate-pulse" />)}
+        </div>
+      </DashboardShell>
+    )
+  }
+
+  const r = data?.data
+  if (!r) {
+    return (
+      <DashboardShell>
+        <p className="text-muted-foreground">Reservation not found</p>
+      </DashboardShell>
+    )
+  }
+
+  const currentStep = STEPS.indexOf(r.status)
+  const actions = getNextActions(r.status)
+
+  return (
+    <DashboardShell>
+      {/* Header */}
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="icon" onClick={() => router.back()}>
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+        <div className="flex-1">
+          <div className="flex items-center gap-3 flex-wrap">
+            <h2 className="text-2xl font-bold font-mono">{r.reservation_ref}</h2>
+            <Badge className={STATUS_COLORS[r.status] ?? ""} variant="outline">{r.status}</Badge>
+          </div>
+          <p className="text-sm text-muted-foreground capitalize">{r.restaurant_name} — {r.location_name}</p>
+          <p className="text-xs text-muted-foreground">{format(new Date(r.created), "PPp")}</p>
+        </div>
+      </div>
+
+      {/* Status stepper */}
+      {!["cancelled", "no_show"].includes(r.status) && (
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              {STEPS.map((step, i) => {
+                const done = i <= currentStep
+                const current = i === currentStep
+                return (
+                  <div key={step} className="flex flex-1 items-center">
+                    <div className="flex flex-col items-center gap-1">
+                      <div className={`flex h-7 w-7 items-center justify-center rounded-full border-2 ${done ? "border-primary bg-primary text-primary-foreground" : "border-muted-foreground/30 text-muted-foreground/30"} ${current ? "ring-2 ring-primary/20" : ""}`}>
+                        {done ? <CheckCircle2 className="h-3.5 w-3.5" /> : <Clock className="h-3.5 w-3.5" />}
+                      </div>
+                      <span className={`text-[11px] capitalize ${done ? "font-medium" : "text-muted-foreground/50"}`}>{step}</span>
+                    </div>
+                    {i < STEPS.length - 1 && (
+                      <div className={`mx-1 h-0.5 flex-1 ${i < currentStep ? "bg-primary" : "bg-muted"}`} />
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Actions */}
+      {actions.length > 0 && (
+        <div className="flex gap-2 flex-wrap">
+          {actions.map((a) => (
+            <Button
+              key={a.status}
+              variant={a.variant}
+              onClick={() => statusMutation.mutate(a.status)}
+              disabled={statusMutation.isPending}
+            >
+              {a.label}
+            </Button>
+          ))}
+        </div>
+      )}
+
+      <div className="grid gap-6 md:grid-cols-2">
+        {/* Guest */}
+        <Card>
+          <CardHeader><CardTitle className="text-base">Guest</CardTitle></CardHeader>
+          <CardContent className="space-y-1.5 text-sm">
+            <p><span className="text-muted-foreground">Name:</span> {r.full_name}</p>
+            <p><span className="text-muted-foreground">Contact:</span> {r.contact}</p>
+          </CardContent>
+        </Card>
+
+        {/* Booking details */}
+        <Card>
+          <CardHeader><CardTitle className="text-base">Booking Details</CardTitle></CardHeader>
+          <CardContent className="space-y-1.5 text-sm">
+            <p className="flex items-center gap-2">
+              <Calendar className="h-4 w-4 text-muted-foreground" />
+              {r.date} at {r.preferred_time}
+            </p>
+            <p className="flex items-center gap-2">
+              <Users className="h-4 w-4 text-muted-foreground" />
+              {r.number_of_guests} {r.number_of_guests === 1 ? "guest" : "guests"}
+            </p>
+            {r.notes && (
+              <p className="text-muted-foreground italic mt-2">{r.notes}</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Timeline */}
+      {r.status_history?.length > 0 && (
+        <Card>
+          <CardHeader><CardTitle className="text-base">Timeline</CardTitle></CardHeader>
+          <CardContent>
+            <div className="space-y-3">
+              {r.status_history.map((h: any, i: number) => (
+                <div key={i} className="flex gap-3">
+                  <div className="flex flex-col items-center">
+                    <div className="h-2 w-2 rounded-full bg-primary mt-1.5" />
+                    {i < r.status_history.length - 1 && <div className="w-px flex-1 bg-border mt-1" />}
+                  </div>
+                  <div className="pb-3">
+                    <p className="text-sm font-medium capitalize">{h.to}</p>
+                    <p className="text-xs text-muted-foreground">{format(new Date(h.timestamp), "PPp")}</p>
+                    {h.admin_notes && <p className="text-xs text-muted-foreground mt-0.5 italic">{h.admin_notes}</p>}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </DashboardShell>
+  )
+}

--- a/apps/admin-fnp/app/dashboard/restaurants/reservations/page.tsx
+++ b/apps/admin-fnp/app/dashboard/restaurants/reservations/page.tsx
@@ -1,0 +1,132 @@
+"use client"
+
+import { useState } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { useRouter } from "next/navigation"
+import { format } from "date-fns"
+import { queryMenusReservations } from "@/lib/query"
+import { DashboardHeader } from "@/components/state/dashboardHeader"
+import { DashboardShell } from "@/components/state/dashboardShell"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+
+const STATUS_COLORS: Record<string, string> = {
+  pending:   "bg-yellow-100 text-yellow-800",
+  confirmed: "bg-blue-100 text-blue-800",
+  seated:    "bg-purple-100 text-purple-800",
+  completed: "bg-green-100 text-green-800",
+  cancelled: "bg-red-100 text-red-800",
+  no_show:   "bg-zinc-100 text-zinc-700",
+}
+
+export default function ReservationsPage() {
+  const router = useRouter()
+  const [statusFilter, setStatusFilter] = useState("all")
+  const [page, setPage] = useState(1)
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["menus-reservations", { status: statusFilter, p: page }],
+    queryFn: () => queryMenusReservations({
+      status: statusFilter === "all" ? undefined : statusFilter,
+      p: page,
+    }),
+    refetchOnWindowFocus: false,
+  })
+
+  const reservations = data?.data?.reservations ?? []
+  const total: number = data?.data?.total ?? 0
+  const pageSize = 20
+  const totalPages = Math.ceil(total / pageSize)
+
+  return (
+    <DashboardShell>
+      <DashboardHeader heading="Table Reservations" text="Manage reservation requests from menus.co.zw." />
+
+      {/* Filters */}
+      <div className="flex gap-3 flex-wrap">
+        <Select value={statusFilter} onValueChange={(v) => { setStatusFilter(v); setPage(1) }}>
+          <SelectTrigger className="w-40">
+            <SelectValue placeholder="All statuses" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All statuses</SelectItem>
+            <SelectItem value="pending">Pending</SelectItem>
+            <SelectItem value="confirmed">Confirmed</SelectItem>
+            <SelectItem value="seated">Seated</SelectItem>
+            <SelectItem value="completed">Completed</SelectItem>
+            <SelectItem value="no_show">No show</SelectItem>
+            <SelectItem value="cancelled">Cancelled</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Table */}
+      {isLoading ? (
+        <div className="space-y-2">
+          {[1,2,3].map(n => <div key={n} className="h-14 rounded-lg bg-muted animate-pulse" />)}
+        </div>
+      ) : reservations.length === 0 ? (
+        <div className="rounded-lg border p-12 text-center text-sm text-muted-foreground">
+          No reservations found
+        </div>
+      ) : (
+        <div className="rounded-lg border overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="border-b bg-muted/50">
+              <tr>
+                <th className="px-4 py-3 text-left font-medium">Ref</th>
+                <th className="px-4 py-3 text-left font-medium">Restaurant</th>
+                <th className="px-4 py-3 text-left font-medium">Guest</th>
+                <th className="px-4 py-3 text-left font-medium">Date &amp; Time</th>
+                <th className="px-4 py-3 text-left font-medium">Guests</th>
+                <th className="px-4 py-3 text-left font-medium">Status</th>
+                <th className="px-4 py-3 text-left font-medium">Submitted</th>
+                <th className="px-4 py-3" />
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {reservations.map((r: any) => (
+                <tr key={r.id} className="hover:bg-muted/30 transition-colors">
+                  <td className="px-4 py-3 font-mono text-xs">{r.reservation_ref}</td>
+                  <td className="px-4 py-3 capitalize">{r.restaurant_name}</td>
+                  <td className="px-4 py-3">{r.full_name}</td>
+                  <td className="px-4 py-3">{r.date} {r.preferred_time}</td>
+                  <td className="px-4 py-3">{r.number_of_guests}</td>
+                  <td className="px-4 py-3">
+                    <Badge className={STATUS_COLORS[r.status] ?? ""} variant="outline">
+                      {r.status}
+                    </Badge>
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground text-xs">
+                    {format(new Date(r.created), "dd MMM, HH:mm")}
+                  </td>
+                  <td className="px-4 py-3">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => router.push(`/dashboard/restaurants/reservations/${r.id}`)}
+                    >
+                      View
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between text-sm text-muted-foreground">
+          <span>{total} reservations total</span>
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" onClick={() => setPage(p => p - 1)} disabled={page === 1}>Previous</Button>
+            <span className="flex items-center px-2">Page {page} of {totalPages}</span>
+            <Button variant="outline" size="sm" onClick={() => setPage(p => p + 1)} disabled={page >= totalPages}>Next</Button>
+          </div>
+        </div>
+      )}
+    </DashboardShell>
+  )
+}

--- a/apps/admin-fnp/components/icons/lucide.ts
+++ b/apps/admin-fnp/components/icons/lucide.ts
@@ -60,6 +60,8 @@ import {
   BarChart3,
   Eye,
   MapPin,
+  ShoppingBag,
+  CalendarCheck,
 } from "lucide-react"
 
 export type Icon = LucideIcon
@@ -128,4 +130,6 @@ export const Icons = {
   barChart: BarChart3,
   eye: Eye,
   mapPin: MapPin,
+  shoppingBag: ShoppingBag,
+  calendarCheck: CalendarCheck,
 }

--- a/apps/admin-fnp/config/restaurants-dashboard.ts
+++ b/apps/admin-fnp/config/restaurants-dashboard.ts
@@ -71,6 +71,22 @@ export const restaurantsDashboardConfig: DashboardConfig = {
       ],
     },
     {
+      label: "Ordering",
+      alwaysOpen: true,
+      items: [
+        {
+          title: "Food Orders",
+          href: "/dashboard/restaurants/menus-orders",
+          icon: "shoppingBag",
+        },
+        {
+          title: "Reservations",
+          href: "/dashboard/restaurants/reservations",
+          icon: "calendarCheck",
+        },
+      ],
+    },
+    {
       label: "Subscriptions",
       alwaysOpen: true,
       items: [

--- a/apps/admin-fnp/lib/query.ts
+++ b/apps/admin-fnp/lib/query.ts
@@ -1668,3 +1668,49 @@ export function updateDeliveryLocation(id: string, data: Partial<{
 }>) {
   return api.put(`${baseUrl}/booking/admin/client-locations/${id}`, data)
 }
+
+// ── Menus: Restaurant Food Orders ─────────────────────────────────────────────
+
+export function queryMenusOrders(params?: {
+  status?: string
+  type?: string
+  restaurant_id?: string
+  p?: number
+}) {
+  const q = new URLSearchParams()
+  if (params?.status) q.set("status", params.status)
+  if (params?.type) q.set("type", params.type)
+  if (params?.restaurant_id) q.set("restaurant_id", params.restaurant_id)
+  if (params?.p) q.set("p", String(params.p))
+  return api.get(`${baseUrl}/restaurant-orders/admin/list?${q}`)
+}
+
+export function queryMenusOrder(id: string) {
+  return api.get(`${baseUrl}/restaurant-orders/admin/${id}`)
+}
+
+export function updateMenusOrderStatus(id: string, status: string, adminNotes?: string) {
+  return api.put(`${baseUrl}/restaurant-orders/admin/${id}/status`, { status, admin_notes: adminNotes })
+}
+
+// ── Menus: Table Reservations ─────────────────────────────────────────────────
+
+export function queryMenusReservations(params?: {
+  status?: string
+  restaurant_id?: string
+  p?: number
+}) {
+  const q = new URLSearchParams()
+  if (params?.status) q.set("status", params.status)
+  if (params?.restaurant_id) q.set("restaurant_id", params.restaurant_id)
+  if (params?.p) q.set("p", String(params.p))
+  return api.get(`${baseUrl}/table-reservations/admin/list?${q}`)
+}
+
+export function queryMenusReservation(id: string) {
+  return api.get(`${baseUrl}/table-reservations/admin/${id}`)
+}
+
+export function updateMenusReservationStatus(id: string, status: string, adminNotes?: string) {
+  return api.put(`${baseUrl}/table-reservations/admin/${id}/status`, { status, admin_notes: adminNotes })
+}


### PR DESCRIPTION
## Summary
- Food Orders list with status/type filters and paginated table
- Food Order detail with status stepper (varies by pickup/delivery/dine_in), items table, action buttons
- Reservations list with status filter
- Reservation detail with 4-step stepper (pending → confirmed → seated → completed), No-show + Cancel actions
- Add query functions for admin orders/reservations
- Add Ordering nav group to restaurants sidebar