### PR TITLE
feat: document purchases — admin UI, client listing, downloads

### DIFF
--- a/apps/admin-fnp/app/dashboard/farmnport/documents/DocumentForm.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/documents/DocumentForm.tsx
@@ -1,0 +1,338 @@
+"use client"
+
+import Link from "next/link"
+import { useState } from "react"
+import { useMutation } from "@tanstack/react-query"
+import { useForm } from "react-hook-form"
+import { useRouter } from "next/navigation"
+
+import { adminUploadPDF, adminCreateDocument, adminUpdateDocument } from "@/lib/query"
+import { toast } from "@/components/ui/use-toast"
+import { handleApiError, handleFormErrors } from "@/lib/error-handler"
+import { cn } from "@/lib/utilities"
+import { buttonVariants } from "@/components/ui/button"
+import { Icons } from "@/components/icons/lucide"
+import {
+    Form,
+    FormControl,
+    FormField,
+    FormItem,
+    FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+
+const inputClass = "block w-full rounded-md bg-white px-3 py-1.5 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6 dark:bg-white/5 dark:text-white dark:outline-white/10 dark:placeholder:text-gray-500"
+
+const CATEGORIES = [
+    { value: "spray-program", label: "Spray Program" },
+    { value: "guide", label: "Guide" },
+    { value: "datasheet", label: "Datasheet" },
+    { value: "catalogue", label: "Catalogue" },
+]
+
+interface DocumentFormValues {
+    title: string
+    slug: string
+    description: string
+    category: string
+    tags: string
+    file_key: string
+    file_type: string
+    file_size_bytes: number
+    price_cents: number
+    active: string
+}
+
+interface DocumentFormProps {
+    mode: "new" | "edit"
+    documentId?: string
+    defaultValues?: Partial<DocumentFormValues>
+}
+
+function slugify(s: string) {
+    return s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")
+}
+
+export default function DocumentForm({ mode, documentId, defaultValues }: DocumentFormProps) {
+    const router = useRouter()
+    const [uploadingPDF, setUploadingPDF] = useState(false)
+    const [uploadedFilename, setUploadedFilename] = useState("")
+
+    const form = useForm<DocumentFormValues>({
+        defaultValues: {
+            title: "",
+            slug: "",
+            description: "",
+            category: "",
+            tags: "",
+            file_key: "",
+            file_type: "pdf",
+            file_size_bytes: 0,
+            price_cents: 0,
+            active: "true",
+            ...defaultValues,
+        },
+    })
+
+    async function handlePDFUpload(e: React.ChangeEvent<HTMLInputElement>) {
+        const file = e.target.files?.[0]
+        if (!file) return
+        setUploadingPDF(true)
+        try {
+            const res = await adminUploadPDF(file)
+            const { file_key, file_size_bytes, original_name } = res.data
+            form.setValue("file_key", file_key)
+            form.setValue("file_size_bytes", file_size_bytes)
+            form.setValue("file_type", "pdf")
+            setUploadedFilename(original_name)
+            toast({ description: "PDF uploaded successfully" })
+        } catch (err) {
+            handleApiError(err, { context: "PDF upload" })
+        } finally {
+            setUploadingPDF(false)
+        }
+    }
+
+    const { mutate, isPending } = useMutation({
+        mutationFn: (data: DocumentFormValues) => {
+            const payload = {
+                title: data.title,
+                slug: data.slug,
+                description: data.description || undefined,
+                category: data.category || undefined,
+                tags: data.tags ? data.tags.split(",").map(t => t.trim()).filter(Boolean) : [],
+                file_key: data.file_key,
+                file_type: data.file_type || undefined,
+                file_size_bytes: Number(data.file_size_bytes) || undefined,
+                price_cents: Math.round(Number(data.price_cents) * 100),
+                active: data.active === "true",
+            }
+            if (mode === "edit" && documentId) {
+                return adminUpdateDocument(documentId, payload)
+            }
+            return adminCreateDocument(payload)
+        },
+        onSuccess: () => {
+            toast({ description: mode === "edit" ? "Document updated" : "Document created" })
+            router.push("/dashboard/farmnport/documents")
+        },
+        onError: (error) => handleApiError(error, { context: mode === "edit" ? "update document" : "create document" }),
+    })
+
+    return (
+        <div className="space-y-10">
+            <div className="flex items-center justify-between">
+                <div>
+                    <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+                        {mode === "edit" ? "Edit Document" : "New Document"}
+                    </h1>
+                    <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                        {mode === "edit" ? "Update document details and file." : "Upload a PDF and create a document listing."}
+                    </p>
+                </div>
+                <Link href="/dashboard/farmnport/documents" className={cn(buttonVariants({ variant: "ghost" }))}>
+                    <Icons.close className="w-4 h-4 mr-2" />Close
+                </Link>
+            </div>
+
+            <Form {...form}>
+                <form onSubmit={form.handleSubmit((data) => mutate(data), (errors) => handleFormErrors(errors))}>
+                    <div className="space-y-12">
+
+                        {/* File Upload */}
+                        <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
+                            <div className="grid grid-cols-1 gap-x-8 gap-y-10 md:grid-cols-3">
+                                <div>
+                                    <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">PDF File</h2>
+                                    <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">Upload the PDF buyers will receive after purchase. Max 50 MB.</p>
+                                </div>
+                                <div className="md:col-span-2 space-y-4">
+                                    <div>
+                                        <label className="block text-sm/6 font-medium text-gray-900 dark:text-white mb-2">Upload PDF</label>
+                                        <input
+                                            type="file"
+                                            accept="application/pdf,.pdf"
+                                            onChange={handlePDFUpload}
+                                            disabled={uploadingPDF}
+                                            className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-primary file:text-white hover:file:bg-primary/90 disabled:opacity-50"
+                                        />
+                                        {uploadingPDF && (
+                                            <p className="mt-2 text-sm text-muted-foreground flex items-center gap-2">
+                                                <Icons.spinner className="w-4 h-4 animate-spin" /> Uploading…
+                                            </p>
+                                        )}
+                                        {uploadedFilename && !uploadingPDF && (
+                                            <p className="mt-2 text-sm text-green-600">✓ {uploadedFilename}</p>
+                                        )}
+                                    </div>
+                                    <div>
+                                        <label className="block text-sm/6 font-medium text-gray-900 dark:text-white mb-2">File Key <span className="text-gray-400 font-normal">(auto-filled on upload)</span></label>
+                                        <FormField control={form.control} name="file_key" render={({ field }) => (
+                                            <FormItem>
+                                                <FormControl>
+                                                    <Input placeholder="e.g. abc123.pdf" className={inputClass} {...field} />
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )} />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        {/* Details */}
+                        <div className="border-b border-gray-900/10 pb-12 dark:border-white/10">
+                            <div className="grid grid-cols-1 gap-x-8 gap-y-10 md:grid-cols-3">
+                                <div>
+                                    <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">Document Details</h2>
+                                    <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">Title, category, description and pricing.</p>
+                                </div>
+                                <div className="md:col-span-2">
+                                    <div className="grid grid-cols-1 gap-x-6 gap-y-6 sm:grid-cols-6">
+
+                                        <div className="sm:col-span-4">
+                                            <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">Title</label>
+                                            <div className="mt-2">
+                                                <FormField control={form.control} name="title" render={({ field }) => (
+                                                    <FormItem>
+                                                        <FormControl>
+                                                            <Input
+                                                                placeholder="e.g. Tomato Spray Program 2026"
+                                                                className={inputClass}
+                                                                {...field}
+                                                                onChange={(e) => {
+                                                                    field.onChange(e)
+                                                                    if (mode === "new") {
+                                                                        form.setValue("slug", slugify(e.target.value))
+                                                                    }
+                                                                }}
+                                                            />
+                                                        </FormControl>
+                                                        <FormMessage />
+                                                    </FormItem>
+                                                )} />
+                                            </div>
+                                        </div>
+
+                                        <div className="sm:col-span-4">
+                                            <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">Slug</label>
+                                            <div className="mt-2">
+                                                <FormField control={form.control} name="slug" render={({ field }) => (
+                                                    <FormItem>
+                                                        <FormControl>
+                                                            <Input placeholder="e.g. tomato-spray-program-2026" className={inputClass} {...field} />
+                                                        </FormControl>
+                                                        <FormMessage />
+                                                    </FormItem>
+                                                )} />
+                                            </div>
+                                        </div>
+
+                                        <div className="sm:col-span-3">
+                                            <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">Category</label>
+                                            <div className="mt-2">
+                                                <FormField control={form.control} name="category" render={({ field }) => (
+                                                    <FormItem>
+                                                        <Select onValueChange={field.onChange} value={field.value}>
+                                                            <FormControl><SelectTrigger><SelectValue placeholder="Select category" /></SelectTrigger></FormControl>
+                                                            <SelectContent>
+                                                                {CATEGORIES.map(c => <SelectItem key={c.value} value={c.value}>{c.label}</SelectItem>)}
+                                                            </SelectContent>
+                                                        </Select>
+                                                        <FormMessage />
+                                                    </FormItem>
+                                                )} />
+                                            </div>
+                                        </div>
+
+                                        <div className="sm:col-span-3">
+                                            <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">Price ($)</label>
+                                            <div className="mt-2">
+                                                <FormField control={form.control} name="price_cents" render={({ field }) => (
+                                                    <FormItem>
+                                                        <FormControl>
+                                                            <Input type="number" step="0.01" min="0" placeholder="0.00" className={inputClass} {...field} />
+                                                        </FormControl>
+                                                        <FormMessage />
+                                                    </FormItem>
+                                                )} />
+                                            </div>
+                                        </div>
+
+                                        <div className="sm:col-span-6">
+                                            <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">Description <span className="text-gray-400 font-normal">(optional)</span></label>
+                                            <div className="mt-2">
+                                                <FormField control={form.control} name="description" render={({ field }) => (
+                                                    <FormItem>
+                                                        <FormControl>
+                                                            <Textarea rows={4} placeholder="What's included, who it's for, key contents…" className={inputClass} {...field} />
+                                                        </FormControl>
+                                                        <FormMessage />
+                                                    </FormItem>
+                                                )} />
+                                            </div>
+                                        </div>
+
+                                        <div className="sm:col-span-6">
+                                            <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">Tags <span className="text-gray-400 font-normal">(comma-separated, optional)</span></label>
+                                            <div className="mt-2">
+                                                <FormField control={form.control} name="tags" render={({ field }) => (
+                                                    <FormItem>
+                                                        <FormControl>
+                                                            <Input placeholder="e.g. tomato, spray, agrochemical" className={inputClass} {...field} />
+                                                        </FormControl>
+                                                        <FormMessage />
+                                                    </FormItem>
+                                                )} />
+                                            </div>
+                                        </div>
+
+                                        <div className="sm:col-span-3">
+                                            <label className="block text-sm/6 font-medium text-gray-900 dark:text-white">Status</label>
+                                            <div className="mt-2">
+                                                <FormField control={form.control} name="active" render={({ field }) => (
+                                                    <FormItem>
+                                                        <Select onValueChange={field.onChange} value={field.value}>
+                                                            <FormControl><SelectTrigger><SelectValue placeholder="Select status" /></SelectTrigger></FormControl>
+                                                            <SelectContent>
+                                                                <SelectItem value="true">Active</SelectItem>
+                                                                <SelectItem value="false">Inactive</SelectItem>
+                                                            </SelectContent>
+                                                        </Select>
+                                                        <FormMessage />
+                                                    </FormItem>
+                                                )} />
+                                            </div>
+                                        </div>
+
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                    </div>
+
+                    <div className="mt-6 flex items-center justify-end gap-x-6">
+                        <button
+                            type="button"
+                            onClick={() => router.push("/dashboard/farmnport/documents")}
+                            className="text-sm/6 font-semibold text-gray-900 dark:text-white"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={isPending}
+                            className="inline-flex items-center rounded-md bg-primary px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                            {isPending && <Icons.spinner className="w-4 h-4 mr-2 animate-spin" />}
+                            {mode === "edit" ? "Save Changes" : "Create Document"}
+                        </button>
+                    </div>
+                </form>
+            </Form>
+        </div>
+    )
+}

--- a/apps/admin-fnp/app/dashboard/farmnport/documents/[id]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/documents/[id]/edit/page.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import { useParams } from "next/navigation"
+import { useQuery } from "@tanstack/react-query"
+import { Loader2 } from "lucide-react"
+
+import { adminGetDocument } from "@/lib/query"
+import DocumentForm from "../../DocumentForm"
+
+export default function EditDocumentPage() {
+    const { id } = useParams<{ id: string }>()
+
+    const { data, isLoading } = useQuery({
+        queryKey: ["admin-document", id],
+        queryFn: () => adminGetDocument(id).then(r => r.data),
+        enabled: !!id,
+    })
+
+    if (isLoading) {
+        return (
+            <div className="flex items-center justify-center py-24">
+                <Loader2 className="w-8 h-8 animate-spin text-muted-foreground" />
+            </div>
+        )
+    }
+
+    const doc = data?.document
+    if (!doc) return null
+
+    return (
+        <DocumentForm
+            mode="edit"
+            documentId={id}
+            defaultValues={{
+                title: doc.title,
+                slug: doc.slug,
+                description: doc.description ?? "",
+                category: doc.category ?? "",
+                tags: (doc.tags ?? []).join(", "),
+                file_key: doc.file_key ?? "",
+                file_type: doc.file_type ?? "pdf",
+                file_size_bytes: doc.file_size_bytes ?? 0,
+                price_cents: doc.price_cents ? doc.price_cents / 100 : 0,
+                active: doc.active ? "true" : "false",
+            }}
+        />
+    )
+}

--- a/apps/admin-fnp/app/dashboard/farmnport/documents/[id]/purchases/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/documents/[id]/purchases/page.tsx
@@ -1,0 +1,115 @@
+"use client"
+
+import Link from "next/link"
+import { useParams } from "next/navigation"
+import { useQuery } from "@tanstack/react-query"
+import { Loader2, KeyRound } from "lucide-react"
+
+import { adminDocumentPurchases, adminGetDocument } from "@/lib/query"
+
+function formatDate(d: string) {
+    return new Date(d).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" })
+}
+
+export default function DocumentPurchasesPage() {
+    const { id } = useParams<{ id: string }>()
+
+    const { data: docData, isLoading: docLoading } = useQuery({
+        queryKey: ["admin-document", id],
+        queryFn: () => adminGetDocument(id).then(r => r.data),
+        enabled: !!id,
+    })
+
+    const { data: purchasesData, isLoading: purchasesLoading } = useQuery({
+        queryKey: ["admin-document-purchases", id],
+        queryFn: () => adminDocumentPurchases(id).then(r => r.data),
+        enabled: !!id,
+    })
+
+    const isLoading = docLoading || purchasesLoading
+    if (isLoading) {
+        return (
+            <div className="flex items-center justify-center py-24">
+                <Loader2 className="w-8 h-8 animate-spin text-muted-foreground" />
+            </div>
+        )
+    }
+
+    const doc = docData?.document
+    const purchases: any[] = purchasesData?.purchases ?? []
+
+    return (
+        <div className="space-y-6">
+            <div className="flex items-center justify-between">
+                <div>
+                    <nav className="flex items-center gap-1.5 text-sm text-muted-foreground mb-1">
+                        <Link href="/dashboard/farmnport/documents" className="hover:text-foreground">Documents</Link>
+                        <span>/</span>
+                        <span className="text-foreground font-medium truncate">{doc?.title ?? id}</span>
+                        <span>/</span>
+                        <span className="text-foreground font-medium">Purchases</span>
+                    </nav>
+                    <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+                        Purchases
+                    </h1>
+                    <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                        {purchases.length} purchase{purchases.length !== 1 ? "s" : ""} for this document
+                    </p>
+                </div>
+                <Link
+                    href={`/dashboard/farmnport/documents/${id}/edit`}
+                    className="text-sm font-medium text-primary hover:underline"
+                >
+                    Edit Document
+                </Link>
+            </div>
+
+            {purchases.length === 0 ? (
+                <div className="text-center py-16 text-muted-foreground">
+                    No purchases yet.
+                </div>
+            ) : (
+                <div className="rounded-lg border border-border overflow-hidden">
+                    <table className="w-full text-sm">
+                        <thead className="bg-muted/50">
+                            <tr>
+                                <th className="text-left px-4 py-3 font-medium text-muted-foreground">Buyer</th>
+                                <th className="text-left px-4 py-3 font-medium text-muted-foreground">License</th>
+                                <th className="text-left px-4 py-3 font-medium text-muted-foreground">Downloads</th>
+                                <th className="text-left px-4 py-3 font-medium text-muted-foreground">Date</th>
+                                <th className="text-left px-4 py-3 font-medium text-muted-foreground">Status</th>
+                            </tr>
+                        </thead>
+                        <tbody className="divide-y divide-border">
+                            {purchases.map((p: any) => (
+                                <tr key={p.id} className="hover:bg-muted/50">
+                                    <td className="px-4 py-3">
+                                        <span className="font-medium">{p.client_id}</span>
+                                    </td>
+                                    <td className="px-4 py-3">
+                                        <span className="flex items-center gap-1 text-xs text-muted-foreground font-mono">
+                                            <KeyRound className="w-3 h-3" />
+                                            {p.license_serial ?? "—"}
+                                        </span>
+                                    </td>
+                                    <td className="px-4 py-3 text-muted-foreground">
+                                        {p.download_count ?? 0}
+                                    </td>
+                                    <td className="px-4 py-3 text-muted-foreground">
+                                        {p.created ? formatDate(p.created) : "—"}
+                                    </td>
+                                    <td className="px-4 py-3">
+                                        {p.is_revoked
+                                            ? <span className="inline-flex items-center rounded-md bg-red-50 px-2 py-0.5 text-xs font-medium text-red-700">Revoked</span>
+                                            : <span className="inline-flex items-center rounded-md bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700">Active</span>
+                                        }
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/apps/admin-fnp/app/dashboard/farmnport/documents/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/documents/new/page.tsx
@@ -1,0 +1,5 @@
+import DocumentForm from "../DocumentForm"
+
+export default function NewDocumentPage() {
+    return <DocumentForm mode="new" />
+}

--- a/apps/admin-fnp/app/dashboard/farmnport/documents/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/documents/page.tsx
@@ -1,0 +1,15 @@
+import { DashboardHeader } from "@/components/state/dashboardHeader"
+import { DashboardShell } from "@/components/state/dashboardShell"
+import { DocumentsTable } from "@/components/structures/tables/documents"
+
+export default async function DocumentsPage() {
+    return (
+        <DashboardShell>
+            <DashboardHeader
+                heading="Documents"
+                text="Manage digital documents available for purchase."
+            />
+            <DocumentsTable />
+        </DashboardShell>
+    )
+}

--- a/apps/admin-fnp/components/structures/columns/documents.tsx
+++ b/apps/admin-fnp/components/structures/columns/documents.tsx
@@ -1,0 +1,90 @@
+"use client"
+
+import Link from "next/link"
+import { ColumnDef } from "@tanstack/react-table"
+import { Checkbox } from "@/components/ui/checkbox"
+import { centsToDollars } from "@/lib/utilities"
+
+function formatDate(d: string) {
+  return new Date(d).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" })
+}
+
+export const documentColumns: ColumnDef<any>[] = [
+  {
+    id: "select",
+    header: ({ table }) => (
+      <Checkbox
+        checked={table.getIsAllPageRowsSelected()}
+        onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+        aria-label="Select all"
+        className="translate-y-[2px]"
+      />
+    ),
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        onCheckedChange={(value) => row.toggleSelected(!!value)}
+        aria-label="Select row"
+        className="translate-y-[2px]"
+      />
+    ),
+    enableSorting: false,
+    enableHiding: false,
+  },
+  {
+    accessorKey: "title",
+    header: "Title",
+    cell: ({ row }) => (
+      <Link
+        href={`/dashboard/farmnport/documents/${row.original.id}/edit`}
+        className="font-medium hover:underline"
+      >
+        {row.original.title}
+      </Link>
+    ),
+  },
+  {
+    accessorKey: "category",
+    header: "Category",
+    cell: ({ row }) => (
+      <span className="capitalize">{row.original.category?.replace("-", " ") ?? "—"}</span>
+    ),
+  },
+  {
+    accessorKey: "file_type",
+    header: "Type",
+    cell: ({ row }) => (
+      <span className="uppercase text-xs font-medium">{row.original.file_type ?? "—"}</span>
+    ),
+  },
+  {
+    accessorKey: "price_cents",
+    header: "Price",
+    cell: ({ row }) => (
+      <span>{row.original.price_cents ? centsToDollars(row.original.price_cents) : "Free"}</span>
+    ),
+  },
+  {
+    accessorKey: "active",
+    header: "Status",
+    cell: ({ row }) => row.original.active
+      ? <span className="inline-flex items-center rounded-md bg-green-50 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400">Active</span>
+      : <span className="inline-flex items-center rounded-md bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400">Inactive</span>,
+  },
+  {
+    accessorKey: "created",
+    header: "Created",
+    cell: ({ row }) => <span className="text-muted-foreground">{row.original.created ? formatDate(row.original.created) : "—"}</span>,
+  },
+  {
+    id: "actions",
+    cell: ({ row }) => (
+      <Link
+        href={`/dashboard/farmnport/documents/${row.original.id}/purchases`}
+        className="text-xs text-muted-foreground hover:text-foreground hover:underline"
+      >
+        Purchases
+      </Link>
+    ),
+  },
+]

--- a/apps/admin-fnp/components/structures/tables/documents.tsx
+++ b/apps/admin-fnp/components/structures/tables/documents.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { useState, useEffect, useRef } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { PaginationState } from "@tanstack/react-table"
+
+import { adminListDocuments } from "@/lib/query"
+import { handleFetchError } from "@/lib/error-handler"
+import { Placeholder } from "@/components/state/placeholder"
+import { TableSkeleton } from "@/components/state/skeleton-table"
+import { DataTable } from "@/components/structures/data-table"
+import { documentColumns } from "@/components/structures/columns/documents"
+
+export function DocumentsTable() {
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 20,
+  })
+  const [search, setSearch] = useState("")
+
+  const { isError, isLoading, isFetching, refetch, data, error } = useQuery({
+    queryKey: ["admin-documents", { p: pagination.pageIndex + 1 }],
+    queryFn: () => adminListDocuments({ p: pagination.pageIndex + 1 }),
+    refetchOnWindowFocus: false,
+  })
+
+  const documents = data?.data?.documents || []
+  const total = data?.data?.total as number
+
+  const hasShownError = useRef(false)
+  useEffect(() => {
+    if (isError && !hasShownError.current) {
+      hasShownError.current = true
+      handleFetchError(error, {
+        onRetry: () => {
+          hasShownError.current = false
+          refetch()
+        },
+        context: "documents",
+      })
+    }
+    if (!isError) hasShownError.current = false
+  }, [isError, error, refetch])
+
+  if (isError) {
+    return (
+      <Placeholder>
+        <Placeholder.Icon name="close" />
+        <Placeholder.Title>Error Fetching Documents</Placeholder.Title>
+        <Placeholder.Description>Error fetching documents from the database</Placeholder.Description>
+      </Placeholder>
+    )
+  }
+
+  if (isLoading || isFetching) return <TableSkeleton />
+
+  return (
+    <DataTable
+      columns={documentColumns}
+      data={documents}
+      newUrl="/dashboard/farmnport/documents/new"
+      tableName="Document"
+      total={total}
+      pagination={pagination}
+      setPagination={setPagination}
+      search={search}
+      setSearch={setSearch}
+    />
+  )
+}

--- a/apps/admin-fnp/config/dashboard.ts
+++ b/apps/admin-fnp/config/dashboard.ts
@@ -117,6 +117,17 @@ export const dashboardConfig: DashboardConfig = {
       ],
     },
     {
+      label: "Documents",
+      alwaysOpen: true,
+      items: [
+        {
+          title: "Documents",
+          href: "/dashboard/farmnport/documents",
+          icon: "fileText",
+        },
+      ],
+    },
+    {
       label: "AgroChemicals",
       items: [
         {

--- a/apps/admin-fnp/lib/query.ts
+++ b/apps/admin-fnp/lib/query.ts
@@ -1810,3 +1810,61 @@ export function queryTableReservation(id: string) {
 export function updateTableReservationStatus(id: string, status: string, admin_notes?: string) {
   return api.put(`${baseUrl}/table-reservations/admin/${id}/status`, { status, admin_notes: admin_notes ?? "" })
 }
+
+// ── Documents ──────────────────────────────────────────────────────────────────
+
+export function adminListDocuments(params?: { category?: string; p?: number }) {
+  const qs = new URLSearchParams()
+  if (params?.category) qs.set("category", params.category)
+  if (params?.p && params.p > 1) qs.set("p", params.p.toString())
+  const q = qs.toString()
+  return api.get(`${baseUrl}/documents/admin/list${q ? `?${q}` : ""}`)
+}
+
+export function adminGetDocument(id: string) {
+  return api.get(`${baseUrl}/documents/admin/${id}`)
+}
+
+export function adminUploadPDF(file: File) {
+  const form = new FormData()
+  form.append("pdf", file)
+  return api.post(`${baseUrl}/documents/admin/upload`, form, {
+    headers: { "Content-Type": "multipart/form-data" },
+  })
+}
+
+export function adminCreateDocument(data: {
+  title: string
+  slug: string
+  description?: string
+  category?: string
+  tags?: string[]
+  file_key: string
+  file_type?: string
+  file_size_bytes?: number
+  preview_images?: string[]
+  price_cents: number
+  active?: boolean
+}) {
+  return api.post(`${baseUrl}/documents/admin`, data)
+}
+
+export function adminUpdateDocument(id: string, data: {
+  title?: string
+  slug?: string
+  description?: string
+  category?: string
+  tags?: string[]
+  file_key?: string
+  file_type?: string
+  file_size_bytes?: number
+  preview_images?: string[]
+  price_cents?: number
+  active?: boolean
+}) {
+  return api.put(`${baseUrl}/documents/admin/${id}`, data)
+}
+
+export function adminDocumentPurchases(id: string) {
+  return api.get(`${baseUrl}/documents/admin/${id}/purchases`)
+}

--- a/apps/client-fnp/app/(landing)/account/(sections)/documents/page.tsx
+++ b/apps/client-fnp/app/(landing)/account/(sections)/documents/page.tsx
@@ -1,10 +1,142 @@
 "use client"
 
-export default function AccountDocumentsPage() {
+import { useState } from "react"
+import { useSession } from "next-auth/react"
+import { useQuery } from "@tanstack/react-query"
+import { Download, FileText, Loader2, KeyRound } from "lucide-react"
+import Link from "next/link"
+import { toast } from "sonner"
+import { myDownloads, downloadDocument } from "@/lib/query"
+
+function formatDate(d: string) {
+    return new Date(d).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" })
+}
+
+function DownloadButton({ token, title }: { token: string; title: string }) {
+    const [loading, setLoading] = useState(false)
+
+    async function handleDownload() {
+        setLoading(true)
+        try {
+            const res = await downloadDocument(token)
+            const url = res.data?.download_url
+            if (!url) throw new Error("No download URL returned")
+            window.open(url, "_blank", "noopener,noreferrer")
+        } catch {
+            toast.error("Download failed. Please try again.")
+        } finally {
+            setLoading(false)
+        }
+    }
+
     return (
-        <div className="flex flex-col items-center justify-center py-20 text-center">
-            <p className="font-semibold text-sm">No documents yet</p>
-            <p className="text-xs text-muted-foreground mt-1">Purchased documents and plans will appear here.</p>
+        <button
+            onClick={handleDownload}
+            disabled={loading}
+            className="flex items-center gap-1.5 text-sm font-medium text-primary hover:underline disabled:opacity-60"
+        >
+            {loading ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Download className="w-3.5 h-3.5" />}
+            {loading ? "Preparing…" : "Download"}
+        </button>
+    )
+}
+
+export default function AccountDocumentsPage() {
+    const { data: session, status } = useSession()
+
+    const { data, isLoading } = useQuery({
+        queryKey: ["my-downloads"],
+        queryFn: () => myDownloads().then(r => r.data),
+        enabled: !!session,
+    })
+
+    if (status === "loading" || isLoading) {
+        return (
+            <div className="flex items-center justify-center py-24">
+                <Loader2 className="w-8 h-8 animate-spin text-muted-foreground" />
+            </div>
+        )
+    }
+
+    if (!session) {
+        return (
+            <div className="flex items-center justify-center py-24">
+                <div className="text-center space-y-4">
+                    <FileText className="w-12 h-12 mx-auto text-muted-foreground/40" />
+                    <p className="font-semibold">Sign in to view your downloads</p>
+                    <Link
+                        href="/login?next=/account/documents"
+                        className="inline-flex items-center justify-center rounded-full bg-primary text-primary-foreground text-sm font-semibold px-6 py-2.5 hover:bg-primary/90 transition-colors"
+                    >
+                        Sign In
+                    </Link>
+                </div>
+            </div>
+        )
+    }
+
+    const downloads: any[] = data?.downloads ?? []
+
+    return (
+        <div>
+            <nav className="flex items-center gap-1.5 text-sm text-muted-foreground mb-4">
+                <Link href="/account" className="hover:text-foreground transition-colors">Account</Link>
+                <span>/</span>
+                <span className="text-foreground font-medium">My Downloads</span>
+            </nav>
+            <h1 className="text-xl font-bold mb-6">My Downloads</h1>
+
+            {downloads.length === 0 ? (
+                <div className="text-center py-16 space-y-4">
+                    <FileText className="w-12 h-12 mx-auto text-muted-foreground/40" />
+                    <p className="font-semibold">No downloads yet</p>
+                    <p className="text-sm text-muted-foreground">Purchased documents will appear here.</p>
+                    <Link
+                        href="/documents"
+                        className="inline-flex items-center justify-center rounded-full bg-primary text-primary-foreground text-sm font-semibold px-6 py-2.5 hover:bg-primary/90 transition-colors"
+                    >
+                        Browse Documents
+                    </Link>
+                </div>
+            ) : (
+                <div className="divide-y">
+                    {downloads.map((item: any) => {
+                        const doc = item.document
+                        const purchase = item.purchase
+                        return (
+                            <div key={purchase.id} className="py-4 flex items-start justify-between gap-4">
+                                <div className="flex items-start gap-3 min-w-0">
+                                    {doc?.preview_images?.[0] ? (
+                                        <img src={doc.preview_images[0]} alt={doc.title} className="w-12 h-16 rounded object-cover shrink-0 border border-border" />
+                                    ) : (
+                                        <div className="w-12 h-16 rounded bg-muted/30 flex items-center justify-center shrink-0 border border-border">
+                                            <FileText className="w-5 h-5 text-muted-foreground/40" />
+                                        </div>
+                                    )}
+                                    <div className="space-y-1 min-w-0">
+                                        <p className="font-semibold text-sm truncate">{doc?.title}</p>
+                                        {doc?.category && (
+                                            <p className="text-xs text-muted-foreground capitalize">{doc.category.replace("-", " ")}</p>
+                                        )}
+                                        <p className="text-xs text-muted-foreground">
+                                            Purchased {formatDate(purchase.created)} · {purchase.download_count ?? 0} download{purchase.download_count !== 1 ? "s" : ""}
+                                        </p>
+                                        {purchase.license_serial && (
+                                            <p className="text-xs text-muted-foreground flex items-center gap-1">
+                                                <KeyRound className="w-3 h-3" />
+                                                {purchase.license_serial}
+                                            </p>
+                                        )}
+                                    </div>
+                                </div>
+                                <div className="shrink-0">
+                                    <DownloadButton token={purchase.download_token} title={doc?.title ?? "document"} />
+                                </div>
+                            </div>
+                        )
+                    })}
+                </div>
+            )}
         </div>
     )
 }

--- a/apps/client-fnp/app/(landing)/documents/DocumentsClient.tsx
+++ b/apps/client-fnp/app/(landing)/documents/DocumentsClient.tsx
@@ -1,0 +1,130 @@
+"use client"
+
+import { useQuery } from "@tanstack/react-query"
+import { parseAsInteger, parseAsString, useQueryStates } from "nuqs"
+import { FileText, Loader2 } from "lucide-react"
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { listDocuments } from "@/lib/query"
+
+const CATEGORIES = [
+    { value: "", label: "All" },
+    { value: "spray-program", label: "Spray Programs" },
+    { value: "guide", label: "Guides" },
+    { value: "datasheet", label: "Datasheets" },
+    { value: "catalogue", label: "Catalogues" },
+]
+
+interface DocumentsClientProps {
+    initialDocs: any[]
+    initialTotal: number
+}
+
+export function DocumentsClient({ initialDocs, initialTotal }: DocumentsClientProps) {
+    const [qs, setQs] = useQueryStates({
+        category: parseAsString.withDefault(""),
+        p: parseAsInteger.withDefault(1),
+    })
+
+    const hasFilters = qs.category !== "" || qs.p > 1
+
+    const { data, isLoading } = useQuery({
+        queryKey: ["documents", qs.category, qs.p],
+        queryFn: () => listDocuments(qs.category || undefined).then(r => r.data),
+        placeholderData: !hasFilters ? { documents: initialDocs, total: initialTotal } as any : undefined,
+        refetchOnWindowFocus: false,
+    })
+
+    const docs: any[] = data?.documents ?? []
+    const total: number = data?.total ?? 0
+    const totalPages = Math.ceil(total / 24)
+
+    return (
+        <div>
+            {/* Category filter */}
+            <div className="flex flex-wrap gap-2 mb-6">
+                {CATEGORIES.map(c => (
+                    <button
+                        key={c.value}
+                        onClick={() => setQs({ category: c.value, p: 1 })}
+                        className={`text-sm px-4 py-1.5 rounded-full border font-medium transition-colors ${
+                            qs.category === c.value
+                                ? "bg-primary text-primary-foreground border-primary"
+                                : "border-border hover:bg-muted"
+                        }`}
+                    >
+                        {c.label}
+                    </button>
+                ))}
+            </div>
+
+            {isLoading ? (
+                <div className="flex items-center justify-center py-24">
+                    <Loader2 className="w-8 h-8 animate-spin text-muted-foreground" />
+                </div>
+            ) : docs.length === 0 ? (
+                <div className="text-center py-20 space-y-3">
+                    <FileText className="w-12 h-12 mx-auto text-muted-foreground/40" />
+                    <p className="font-semibold">No documents found</p>
+                    <p className="text-sm text-muted-foreground">Try a different category.</p>
+                </div>
+            ) : (
+                <>
+                    <p className="text-sm text-muted-foreground mb-4">Showing {docs.length} of {total}</p>
+                    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-5">
+                        {docs.map((doc: any) => (
+                            <DocumentCard key={doc.id} doc={doc} />
+                        ))}
+                    </div>
+
+                    {totalPages > 1 && (
+                        <div className="mt-8 flex justify-center gap-1">
+                            {Array.from({ length: totalPages }, (_, i) => i + 1)
+                                .filter(n => n === 1 || n === totalPages || (n >= qs.p - 2 && n <= qs.p + 2))
+                                .map((n, idx, arr) => {
+                                    const prev = arr[idx - 1]
+                                    return (
+                                        <div key={n} className="flex items-center gap-1">
+                                            {prev && n - prev > 1 && <span className="px-2 text-muted-foreground">...</span>}
+                                            <Button
+                                                variant={qs.p === n ? "default" : "outline"}
+                                                size="sm"
+                                                className="min-w-[40px]"
+                                                onClick={() => { setQs({ p: n }); window.scrollTo({ top: 0, behavior: "smooth" }) }}
+                                            >
+                                                {n}
+                                            </Button>
+                                        </div>
+                                    )
+                                })}
+                        </div>
+                    )}
+                </>
+            )}
+        </div>
+    )
+}
+
+function DocumentCard({ doc }: { doc: any }) {
+    const price = doc.price_cents ? `$${(doc.price_cents / 100).toFixed(2)}` : "Free"
+
+    return (
+        <Link href={`/documents/${doc.slug}`} className="group flex flex-col rounded-lg border border-border bg-card hover:shadow-md transition-shadow overflow-hidden">
+            {/* Cover */}
+            {doc.preview_images?.[0] ? (
+                <img src={doc.preview_images[0]} alt={doc.title} className="w-full aspect-[3/4] object-cover" />
+            ) : (
+                <div className="w-full aspect-[3/4] bg-muted/30 flex items-center justify-center">
+                    <FileText className="w-10 h-10 text-muted-foreground/40" />
+                </div>
+            )}
+            <div className="p-3 flex flex-col gap-1.5">
+                {doc.category && (
+                    <span className="text-[10px] uppercase tracking-wide font-semibold text-muted-foreground">{doc.category.replace("-", " ")}</span>
+                )}
+                <p className="text-sm font-semibold leading-snug line-clamp-2 group-hover:text-primary transition-colors">{doc.title}</p>
+                <p className="text-sm font-bold text-primary mt-auto">{price}</p>
+            </div>
+        </Link>
+    )
+}

--- a/apps/client-fnp/app/(landing)/documents/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/documents/[slug]/page.tsx
@@ -1,0 +1,134 @@
+import { notFound } from "next/navigation"
+import Link from "next/link"
+import { FileText, Tag, Download } from "lucide-react"
+import { serverFetch } from "@/lib/serverFetch"
+import { AddToCartButton } from "@/components/cart/AddToCartButton"
+
+interface Props {
+    params: { slug: string }
+}
+
+export async function generateMetadata({ params }: Props) {
+    try {
+        const result = await serverFetch(`/documents/${params.slug}`)
+        const doc = result?.document
+        if (!doc) return {}
+        return {
+            title: `${doc.title} | Farmnport Documents`,
+            description: doc.description,
+        }
+    } catch {
+        return {}
+    }
+}
+
+export default async function DocumentDetailPage({ params }: Props) {
+    let doc: any = null
+
+    try {
+        const result = await serverFetch(`/documents/${params.slug}`)
+        doc = result?.document
+    } catch {
+        notFound()
+    }
+
+    if (!doc) notFound()
+
+    const price = doc.price_cents ? `$${(doc.price_cents / 100).toFixed(2)}` : "Free"
+    const fileSizeKB = doc.file_size_bytes ? Math.round(doc.file_size_bytes / 1024) : null
+
+    return (
+        <div className="min-h-screen bg-gradient-to-b from-background to-muted/20">
+            <div className="mx-auto max-w-5xl px-6 lg:px-8 py-6">
+                <nav className="flex items-center gap-1.5 text-xs text-muted-foreground mb-6">
+                    <Link href="/" className="hover:text-foreground transition-colors">Home</Link>
+                    <span>/</span>
+                    <Link href="/documents" className="hover:text-foreground transition-colors">Documents</Link>
+                    <span>/</span>
+                    <span className="text-foreground font-medium truncate">{doc.title}</span>
+                </nav>
+
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-10">
+                    {/* Cover */}
+                    <div className="md:col-span-1">
+                        {doc.preview_images?.[0] ? (
+                            <img
+                                src={doc.preview_images[0]}
+                                alt={doc.title}
+                                className="w-full rounded-xl border border-border shadow-sm object-cover aspect-[3/4]"
+                            />
+                        ) : (
+                            <div className="w-full aspect-[3/4] rounded-xl border border-border bg-muted/30 flex items-center justify-center">
+                                <FileText className="w-16 h-16 text-muted-foreground/30" />
+                            </div>
+                        )}
+                    </div>
+
+                    {/* Details */}
+                    <div className="md:col-span-2 flex flex-col gap-5">
+                        {doc.category && (
+                            <span className="text-xs uppercase tracking-wide font-semibold text-muted-foreground">
+                                {doc.category.replace("-", " ")}
+                            </span>
+                        )}
+
+                        <h1 className="text-3xl font-bold tracking-tight font-heading">{doc.title}</h1>
+
+                        {doc.description && (
+                            <p className="text-muted-foreground leading-relaxed">{doc.description}</p>
+                        )}
+
+                        {/* Meta */}
+                        <div className="flex flex-wrap gap-4 text-sm text-muted-foreground">
+                            {doc.file_type && (
+                                <span className="flex items-center gap-1.5">
+                                    <FileText className="w-4 h-4" />
+                                    {doc.file_type.toUpperCase()}
+                                </span>
+                            )}
+                            {fileSizeKB && (
+                                <span className="flex items-center gap-1.5">
+                                    <Download className="w-4 h-4" />
+                                    {fileSizeKB < 1024 ? `${fileSizeKB} KB` : `${(fileSizeKB / 1024).toFixed(1)} MB`}
+                                </span>
+                            )}
+                        </div>
+
+                        {doc.tags?.length > 0 && (
+                            <div className="flex flex-wrap gap-2">
+                                {doc.tags.map((tag: string) => (
+                                    <span key={tag} className="flex items-center gap-1 text-xs bg-muted px-2.5 py-1 rounded-full text-muted-foreground">
+                                        <Tag className="w-3 h-3" />
+                                        {tag}
+                                    </span>
+                                ))}
+                            </div>
+                        )}
+
+                        {/* Purchase box */}
+                        <div className="rounded-xl border border-border bg-card p-5 space-y-4 mt-auto">
+                            <div className="flex items-baseline gap-2">
+                                <span className="text-3xl font-bold">{price}</span>
+                                <span className="text-sm text-muted-foreground">one-time purchase</span>
+                            </div>
+                            <ul className="text-sm text-muted-foreground space-y-1">
+                                <li>✓ Instant digital download</li>
+                                <li>✓ Watermarked with your name for security</li>
+                                <li>✓ Re-download anytime from your account</li>
+                                <li>✓ Includes license serial number</li>
+                            </ul>
+                            <AddToCartButton
+                                productId={doc.id}
+                                productType="document"
+                                productName={doc.title}
+                                productSlug={doc.slug}
+                                unitPrice={doc.price_cents}
+                                loginRedirect={`/documents/${doc.slug}`}
+                            />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/apps/client-fnp/app/(landing)/documents/page.tsx
+++ b/apps/client-fnp/app/(landing)/documents/page.tsx
@@ -1,0 +1,42 @@
+import Link from "next/link"
+import { serverFetch } from "@/lib/serverFetch"
+import { DocumentsClient } from "./DocumentsClient"
+
+export const metadata = {
+    title: "Farm Documents & Guides | Farmnport",
+    description: "Download premium farm management guides, spray programs, agrochemical datasheets and seed catalogues.",
+}
+
+export default async function DocumentsPage() {
+    let initialDocs: any[] = []
+    let initialTotal = 0
+
+    try {
+        const result = await serverFetch("/documents/all")
+        initialDocs = result?.documents || []
+        initialTotal = result?.total || 0
+    } catch {
+        // render empty — client will retry
+    }
+
+    return (
+        <div className="min-h-screen bg-gradient-to-b from-background to-muted/20">
+            <div className="mx-auto max-w-7xl px-6 lg:px-8 py-6">
+                <nav className="flex items-center gap-1.5 text-xs text-muted-foreground mb-6">
+                    <Link href="/" className="hover:text-foreground transition-colors">Home</Link>
+                    <span>/</span>
+                    <span className="text-foreground font-medium">Documents</span>
+                </nav>
+                <div className="mb-8">
+                    <h1 className="text-4xl font-bold tracking-tight font-heading mb-4">
+                        Farm Documents & Guides
+                    </h1>
+                    <p className="text-lg text-muted-foreground">
+                        Download premium spray programs, agrochemical datasheets, rearing guides and more.
+                    </p>
+                </div>
+                <DocumentsClient initialDocs={initialDocs} initialTotal={initialTotal} />
+            </div>
+        </div>
+    )
+}

--- a/apps/client-fnp/lib/query.ts
+++ b/apps/client-fnp/lib/query.ts
@@ -891,6 +891,24 @@ export function retryOrderPayment(id: string) {
   return api.post(`${BaseURL}/order/${id}/pay`, {})
 }
 
+// Documents
+export function listDocuments(category?: string) {
+  const q = category ? `?category=${category}` : ""
+  return api.get(`${BaseURL}/documents/all${q}`)
+}
+
+export function getDocument(slug: string) {
+  return api.get(`${BaseURL}/documents/${slug}`)
+}
+
+export function myDownloads() {
+  return api.get(`${BaseURL}/documents/my-downloads`)
+}
+
+export function downloadDocument(token: string) {
+  return api.get(`${BaseURL}/documents/download/${token}`)
+}
+
 // Lots
 export function myLots(page?: number) {
   const p = page && page >= 2 ? `?p=${page}` : ""


### PR DESCRIPTION
## Summary
- Admin: documents list, create/edit form with PDF upload, purchases per document view
- Client: /documents listing + /documents/[slug] detail with Add to Cart
- Client: /account/documents My Downloads with presigned download links
- Admin + client query functions in query.ts