### PR TITLE
fix: filter admin notifications by source

### DIFF
--- a/apps/admin-fnp/app/dashboard/farmnport/layout.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/layout.tsx
@@ -24,7 +24,7 @@ export default async function DashboardLayout({
             Manage Apps
           </Link>
           <div className="flex items-center gap-2">
-            <NotificationBell />
+            <NotificationBell source="farmnport" />
             <AccountNavigation />
           </div>
         </div>

--- a/apps/admin-fnp/components/notifications/notification-bell.tsx
+++ b/apps/admin-fnp/components/notifications/notification-bell.tsx
@@ -9,12 +9,16 @@ import { Button } from "@/components/ui/button"
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet"
 import { NotificationDrawer } from "./notification-dropdown"
 
-export function NotificationBell() {
+interface NotificationBellProps {
+  source?: string
+}
+
+export function NotificationBell({ source }: NotificationBellProps) {
   const [open, setOpen] = useState(false)
 
   const { data } = useQuery({
-    queryKey: ["notifications", "unread-count"],
-    queryFn: () => queryUnreadNotificationCount(),
+    queryKey: ["notifications", "unread-count", source],
+    queryFn: () => queryUnreadNotificationCount(source),
     refetchInterval: 15000,
   })
 
@@ -39,7 +43,7 @@ export function NotificationBell() {
               Notifications
             </SheetTitle>
           </SheetHeader>
-          <NotificationDrawer onClose={() => setOpen(false)} />
+          <NotificationDrawer onClose={() => setOpen(false)} source={source} />
         </SheetContent>
       </Sheet>
     </>

--- a/apps/admin-fnp/components/notifications/notification-dropdown.tsx
+++ b/apps/admin-fnp/components/notifications/notification-dropdown.tsx
@@ -21,18 +21,19 @@ interface Notification {
 
 interface NotificationDrawerProps {
   onClose: () => void
+  source?: string
 }
 
 const PAGE_SIZE = 20
 
-export function NotificationDrawer({ onClose }: NotificationDrawerProps) {
+export function NotificationDrawer({ onClose, source }: NotificationDrawerProps) {
   const router = useRouter()
   const queryClient = useQueryClient()
   const observerRef = useRef<IntersectionObserver | null>(null)
 
   const { data, isLoading, isFetchingNextPage, fetchNextPage, hasNextPage } = useInfiniteQuery({
-    queryKey: ["notifications", "list"],
-    queryFn: ({ pageParam = 1 }) => queryNotificationsList(pageParam as number).then((r) => r.data),
+    queryKey: ["notifications", "list", source],
+    queryFn: ({ pageParam = 1 }) => queryNotificationsList(pageParam as number, source).then((r) => r.data),
     getNextPageParam: (lastPage: any, allPages) => {
       const total = lastPage?.total ?? 0
       const fetched = allPages.length * PAGE_SIZE
@@ -42,7 +43,7 @@ export function NotificationDrawer({ onClose }: NotificationDrawerProps) {
   })
 
   const markReadMutation = useMutation({
-    mutationFn: (data: { ids?: string[]; all?: boolean }) => markNotificationsRead(data),
+    mutationFn: (data: { ids?: string[]; all?: boolean }) => markNotificationsRead(data, source),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["notifications"] })
     },

--- a/apps/admin-fnp/lib/query.ts
+++ b/apps/admin-fnp/lib/query.ts
@@ -991,23 +991,27 @@ export function querySalesStats(orderType?: string) {
 }
 
 // Notifications
-export function queryUnreadNotificationCount() {
-  const url = `${baseUrl}/user/notifications/unread-count`
+export function queryUnreadNotificationCount(source?: string) {
+  const params = source ? `?source=${source}` : ""
+  const url = `${baseUrl}/admin-notifications/count${params}`
   return api.get(url)
 }
 
-export function queryRecentNotifications() {
-  const url = `${baseUrl}/user/notifications/recent`
+export function queryRecentNotifications(source?: string) {
+  const params = source ? `?source=${source}` : ""
+  const url = `${baseUrl}/admin-notifications/recent${params}`
   return api.get(url)
 }
 
-export function queryNotificationsList(page: number) {
-  const url = `${baseUrl}/admin-notifications/list?p=${page}`
+export function queryNotificationsList(page: number, source?: string) {
+  const params = source ? `&source=${source}` : ""
+  const url = `${baseUrl}/admin-notifications/list?p=${page}${params}`
   return api.get(url)
 }
 
-export function markNotificationsRead(data: { ids?: string[]; all?: boolean }) {
-  const url = `${baseUrl}/user/notifications/mark-read`
+export function markNotificationsRead(data: { ids?: string[]; all?: boolean }, source?: string) {
+  const params = source ? `?source=${source}` : ""
+  const url = `${baseUrl}/admin-notifications/mark-read${params}`
   return api.post(url, data)
 }
 


### PR DESCRIPTION
## Summary
- `NotificationBell` accepts `source` prop; farmnport layout passes `source="farmnport"`
- All notification queries pass `?source=farmnport` to backend
- Fixed count endpoint URL from `/user/notifications/unread-count` to `/admin-notifications/count`