### PR TITLE
fix: remove QuickLinks sidebar from feed-guides listing

### DIFF
--- a/apps/client-fnp/app/(landing)/feed-guides/FeedListingClient.tsx
+++ b/apps/client-fnp/app/(landing)/feed-guides/FeedListingClient.tsx
@@ -2,7 +2,6 @@
 
 import { useQuery } from "@tanstack/react-query"
 import { queryAllFeedProducts } from "@/lib/query"
-import { QuickLinks } from "@/components/generic/quick-links"
 import { Button } from "@/components/ui/button"
 import { useQueryStates, parseAsArrayOf, parseAsString, parseAsInteger } from "nuqs"
 import { FeedFilterSidebar } from "@/components/generic/feedFilterSidebar"
@@ -144,9 +143,6 @@ export function FeedListingClient({ initialData, initialTotal }: FeedListingClie
                         )}
                     </>
                 )}
-            </div>
-            <div className="hidden lg:block lg:w-44 shrink-0">
-                <QuickLinks />
             </div>
         </div>
     )

--- a/apps/client-fnp/app/(landing)/feed-guides/page.tsx
+++ b/apps/client-fnp/app/(landing)/feed-guides/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link"
 import { BaseURL } from "@/lib/schemas"
 import { FeedListingClient } from "./FeedListingClient"
+import { OtherGuidesLinks } from "@/components/shared/OtherGuidesLinks"
 
 const fetchOptions: RequestInit = process.env.NODE_ENV === "production"
     ? { next: { revalidate: 3600 } } as RequestInit
@@ -29,13 +30,16 @@ export default async function FeedProductsPage() {
                         <span className="mx-2">/</span>
                         <span className="text-foreground">Animal Nutrition</span>
                     </nav>
-                    <div>
-                        <h1 className="text-3xl font-bold font-heading tracking-tight">
-                            Livestock Feed Products
-                        </h1>
-                        <p className="mt-2 text-sm text-muted-foreground">
-                            Browse our complete collection of livestock feed products across all categories and animal types.
-                        </p>
+                    <div className="flex items-start justify-between gap-4">
+                        <div>
+                            <h1 className="text-3xl font-bold font-heading tracking-tight">
+                                Livestock Feed Products
+                            </h1>
+                            <p className="mt-2 text-sm text-muted-foreground">
+                                Browse our complete collection of livestock feed products across all categories and animal types.
+                            </p>
+                        </div>
+                        <OtherGuidesLinks current="animal-nutrition" />
                     </div>
                 </div>
 


### PR DESCRIPTION
Removes the QuickLinks sidebar component from the FeedListingClient product grid.