### PR TITLE
fix: remove quick links from feed-guides page

### DIFF
--- a/apps/client-fnp/app/(landing)/feed-guides/page.tsx
+++ b/apps/client-fnp/app/(landing)/feed-guides/page.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link"
 import { BaseURL } from "@/lib/schemas"
 import { FeedListingClient } from "./FeedListingClient"
-import { OtherGuidesLinks } from "@/components/shared/OtherGuidesLinks"
 
 const fetchOptions: RequestInit = process.env.NODE_ENV === "production"
     ? { next: { revalidate: 3600 } } as RequestInit
@@ -30,16 +29,13 @@ export default async function FeedProductsPage() {
                         <span className="mx-2">/</span>
                         <span className="text-foreground">Animal Nutrition</span>
                     </nav>
-                    <div className="flex items-start justify-between gap-4">
-                        <div>
-                            <h1 className="text-3xl font-bold font-heading tracking-tight">
-                                Livestock Feed Products
-                            </h1>
-                            <p className="mt-2 text-sm text-muted-foreground">
-                                Browse our complete collection of livestock feed products across all categories and animal types.
-                            </p>
-                        </div>
-                        <OtherGuidesLinks current="animal-nutrition" />
+                    <div>
+                        <h1 className="text-3xl font-bold font-heading tracking-tight">
+                            Livestock Feed Products
+                        </h1>
+                        <p className="mt-2 text-sm text-muted-foreground">
+                            Browse our complete collection of livestock feed products across all categories and animal types.
+                        </p>
                     </div>
                 </div>
 


### PR DESCRIPTION
Removes the OtherGuidesLinks component from the feed-guides listing page.