### PR TITLE
fix: hide bookings card on /market when bookings_enabled flag is off

### DIFF
--- a/apps/client-fnp/app/(landing)/market/page.tsx
+++ b/apps/client-fnp/app/(landing)/market/page.tsx
@@ -1,35 +1,44 @@
 import Link from "next/link"
 import { TrendingUp } from "lucide-react"
+import { bookingsEnabled } from "@/flags"
 
-const sections = [
+const allSections = [
     {
         title: "Prices",
         description: "Live and historical commodity prices for crops and livestock — track market movements and plan your sales.",
         href: "/prices",
+        flag: null,
     },
     {
         title: "Bookings",
         description: "Browse open booking slots from buyers and suppliers — reserve a delivery drop-off or collection slot near you.",
         href: "/bookings",
+        flag: "bookings_enabled",
     },
     {
         title: "Lots",
         description: "Browse active lots posted by farmers selling produce — buy directly at listed prices across Zimbabwe.",
         href: "/lots",
+        flag: null,
     },
     {
         title: "Buyers",
         description: "Browse verified commodity buyers looking to purchase crops and livestock across Zimbabwe.",
         href: "/buyers",
+        flag: null,
     },
     {
         title: "Farmers",
         description: "Find farmers and producers selling commodities — connect directly and negotiate deals.",
         href: "/farmers",
+        flag: null,
     },
 ]
 
-export default function MarketPage() {
+export default async function MarketPage() {
+    const showBookings = await bookingsEnabled()
+    const sections = allSections.filter(s => s.flag !== "bookings_enabled" || showBookings)
+
     return (
         <main className="bg-gradient-to-b from-background to-muted/20">
             <section className="py-6 lg:py-8 relative overflow-hidden">


### PR DESCRIPTION
## Summary
- /market page now checks the `bookings_enabled` GrowthBook flag before rendering the Bookings card
- When flag is off, the card is filtered out server-side

## Test plan
- [ ] With `bookings_enabled` off: /market should not show the Bookings card
- [ ] With `bookings_enabled` on: /market should show all 5 cards including Bookings