### PR TITLE
fix: gate /bookings route behind bookings_enabled flag

### DIFF
--- a/apps/client-fnp/proxy.ts
+++ b/apps/client-fnp/proxy.ts
@@ -26,6 +26,7 @@ async function isFeatureOn(key: string): Promise<boolean> {
 
 // ── Route → flag map ──────────────────────────────────────────────────────────
 const FLAG_GATES: { pattern: RegExp; flag: string }[] = [
+  { pattern: /^\/bookings(\/|$)/, flag: "bookings_enabled" },
   { pattern: /^\/account\/bookings(\/|$)/, flag: "bookings_enabled" },
   { pattern: /^\/account\/incoming-bookings(\/|$)/, flag: "bookings_enabled" },
   { pattern: /^\/account\/profile(\/|$)/, flag: "profile_enabled" },


### PR DESCRIPTION
## Summary
- Added `/bookings` route to FLAG_GATES in proxy.ts — was missing, causing the page to render regardless of the `bookings_enabled` GrowthBook flag
- `/account/bookings` and `/account/incoming-bookings` were already gated; now the main listing page is too

## Test plan
- [ ] With `bookings_enabled` off: visiting /bookings should redirect to /account
- [ ] With `bookings_enabled` on: /bookings should load normally