### PR TITLE
feat: active booking CTA, skeleton loaders, remove Sell to card

### DIFF
--- a/apps/client-fnp/components/layouts/buyers.tsx
+++ b/apps/client-fnp/components/layouts/buyers.tsx
@@ -14,6 +14,7 @@ import {AdSenseInFeed} from "@/components/ads/AdSenseInFeed"
 import {ApplicationUser, AuthenticatedUser} from "@/lib/schemas"
 import {capitalizeFirstLetter, plural} from "@/lib/utilities"
 import {BuyerContactsCard} from "@/components/layouts/buyer-contacts"
+import {ClientListSkeleton} from "@/components/skeletons/client-list"
 
 interface BuyersPageProps {
   user: AuthenticatedUser | null
@@ -64,7 +65,7 @@ export function Buyers({queryBy}: BuyersPageProps) {
   }
 
   if (isFetching) {
-    return null
+    return <ClientListSkeleton />
   }
 
   const buyers = data?.data?.data as ApplicationUser[]

--- a/apps/client-fnp/components/layouts/client.tsx
+++ b/apps/client-fnp/components/layouts/client.tsx
@@ -120,9 +120,11 @@ export function Client({ slug, user, latestPrices }: ClientPageProps) {
                   {capitalizeFirstLetter(client.type)}
                 </Badge>
                 {client.has_booking && (
-                  <Badge className="bg-blue-100 text-blue-800 hover:bg-blue-100 border-blue-200">
-                    Accepts Online Bookings
-                  </Badge>
+                  <Link href={`/book/${slug}`}>
+                    <Badge className="bg-blue-100 text-blue-800 hover:bg-blue-100 border-blue-200 cursor-pointer">
+                      Accepts Online Bookings →
+                    </Badge>
+                  </Link>
                 )}
               </div>
 

--- a/apps/client-fnp/components/layouts/client.tsx
+++ b/apps/client-fnp/components/layouts/client.tsx
@@ -38,8 +38,6 @@ export function Client({ slug, user, latestPrices }: ClientPageProps) {
   const [showWhatsapp, setShowWhatsapp] = useState(false)
   const [showEmail, setShowEmail] = useState(false)
 
-  const paywallEnabled = process.env.NEXT_PUBLIC_ENABLE_PAYWALL === "true"
-  const isSubscribed = !paywallEnabled || user?.subscription_active === true
 
   const { data, isError, isFetching } = useQuery({
     queryKey: [`result-client-${slug}`, slug],
@@ -119,7 +117,7 @@ export function Client({ slug, user, latestPrices }: ClientPageProps) {
                 <Badge variant="secondary" className="font-medium">
                   {capitalizeFirstLetter(client.type)}
                 </Badge>
-                {client.has_booking && (
+                {client.has_active_booking && (
                   <Link href={`/book/${slug}`}>
                     <Badge className="bg-blue-100 text-blue-800 hover:bg-blue-100 border-blue-200 cursor-pointer">
                       Accepts Online Bookings →
@@ -186,8 +184,18 @@ export function Client({ slug, user, latestPrices }: ClientPageProps) {
       {/* Main Content */}
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mt-8 space-y-6">
         <div className="flex flex-col sm:flex-row gap-4">
-
-            {/* Phone + Email CTAs */}
+          {client.has_active_booking ? (
+            <Link
+              href={`/book/${slug}`}
+              className="flex-1 bg-blue-50 border border-blue-200 rounded-xl p-5 flex items-center justify-between hover:bg-blue-100 transition-colors"
+            >
+              <p className="font-semibold text-sm text-blue-900">Book from {titleCase(client.name)}</p>
+              <span className="bg-blue-700 text-white text-sm font-semibold px-4 py-2.5 rounded-lg">
+                Book Now →
+              </span>
+            </Link>
+          ) : (
+            <>
               <div className="flex-1 bg-card border rounded-xl p-4 space-y-3">
                 <div>
                   <p className="font-semibold text-sm">Phone</p>
@@ -196,10 +204,6 @@ export function Client({ slug, user, latestPrices }: ClientPageProps) {
                 {!user ? (
                   <button onClick={() => { sendGTMEvent({ event: 'login_prompt', reason: 'view_phone', client_name: client.name }); router.push(`/login?entity=${client.type}&wantToSee=${slug}`) }} className="block w-full text-center border border-border text-sm font-semibold px-3 py-2 rounded-lg hover:bg-muted transition-colors">
                     See Number →
-                  </button>
-                ) : !isSubscribed ? (
-                  <button onClick={() => { sendGTMEvent({ event: 'paywall_hit', reason: 'view_phone', client_name: client.name }); router.push('/pricing') }} className="block w-full text-center border border-border text-sm font-semibold px-3 py-2 rounded-lg hover:bg-muted transition-colors">
-                    Unlock →
                   </button>
                 ) : showPhone ? (
                   <a href={`tel:${client.phone}`} className="block w-full text-center border border-border text-sm font-semibold px-3 py-2 rounded-lg hover:bg-muted transition-colors">
@@ -221,10 +225,6 @@ export function Client({ slug, user, latestPrices }: ClientPageProps) {
                   <button onClick={() => { sendGTMEvent({ event: 'login_prompt', reason: 'view_whatsapp', client_name: client.name }); router.push(`/login?entity=${client.type}&wantToSee=${slug}`) }} className="block w-full text-center border border-border text-sm font-semibold px-3 py-2 rounded-lg hover:bg-muted transition-colors">
                     See WhatsApp →
                   </button>
-                ) : !isSubscribed ? (
-                  <button onClick={() => { sendGTMEvent({ event: 'paywall_hit', reason: 'view_whatsapp', client_name: client.name }); router.push('/pricing') }} className="block w-full text-center border border-border text-sm font-semibold px-3 py-2 rounded-lg hover:bg-muted transition-colors">
-                    Unlock →
-                  </button>
                 ) : showWhatsapp ? (
                   <a href={`https://wa.me/263${client.phone.replace(/^0/, '')}`} target="_blank" rel="noopener noreferrer" onClick={() => sendGTMEvent({ event: 'whatsapp_click', client_name: client.name })} className="block w-full text-center border border-border text-sm font-semibold px-3 py-2 rounded-lg hover:bg-muted transition-colors">
                     Open WhatsApp →
@@ -245,10 +245,6 @@ export function Client({ slug, user, latestPrices }: ClientPageProps) {
                   <button onClick={() => { sendGTMEvent({ event: 'login_prompt', reason: 'view_email', client_name: client.name }); router.push(`/login?entity=${client.type}&wantToSee=${slug}`) }} className="block w-full text-center border border-border text-sm font-semibold px-3 py-2 rounded-lg hover:bg-muted transition-colors">
                     See Email →
                   </button>
-                ) : !isSubscribed ? (
-                  <button onClick={() => { sendGTMEvent({ event: 'paywall_hit', reason: 'view_email', client_name: client.name }); router.push('/pricing') }} className="block w-full text-center border border-border text-sm font-semibold px-3 py-2 rounded-lg hover:bg-muted transition-colors">
-                    Unlock →
-                  </button>
                 ) : showEmail ? (
                   <a href={`mailto:${client.email}`} className="block w-full text-center border border-border text-sm font-semibold px-3 py-2 rounded-lg hover:bg-muted transition-colors">
                     {client.email}
@@ -259,27 +255,8 @@ export function Client({ slug, user, latestPrices }: ClientPageProps) {
                   </button>
                 )}
               </div>}
-
-            {(client.has_booking || client.has_pickup) && client.type === 'buyer' && (
-              <div className="flex-1 bg-blue-50 border border-blue-200 rounded-xl p-4 space-y-3">
-                <div>
-                  <p className="font-semibold text-sm text-blue-900">Sell to {titleCase(client.name)}</p>
-                  <p className="text-xs text-blue-700 mt-1 leading-relaxed">
-                    {client.has_booking && client.has_pickup
-                      ? "Select a drop-off location or request pickup, and pick a date to reserve your slot."
-                      : client.has_booking
-                      ? "Reserve a drop-off slot directly from the platform."
-                      : "Request this buyer to collect goods directly from your farm."}
-                  </p>
-                </div>
-                <Link
-                  href={`/book/${slug}`}
-                  className="block w-full text-center bg-blue-700 text-white text-sm font-semibold px-4 py-2.5 rounded-lg hover:bg-blue-800 transition-colors"
-                >
-                  Book a Sale →
-                </Link>
-              </div>
-            )}
+            </>
+          )}
         </div>
 
         {client.type === 'buyer' && (

--- a/apps/client-fnp/components/layouts/farmers.tsx
+++ b/apps/client-fnp/components/layouts/farmers.tsx
@@ -12,6 +12,7 @@ import {queryClients, queryClientsByProduct} from "@/lib/query"
 import {ApplicationUser, AuthenticatedUser} from "@/lib/schemas"
 import {slug, capitalizeFirstLetter, plural} from "@/lib/utilities"
 import {ArrowRight} from "lucide-react"
+import {ClientListSkeleton} from "@/components/skeletons/client-list"
 
 interface FarmersPageProps {
   user: AuthenticatedUser | null
@@ -57,7 +58,7 @@ export function Farmers({user, queryBy}: FarmersPageProps) {
   }
 
   if (isFetching) {
-    return null
+    return <ClientListSkeleton />
   }
 
   const farmers = data?.data?.data as ApplicationUser[]

--- a/apps/client-fnp/components/skeletons/client-list.tsx
+++ b/apps/client-fnp/components/skeletons/client-list.tsx
@@ -1,0 +1,32 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export function ClientListSkeleton({ count = 6 }: { count?: number }) {
+  return (
+    <div className="space-y-8">
+      <Skeleton className="h-[72px] w-full rounded-xl" />
+      <div>
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-5 w-80 mt-2" />
+      </div>
+      <ul role="list" className="divide-y">
+        {Array.from({ length: count }).map((_, i) => (
+          <li key={i} className="py-4 first:pt-2">
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-6 w-48" />
+                <Skeleton className="h-5 w-20 rounded-md" />
+              </div>
+              <Skeleton className="h-4 w-72" />
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-1 mt-1">
+                <Skeleton className="h-5 w-40" />
+                <Skeleton className="h-5 w-52" />
+                <Skeleton className="h-5 w-36" />
+                <Skeleton className="h-5 w-44" />
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/apps/client-fnp/lib/schemas.ts
+++ b/apps/client-fnp/lib/schemas.ts
@@ -141,6 +141,7 @@ export const ApplicationUserSchema = z.object({
     payment_terms: z.string(),
     has_prices: z.boolean().optional(),
     has_booking: z.boolean().optional(),
+    has_active_booking: z.boolean().optional(),
     has_pickup: z.boolean().optional(),
     contact_views: z.number().optional(),
 })

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "5.1.5",
+  "version": "5.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- Show "Book Now →" CTA replacing contact cards when client has active pre-order events
- Remove "Sell to {name}" card from buyer profiles
- Badge uses has_active_booking, links to /book/{slug}
- Skeleton loaders on /buyers and /farmers listings
- Add has_active_booking to ApplicationUser schema

## Test plan
- [ ] Visit a client profile with has_active_booking: true → see Book Now CTA, no contact cards
- [ ] Visit a client profile without → see normal contact cards
- [ ] /buyers and /farmers show skeleton while loading