### PR TITLE
feat: add top loading bar on page navigation

### DIFF
--- a/apps/admin-fnp/app/layout.tsx
+++ b/apps/admin-fnp/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Inter as FontSans } from "next/font/google"
 import Script from "next/script"
+import NextTopLoader from "nextjs-toploader"
 
 import { cn } from "@/lib/utilities"
 import QueryProvider from "@/components/providers/QueryProvider"
@@ -52,6 +53,7 @@ export default function RootLayout({ children, modal }: RootLayoutProps) {
             __html: `<iframe src="https://www.googletagmanager.com/ns.html?id=${GTM_ID}" height="0" width="0" style="display: none; visibility: hidden;"></iframe>`,
           }}
         />
+        <NextTopLoader color="#16a34a" showSpinner={false} easing="ease-out" />
         <QueryProvider>
           {children}
           {modal}

--- a/apps/client-fnp/app/layout.tsx
+++ b/apps/client-fnp/app/layout.tsx
@@ -11,6 +11,8 @@ import { Toaster } from "@/components/ui/sonner"
 import { SpeedInsights } from "@vercel/speed-insights/next"
 import { NuqsAdapter } from "nuqs/adapters/next/app"
 
+import NextTopLoader from "nextjs-toploader"
+
 import { cn } from "@/lib/utilities"
 import { AuthSessionProvider } from "@/components/providers/AuthSessionProvider"
 import { CartProvider } from "@/contexts/cart-context"
@@ -70,6 +72,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
             fontHeading.variable
           )}
         >
+          <NextTopLoader color="#f97316" showSpinner={false} easing="ease-out" />
           <AuthSessionProvider>
           <ThemeProvider
             attribute="class"

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",
@@ -44,6 +44,7 @@
     "d3-selection": "^3.0.0",
     "d3-transition": "^3.0.1",
     "date-fns": "^4.1.0",
+    "flags": "^4.2.0",
     "google": "^2.1.0",
     "js-cookie": "^3.0.5",
     "jwt-decode": "^3.1.2",
@@ -52,7 +53,7 @@
     "next": "16.2.9",
     "next-auth": "^5.0.0-beta.31",
     "next-themes": "^0.2.1",
-    "flags": "^4.2.0",
+    "nextjs-toploader": "^3.9.17",
     "nuqs": "^2.8.6",
     "pluralize": "^8.0.0",
     "react": "^19.2.4",


### PR DESCRIPTION
## Summary
- Install nextjs-toploader in admin-fnp and client-fnp
- admin-fnp: green #16a34a loader, no spinner, ease-out
- client-fnp: orange #f97316 loader, no spinner, ease-out
- Shows progress bar on every page navigation