### PR TITLE
Hide Digital Delivery on cancelled orders, bump v5.0.6

### DIFF
--- a/apps/admin-fnp/package.json
+++ b/apps/admin-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin-farmnport",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3000",

--- a/apps/client-fnp/app/(landing)/account/(sections)/orders/[id]/page.tsx
+++ b/apps/client-fnp/app/(landing)/account/(sections)/orders/[id]/page.tsx
@@ -308,7 +308,7 @@ export default function OrderDetailPage() {
 
         <div className="grid sm:grid-cols-2 gap-4">
           {/* Fulfillment */}
-          {isDigitalOrder ? (
+          {isDigitalOrder && order.status !== "cancelled" ? (
             <div className="border rounded-xl p-5 space-y-3">
               <div className="flex items-center gap-2">
                 <CheckCircle2 className="w-4 h-4 text-primary" />

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
Don't show Digital Delivery section when order status is cancelled