### PR TITLE
fix: hide contact cards when has_active_booking is true

### DIFF
--- a/apps/client-fnp/components/layouts/client.tsx
+++ b/apps/client-fnp/components/layouts/client.tsx
@@ -183,7 +183,7 @@ export function Client({ slug, user, latestPrices }: ClientPageProps) {
 
       {/* Main Content */}
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mt-8 space-y-6">
-        <div className="flex flex-col sm:flex-row gap-4">
+        {!client.has_active_booking && <div className="flex flex-col sm:flex-row gap-4">
               <div className="flex-1 bg-card border rounded-xl p-4 space-y-3">
                 <div>
                   <p className="font-semibold text-sm">Phone</p>
@@ -243,7 +243,7 @@ export function Client({ slug, user, latestPrices }: ClientPageProps) {
                   </button>
                 )}
               </div>}
-        </div>
+        </div>}
 
         {client.type === 'buyer' && (
           <div id="price-history">


### PR DESCRIPTION
## Summary
- Hide phone/WhatsApp/email cards on profile when client has active pre-order events
- Badge still shows and links to /bookings