### PR TITLE
Fix Resend init at module level causing build failure

### DIFF
--- a/apps/client-fnp/app/api/emails/send/route.ts
+++ b/apps/client-fnp/app/api/emails/send/route.ts
@@ -14,10 +14,10 @@ import {
   BookingAdminAlertEmail,
 } from "@/emails"
 
-const resend = new Resend(process.env.RESEND_API_KEY)
 const FROM = "farmnport <noreply@farmnport.com>"
 
 export async function POST(req: NextRequest) {
+  const resend = new Resend(process.env.RESEND_API_KEY)
   const secret = req.headers.get("x-email-secret")
   if (secret !== process.env.EMAIL_SECRET) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 })


### PR DESCRIPTION
Moves `new Resend()` inside the POST handler so it only runs at request time, not at build time when env vars are unavailable.