### PR TITLE
Fix: event image upload + admin logout

### DIFF
--- a/apps/admin-fnp/app/dashboard/farmnport/orders/booking-preorders/[id]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/orders/booking-preorders/[id]/edit/page.tsx
@@ -21,7 +21,7 @@ import { Calendar } from "@/components/ui/calendar"
 
 type SelectedLocation = { id: string; name: string }
 
-function ImageUpload({ value, onChange }: { value: string; onChange: (src: string) => void }) {
+function ImageUpload({ value, onChange, entityId }: { value: string; onChange: (src: string) => void; entityId?: string }) {
   const mutation = useMutation({
     mutationFn: uploadImages,
     onSuccess: (res) => { const src = res.data?.[0]?.img?.src; if (src) onChange(src) },
@@ -32,6 +32,9 @@ function ImageUpload({ value, onChange }: { value: string; onChange: (src: strin
     if (!file) return
     const fd = new FormData()
     fd.append("product_image", file)
+    if (entityId) fd.append("entity_id", entityId)
+    fd.append("entity_type", "booking_preorder")
+    fd.append("field_name", "images")
     mutation.mutate(fd)
   }
 
@@ -261,7 +264,7 @@ export default function EditPreOrderPage({ params }: { params: Promise<{ id: str
             <div className="col-span-full">
               <label className={labelCls}>Main Image</label>
               <div className="mt-2">
-                <ImageUpload value={form.image_src} onChange={(src) => set("image_src", src)} />
+                <ImageUpload value={form.image_src} onChange={(src) => set("image_src", src)} entityId={event?.id} />
               </div>
             </div>
             <div className="col-span-full">

--- a/apps/admin-fnp/components/navigation/account.tsx
+++ b/apps/admin-fnp/components/navigation/account.tsx
@@ -1,6 +1,8 @@
 "use client"
 
 import Link from "next/link"
+import { useRouter } from "next/navigation"
+import Cookies from "js-cookie"
 import { LogOut, User } from "lucide-react"
 
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
@@ -19,6 +21,13 @@ import {
 interface AccountNavigationProps extends React.HTMLAttributes<HTMLDivElement> {}
 
 export function AccountNavigation({ ...props }: AccountNavigationProps) {
+  const router = useRouter()
+
+  function handleLogout() {
+    Cookies.remove("cl_jtkn")
+    router.push("/login")
+  }
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -40,7 +49,7 @@ export function AccountNavigation({ ...props }: AccountNavigationProps) {
           </DropdownMenuItem>
         </DropdownMenuGroup>
 
-        <DropdownMenuItem>
+        <DropdownMenuItem onClick={handleLogout}>
           <LogOut className="w-4 h-4 mr-2" />
           <span>Log out</span>
           <DropdownMenuShortcut>⇧⌘Q</DropdownMenuShortcut>

--- a/apps/admin-fnp/package.json
+++ b/apps/admin-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "admin-farmnport",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3000",


### PR DESCRIPTION
## Summary
- Event ImageUpload now sends entity_id, entity_type, and field_name matching the working FileInput pattern
- Add logout handler — clears cookie and redirects to login
- Add is_test to updateLot type
- Bump admin-fnp to 3.2.1

## Test plan
- Upload image on booking preorder edit page
- Test logout from admin dropdown