### PR TITLE
fix: allow /bookings page access without auth

### DIFF
--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",

--- a/apps/client-fnp/proxy.ts
+++ b/apps/client-fnp/proxy.ts
@@ -47,9 +47,9 @@ export default middleware(async (request) => {
   }
 
   // Redirect unauthenticated users to login for protected paths
-  const paths = ["profile", "bookings", "incoming-bookings", "security"]
+  const paths = ["/account/profile", "/account/bookings", "/account/incoming-bookings", "/account/security", "/account/booking-preorders"]
   for (const path of paths) {
-    if (pathname.includes(path) && request.auth?.user === undefined) {
+    if (pathname.startsWith(path) && request.auth?.user === undefined) {
       const url = request.nextUrl.clone()
       url.pathname = "/login"
       return NextResponse.redirect(url)


### PR DESCRIPTION
## Summary
- Middleware was using `pathname.includes("bookings")` which matched both `/bookings` (public) and `/account/bookings` (protected)
- Changed to exact `/account/` prefixed paths with `startsWith` so the public pre-orders page is accessible without login

## Test plan
- [ ] Visit `/bookings` while logged out — should load normally
- [ ] Visit `/account/bookings` while logged out — should redirect to `/login`