### PR TITLE
fix: add unit prop to remaining preorder email templates

### DIFF
--- a/apps/client-fnp/emails/templates/bookings/preorder-collected.tsx
+++ b/apps/client-fnp/emails/templates/bookings/preorder-collected.tsx
@@ -1,12 +1,13 @@
 import { Body, Button, Container, Head, Hr, Html, Preview, Section, Text } from "@react-email/components"
 
-interface Props { name?: string; bookingRef?: string; productName?: string; quantity?: string; bookingUrl?: string }
+interface Props { name?: string; bookingRef?: string; productName?: string; quantity?: string; unit?: string; bookingUrl?: string }
 
 export default function PreorderCollectedEmail({
   name = "Okandas",
   bookingRef = "FNP-BK-PO-0001",
   productName = "Fivet Cobb 500 Day-Old Chicks",
   quantity = "100",
+  unit = "units",
   bookingUrl = "https://farmnport.com/account/bookings/preview",
 }: Props) {
   return (
@@ -19,7 +20,7 @@ export default function PreorderCollectedEmail({
         <Section style={content}>
           <Section style={pillWrapper}><Text style={pill}>Collected</Text></Section>
           <Text style={greeting}>Thank you, {name}!</Text>
-          <Text style={paragraph}>Your order of {quantity} {productName} has been collected. Thank you for sourcing with farmnport.</Text>
+          <Text style={paragraph}>Your order of {quantity} {unit || "units"} of {productName} has been collected. Thank you for sourcing with farmnport.</Text>
           <Section style={refCard}><Text style={refLabel}>Booking reference</Text><Text style={refNumber}>{bookingRef}</Text></Section>
           <Section style={buttonWrapper}><Button href={bookingUrl} style={button}>View your booking</Button></Section>
           <Hr style={divider} />

--- a/apps/client-fnp/emails/templates/bookings/preorder-expired.tsx
+++ b/apps/client-fnp/emails/templates/bookings/preorder-expired.tsx
@@ -1,12 +1,13 @@
 import { Body, Button, Container, Head, Hr, Html, Preview, Row, Column, Section, Text } from "@react-email/components"
 
-interface Props { name?: string; bookingRef?: string; productName?: string; quantity?: string; bookingUrl?: string }
+interface Props { name?: string; bookingRef?: string; productName?: string; quantity?: string; unit?: string; bookingUrl?: string }
 
 export default function PreorderExpiredEmail({
   name = "Okandas",
   bookingRef = "FNP-BK-PO-0001",
   productName = "Fivet Cobb 500 Day-Old Chicks",
   quantity = "100",
+  unit = "units",
   bookingUrl = "https://farmnport.com/account/bookings/preview",
 }: Props) {
   return (
@@ -19,7 +20,7 @@ export default function PreorderExpiredEmail({
         <Section style={content}>
           <Section style={pillWrapper}><Text style={pill}>Booking Expired</Text></Section>
           <Text style={greeting}>Hi {name},</Text>
-          <Text style={paragraph}>Your booking for {quantity} {productName} has expired because the payment was not received within the deadline. Your reserved quantity has been released.</Text>
+          <Text style={paragraph}>Your booking for {quantity} {unit || "units"} of {productName} has expired because the payment was not received within the deadline. Your reserved quantity has been released.</Text>
           <Section style={refCard}><Text style={refLabel}>Booking reference</Text><Text style={refNumber}>{bookingRef}</Text></Section>
           <Text style={paragraph}>If you&apos;d still like to place an order, you can submit a new booking request.</Text>
           <Section style={buttonWrapper}><Button href={bookingUrl} style={button}>View Details</Button></Section>

--- a/apps/client-fnp/emails/templates/bookings/preorder-rejected.tsx
+++ b/apps/client-fnp/emails/templates/bookings/preorder-rejected.tsx
@@ -1,12 +1,13 @@
 import { Body, Button, Container, Head, Hr, Html, Preview, Row, Column, Section, Text } from "@react-email/components"
 
-interface Props { name?: string; bookingRef?: string; productName?: string; quantity?: string; reason?: string; bookingUrl?: string }
+interface Props { name?: string; bookingRef?: string; productName?: string; quantity?: string; unit?: string; reason?: string; bookingUrl?: string }
 
 export default function PreorderRejectedEmail({
   name = "Okandas",
   bookingRef = "FNP-BK-PO-0001",
   productName = "Fivet Cobb 500 Day-Old Chicks",
   quantity = "100",
+  unit = "units",
   reason = "Insufficient stock for requested quantity",
   bookingUrl = "https://farmnport.com/account/bookings/preview",
 }: Props) {
@@ -20,7 +21,7 @@ export default function PreorderRejectedEmail({
         <Section style={content}>
           <Section style={pillWrapper}><Text style={pill}>Not Fulfilled</Text></Section>
           <Text style={greeting}>Hi {name},</Text>
-          <Text style={paragraph}>Unfortunately, your booking request for {quantity} {productName} could not be fulfilled.</Text>
+          <Text style={paragraph}>Unfortunately, your booking request for {quantity} {unit || "units"} of {productName} could not be fulfilled.</Text>
           <Section style={refCard}><Text style={refLabel}>Booking reference</Text><Text style={refNumber}>{bookingRef}</Text></Section>
           {reason && (
             <>

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- Add `unit` prop to preorder-collected, preorder-expired, and preorder-rejected email templates
- These 3 templates were missed in PR #158 and still showed no unit context
- Bump client-fnp to v5.1.5

## Test plan
- [ ] Trigger each email type and verify unit shows correctly