### PR TITLE
Add Typesense search UI — Cmd+K modal

### DIFF
--- a/apps/client-fnp/components/layouts/site-header.tsx
+++ b/apps/client-fnp/components/layouts/site-header.tsx
@@ -1,19 +1,353 @@
 'use client'
 
+import { useState, useEffect } from "react"
+import Link from "next/link"
 import { useSession } from "next-auth/react"
-import { MainNav } from "@/components/layouts/main-nav"
+import { signOut } from "next-auth/react"
+import { sendGTMEvent } from "@next/third-parties/google"
+import { Search, ShoppingCart } from "lucide-react"
+import { siteConfig } from "@/config/site"
 import { MobileNav } from "@/components/layouts/mobile-nav"
-import { AuthenticatedUser } from "@/lib/schemas"
+import { AuthenticatedUser, AppURL } from "@/lib/schemas"
+import { capitalizeFirstLetter } from "@/lib/utilities"
+import { Button, buttonVariants } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
+import { makeAbbveriation } from "@/lib/utilities"
+import { useQuery } from "@tanstack/react-query"
+import { useCart } from "@/contexts/cart-context"
+import { getCart, countBookingNotifications } from "@/lib/query"
+import { SearchModal } from "@/components/structures/search-modal"
+
+function CartIcon({ user }: { user: AuthenticatedUser | null }) {
+  const { openCart } = useCart()
+  const { data } = useQuery({
+    queryKey: ["cart"],
+    queryFn: () => getCart().then((r) => r.data),
+    enabled: !!user,
+    staleTime: 30000,
+  })
+  const items: any[] = (data as any)?.items ?? []
+  const count = items.length
+
+  return (
+    <button
+      onClick={openCart}
+      className="relative flex items-center gap-1.5 p-2 rounded-lg hover:bg-muted transition-colors"
+      aria-label="Open cart"
+    >
+      <ShoppingCart className="w-5 h-5" />
+      {count > 0 && (
+        <span className="absolute -top-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-primary-foreground">
+          {count}
+        </span>
+      )}
+    </button>
+  )
+}
+
+const POLLING_ENABLED = process.env.NEXT_PUBLIC_ENABLE_NOTIFICATION_POLLING === "true"
+
+function BellIcon({ user }: { user: AuthenticatedUser | null }) {
+  const { data } = useQuery({
+    queryKey: ["booking-notifications-count"],
+    queryFn: () => countBookingNotifications().then((r) => r.data),
+    enabled: !!user,
+    staleTime: 30000,
+    refetchInterval: POLLING_ENABLED ? 60000 : false,
+    refetchIntervalInBackground: false,
+  })
+  const count: number = (data as any)?.count ?? 0
+
+  if (!POLLING_ENABLED || !user || count === 0) return null
+
+  return (
+    <Button variant="outline" size="sm" asChild>
+      <Link href="/account/notifications" aria-label={`${count} unread notifications`}>
+        <span className="text-orange-500 font-bold">{count > 99 ? "99+" : count}</span>
+      </Link>
+    </Button>
+  )
+}
+
+const CATEGORIES = [
+  {
+    name: "Agrochemicals",
+    href: "/buy-agrochemicals",
+    subcategories: [
+      { name: "Shop All Agrochemicals", href: "/buy-agrochemicals" },
+      { name: "Agrochemical Guides", href: "/agrochemical-guides" },
+      { name: "Spray Programs", href: "/spray-programs" },
+    ],
+  },
+  {
+    name: "Animal Health",
+    href: "/buy-animal-health",
+    subcategories: [
+      { name: "Shop All Animal Health", href: "/buy-animal-health" },
+      { name: "Animal Health Guides", href: "/animal-health-guides/all" },
+      { name: "Rearing Programs", href: "/rearing-programs" },
+    ],
+  },
+  {
+    name: "Animal Feed",
+    href: "/buy-feeds",
+    subcategories: [
+      { name: "Shop All Feeds", href: "/buy-feeds" },
+      { name: "Feed Guides", href: "/feed-guides" },
+      { name: "Feeding Programs", href: "/feeding-programs" },
+    ],
+  },
+  {
+    name: "Plant Nutrition",
+    href: "/buy-plant-nutrition",
+    subcategories: [
+      { name: "Shop All Plant Nutrition", href: "/buy-plant-nutrition" },
+      { name: "Plant Nutrition Guides", href: "/plant-nutrition-guides" },
+    ],
+  },
+  {
+    name: "Seeds",
+    href: "/buy-seed-products",
+    subcategories: [
+      { name: "Shop All Seeds", href: "/buy-seed-products" },
+      { name: "Seed Guides", href: "/seed-guides" },
+    ],
+  },
+  {
+    name: "Equipment",
+    href: "/buy-equipment",
+    subcategories: [
+      { name: "Shop All Equipment", href: "/buy-equipment" },
+      { name: "Equipment Guides", href: "/equipment-guides" },
+    ],
+  },
+  {
+    name: "Plans & Documents",
+    href: "/buy-documents",
+    subcategories: [
+      { name: "Shop All Documents", href: "/buy-documents" },
+    ],
+  },
+  {
+    name: "Lots & Auctions",
+    href: "/lots",
+    subcategories: [
+      { name: "Browse Lots", href: "/lots" },
+      { name: "List a Lot", href: "/lots/new" },
+    ],
+  },
+  {
+    name: "Bookings",
+    href: "/bookings",
+    subcategories: [
+      { name: "Browse Bookings", href: "/bookings" },
+    ],
+  },
+  {
+    name: "Market Prices",
+    href: "/prices",
+    subcategories: [
+      { name: "View Prices", href: "/prices" },
+    ],
+  },
+]
+
+function ShopByCategory() {
+  const [open, setOpen] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(0)
+
+  return (
+    <div className="hidden lg:block relative">
+      <Button
+        variant="ghost"
+        size="sm"
+        className="shrink-0 rounded-none text-xs font-medium gap-1"
+        onClick={() => setOpen(!open)}
+      >
+        Select Category
+        <svg
+          className={`h-3 w-3 transition-transform ${open ? "rotate-180" : ""}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth="2"
+          stroke="currentColor"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+        </svg>
+      </Button>
+
+      {open && (
+        <>
+          <div className="fixed inset-0 top-14 z-40" onClick={() => setOpen(false)} />
+          <div className="fixed left-0 right-0 top-14 z-50 bottom-0 border-t bg-background overflow-y-auto">
+            <div className="container flex min-h-[480px]">
+              {/* Left sidebar */}
+              <div className="w-[260px] border-r py-4">
+                <h3 className="px-4 pb-3 text-sm font-bold">All Categories</h3>
+                {CATEGORIES.map((cat, i) => (
+                  <button
+                    key={cat.name}
+                    className={`w-full text-left px-4 py-2 text-sm transition-colors ${
+                      activeIndex === i
+                        ? "bg-muted font-medium text-primary"
+                        : "text-foreground hover:bg-muted/50"
+                    }`}
+                    onClick={() => setActiveIndex(i)}
+                  >
+                    {cat.name}
+                  </button>
+                ))}
+              </div>
+
+              {/* Middle — subcategories */}
+              <div className="flex-1 py-4 px-8">
+                <h3 className="pb-3 text-sm font-bold">{CATEGORIES[activeIndex].name}</h3>
+                <div className="space-y-1">
+                  {CATEGORIES[activeIndex].subcategories.map((sub) => (
+                    <Link
+                      key={sub.name}
+                      href={sub.href}
+                      onClick={() => setOpen(false)}
+                      className="block text-sm text-muted-foreground hover:text-foreground transition-colors py-1"
+                    >
+                      {sub.name}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+
+              {/* Right — promo placeholder */}
+              <div className="w-[280px] p-4">
+                <div className="w-full h-full rounded-md bg-muted/30" />
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
 
 export function SiteHeader() {
   const { data: session } = useSession()
   const user = (session?.user as AuthenticatedUser) ?? undefined
+  const [searchOpen, setSearchOpen] = useState(false)
+
+  // Cmd+K keyboard shortcut
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault()
+        sendGTMEvent({ event: "search_open", method: "keyboard" })
+        setSearchOpen(true)
+      }
+    }
+    document.addEventListener("keydown", handleKeyDown)
+    return () => document.removeEventListener("keydown", handleKeyDown)
+  }, [])
 
   return (
-    <header className="sticky top-0 z-50 w-full border-b bg-background">
-      <div className="container flex h-16 items-center px-4">
-        <MainNav user={user}/>
-        <MobileNav user={user}/>
+    <header className="sticky top-0 z-50 w-full bg-background border-b">
+      {/* Main nav */}
+      <div className="container flex h-14 items-center gap-6">
+        {/* Logo */}
+        <Link href="/" className="shrink-0 font-bold text-lg">
+          {siteConfig.name}
+        </Link>
+
+        {/* Select Category */}
+        <ShopByCategory />
+
+        {/* Search bar — takes remaining space */}
+        <div className="hidden lg:flex flex-1 items-center px-6">
+          <button
+            onClick={() => {
+              sendGTMEvent({ event: "search_open", method: "click" })
+              setSearchOpen(true)
+            }}
+            className="relative w-full rounded-sm bg-zinc-100 p-0.5 text-left"
+          >
+            <div className="flex items-center w-full h-8 pl-3 pr-10 text-sm text-muted-foreground/60">
+              Search for products, guides, programs...
+            </div>
+            <div className="absolute right-12 top-1/2 -translate-y-1/2 hidden sm:flex items-center gap-0.5">
+              <kbd className="h-5 select-none items-center rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground inline-flex">⌘K</kbd>
+            </div>
+            <div className="absolute right-0.5 top-1/2 -translate-y-1/2 h-8 w-9 flex items-center justify-center rounded-sm bg-primary text-primary-foreground">
+              <Search className="h-4 w-4" />
+            </div>
+          </button>
+        </div>
+
+        <SearchModal open={searchOpen} onOpenChange={setSearchOpen} />
+
+        {/* Right side actions */}
+        <div className="hidden lg:flex items-center gap-2">
+          <Link
+            href="/prices"
+            onClick={() => sendGTMEvent({ event: 'nav_click', link_name: 'prices' })}
+            className={buttonVariants({ size: "sm", variant: "ghost" })}
+          >
+            Prices
+          </Link>
+          <Link
+            href={user ? "/lots/new" : "/login?next=/lots/new"}
+            onClick={() => sendGTMEvent({ event: 'nav_click', link_name: 'list_lot' })}
+            className={buttonVariants({ size: "sm" })}
+          >
+            List a Lot
+          </Link>
+          <BellIcon user={user} />
+          {user && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" className="relative h-8 w-8 rounded-full">
+                  <Avatar className="h-8 w-8">
+                    <AvatarFallback>{makeAbbveriation(user.username)}</AvatarFallback>
+                  </Avatar>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent className="w-56" align="end" forceMount>
+                <DropdownMenuLabel className="font-normal">
+                  <p className="text-sm font-medium">{capitalizeFirstLetter(user.username ?? '')}</p>
+                </DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuGroup>
+                  <DropdownMenuItem asChild><Link href="/account">Account</Link></DropdownMenuItem>
+                  <DropdownMenuItem asChild><Link href="/orders">Orders</Link></DropdownMenuItem>
+                </DropdownMenuGroup>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={() => signOut({ redirectTo: AppURL })}>
+                  Logout
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+          <CartIcon user={user} />
+        </div>
+
+        {/* Mobile nav */}
+        <div className="flex-1 lg:hidden" />
+        <button
+          onClick={() => {
+            sendGTMEvent({ event: "search_open", method: "mobile_icon" })
+            setSearchOpen(true)
+          }}
+          className="lg:hidden p-2 rounded-lg hover:bg-muted transition-colors"
+          aria-label="Search"
+        >
+          <Search className="h-5 w-5" />
+        </button>
+        <MobileNav user={user} />
       </div>
     </header>
   )

--- a/apps/client-fnp/components/structures/search-modal.tsx
+++ b/apps/client-fnp/components/structures/search-modal.tsx
@@ -1,0 +1,312 @@
+'use client'
+
+import * as React from "react"
+import { useRouter } from "next/navigation"
+import { sendGTMEvent } from "@next/third-parties/google"
+import { Search, FileText, Leaf, Bug, Pill, Wheat, Tractor, ShoppingBag, Users, DollarSign, CalendarCheck, Gavel } from "lucide-react"
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden"
+import { BaseURL } from "@/lib/schemas"
+
+interface SearchResult {
+  collection: string
+  found: number
+  hits: { document: Record<string, any> }[]
+}
+
+interface SearchResponse {
+  results: SearchResult[]
+}
+
+const COLLECTION_META: Record<string, { label: string; icon: React.ElementType; urlPrefix: string }> = {
+  agro_chemicals: { label: "Agrochemicals", icon: Bug, urlPrefix: "/buy-agrochemicals/" },
+  animal_health: { label: "Animal Health", icon: Pill, urlPrefix: "/buy-animal-health/" },
+  plant_nutrition: { label: "Plant Nutrition", icon: Leaf, urlPrefix: "/buy-plant-nutrition/" },
+  feed_products: { label: "Animal Feed", icon: Wheat, urlPrefix: "/buy-feeds/" },
+  seed_products: { label: "Seeds", icon: Wheat, urlPrefix: "/buy-seed-products/" },
+  equipment: { label: "Equipment", icon: Tractor, urlPrefix: "/buy-equipment/" },
+  guides: { label: "Guides & Programs", icon: FileText, urlPrefix: "" },
+  farm_produce: { label: "Farm Produce", icon: ShoppingBag, urlPrefix: "/farm-produce/" },
+  buyers: { label: "Buyers", icon: Users, urlPrefix: "/buyers/" },
+  prices: { label: "Market Prices", icon: DollarSign, urlPrefix: "/prices" },
+  bookings: { label: "Bookings", icon: CalendarCheck, urlPrefix: "/bookings/" },
+  lots: { label: "Lots & Auctions", icon: Gavel, urlPrefix: "/lots/" },
+}
+
+function getResultUrl(collection: string, doc: Record<string, any>): string {
+  const meta = COLLECTION_META[collection]
+  if (!meta) return "/"
+
+  if (collection === "guides") {
+    const type = doc.type
+    if (type === "spray_program") return `/spray-programs/${doc.slug}`
+    if (type === "feeding_program") return `/feeding-programs/${doc.slug}`
+    return `/buy-documents/${doc.slug}`
+  }
+
+  if (collection === "prices") return "/prices"
+  if (collection === "buyers") return `/buyers/${doc.slug}`
+
+  return `${meta.urlPrefix}${doc.slug}`
+}
+
+function getDisplayName(collection: string, doc: Record<string, any>): string {
+  if (collection === "prices") return doc.client_name || "Price Sheet"
+  if (collection === "lots") return doc.farm_produce_name || "Lot"
+  if (collection === "bookings") return doc.name || "Booking"
+  return doc.name || ""
+}
+
+function getStatusPill(collection: string, doc: Record<string, any>): { label: string; className: string } | null {
+  if (collection === "lots") {
+    const expired = doc.expires_at && doc.expires_at * 1000 < Date.now()
+    if (doc.has_accepted_bid) return { label: "Sold", className: "bg-blue-100 text-blue-700" }
+    if (expired) return { label: "Expired", className: "bg-zinc-100 text-zinc-500" }
+    return { label: "Open", className: "bg-green-100 text-green-700" }
+  }
+  if (collection === "bookings") {
+    if (doc.status === "open") return { label: "Open", className: "bg-green-100 text-green-700" }
+    if (doc.status === "closed") return { label: "Closed", className: "bg-zinc-100 text-zinc-500" }
+    return { label: doc.status, className: "bg-zinc-100 text-zinc-500" }
+  }
+  return null
+}
+
+function getDisplaySub(collection: string, doc: Record<string, any>): string {
+  if (collection === "prices") {
+    const commodities = doc.commodities?.join(", ") || ""
+    const date = doc.effective_date ? new Date(doc.effective_date * 1000).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" }) : ""
+    return [commodities, date].filter(Boolean).join(" · ")
+  }
+  if (collection === "lots") {
+    const qty = doc.quantity && doc.unit ? `${doc.quantity} ${doc.unit}` : ""
+    const price = doc.price_per_unit_cents ? `$${(doc.price_per_unit_cents / 100).toFixed(2)}/${doc.unit || "unit"}` : ""
+    const location = [doc.city, doc.province].filter(Boolean).join(", ")
+    return [doc.breed_name, qty, price, location].filter(Boolean).join(" · ")
+  }
+  if (collection === "buyers") {
+    return [doc.city, doc.province].filter(Boolean).join(", ")
+  }
+  if (collection === "farm_produce") {
+    return doc.category_name || ""
+  }
+  const parts = [doc.brand_name, doc.category_name].filter(Boolean)
+  return parts.join(" · ")
+}
+
+export function SearchModal({ open, onOpenChange }: { open: boolean; onOpenChange: (open: boolean) => void }) {
+  const router = useRouter()
+  const [query, setQuery] = React.useState("")
+  const [results, setResults] = React.useState<SearchResult[]>([])
+  const [loading, setLoading] = React.useState(false)
+  const [activeIndex, setActiveIndex] = React.useState(0)
+  const inputRef = React.useRef<HTMLInputElement>(null)
+
+  // Flatten results for keyboard navigation
+  const flatItems = React.useMemo(() => {
+    const items: { collection: string; doc: Record<string, any> }[] = []
+    for (const group of results) {
+      for (const hit of group.hits) {
+        items.push({ collection: group.collection, doc: hit.document })
+      }
+    }
+    return items
+  }, [results])
+
+  // Debounced search
+  React.useEffect(() => {
+    if (!query.trim()) {
+      setResults([])
+      return
+    }
+
+    const timeout = setTimeout(async () => {
+      setLoading(true)
+      try {
+        const res = await fetch(`${BaseURL}/search?q=${encodeURIComponent(query.trim())}`)
+        if (res.ok) {
+          const data: SearchResponse = await res.json()
+          setResults(data.results)
+          setActiveIndex(0)
+          const totalFound = data.results.reduce((sum, r) => sum + r.found, 0)
+          sendGTMEvent({
+            event: "search",
+            search_term: query.trim(),
+            search_results_count: totalFound,
+          })
+        }
+      } catch {
+        // silent fail
+      } finally {
+        setLoading(false)
+      }
+    }, 200)
+
+    return () => clearTimeout(timeout)
+  }, [query])
+
+  // Reset on close
+  React.useEffect(() => {
+    if (!open) {
+      setQuery("")
+      setResults([])
+      setActiveIndex(0)
+    }
+  }, [open])
+
+  function navigate(index: number) {
+    const item = flatItems[index]
+    if (!item) return
+    const url = getResultUrl(item.collection, item.doc)
+    sendGTMEvent({
+      event: "search_result_click",
+      search_term: query,
+      result_collection: item.collection,
+      result_name: item.doc.name,
+      result_position: index + 1,
+    })
+    onOpenChange(false)
+    router.push(url)
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault()
+      setActiveIndex((i) => Math.min(i + 1, flatItems.length - 1))
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault()
+      setActiveIndex((i) => Math.max(i - 1, 0))
+    } else if (e.key === "Enter") {
+      e.preventDefault()
+      navigate(activeIndex)
+    }
+  }
+
+  let flatIndex = -1
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="overflow-hidden p-0 max-w-[640px] top-[20%] translate-y-0 gap-0">
+        <VisuallyHidden><DialogTitle>Search</DialogTitle></VisuallyHidden>
+        {/* Search input */}
+        <div className="flex items-center border-b px-4">
+          <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Search products, guides, buyers, prices..."
+            className="flex h-12 w-full bg-transparent px-3 text-sm outline-none placeholder:text-muted-foreground"
+            autoFocus
+          />
+          {query && (
+            <kbd className="hidden sm:inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
+              ESC
+            </kbd>
+          )}
+        </div>
+
+        {/* Results */}
+        <div className="max-h-[400px] overflow-y-auto p-2">
+          {!query.trim() && (
+            <div className="py-12 text-center text-sm text-muted-foreground">
+              Start typing to search across all products, guides, and buyers
+            </div>
+          )}
+
+          {query.trim() && !loading && results.length === 0 && (
+            <div className="py-12 text-center text-sm text-muted-foreground">
+              No results for &ldquo;{query}&rdquo;
+            </div>
+          )}
+
+          {loading && results.length === 0 && (
+            <div className="py-12 text-center text-sm text-muted-foreground">
+              Searching...
+            </div>
+          )}
+
+          {results.map((group) => {
+            const meta = COLLECTION_META[group.collection]
+            if (!meta) return null
+            const Icon = meta.icon
+
+            return (
+              <div key={group.collection} className="mb-2">
+                <div className="flex items-center gap-2 px-2 py-1.5">
+                  <Icon className="h-3.5 w-3.5 text-muted-foreground" />
+                  <span className="text-xs font-medium text-muted-foreground">{meta.label}</span>
+                  <span className="text-xs text-muted-foreground/60">({group.found})</span>
+                </div>
+                {group.hits.map((hit) => {
+                  flatIndex++
+                  const idx = flatIndex
+                  const doc = hit.document
+                  const isActive = idx === activeIndex
+
+                  return (
+                    <button
+                      key={doc.id}
+                      className={`w-full flex items-center gap-3 rounded-md px-3 py-2 text-left text-sm transition-colors ${
+                        isActive ? "bg-accent text-accent-foreground" : "hover:bg-muted/50"
+                      }`}
+                      onClick={() => navigate(idx)}
+                      onMouseEnter={() => setActiveIndex(idx)}
+                    >
+                      {doc.image_src ? (
+                        <img src={doc.image_src} alt="" className="h-8 w-8 rounded object-cover shrink-0" />
+                      ) : (
+                        <div className="h-8 w-8 rounded bg-muted/30 shrink-0" />
+                      )}
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2">
+                          <p className="font-medium truncate capitalize">{getDisplayName(group.collection, doc)}</p>
+                          {(() => {
+                            const pill = getStatusPill(group.collection, doc)
+                            if (!pill) return null
+                            return <span className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium ${pill.className}`}>{pill.label}</span>
+                          })()}
+                        </div>
+                        <p className="text-xs text-muted-foreground truncate">{getDisplaySub(group.collection, doc)}</p>
+                      </div>
+                    </button>
+                  )
+                })}
+              </div>
+            )
+          })}
+        </div>
+
+        {/* Footer */}
+        {flatItems.length > 0 && (
+          <div className="flex items-center justify-between border-t px-4 py-2 text-xs text-muted-foreground">
+            <span>{flatItems.length} results</span>
+            <div className="flex items-center gap-2">
+              <span>↑↓ navigate</span>
+              <span>↵ open</span>
+              <span>esc close</span>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export function useSearchModal() {
+  const [open, setOpen] = React.useState(false)
+
+  React.useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault()
+        setOpen(true)
+      }
+    }
+    document.addEventListener("keydown", handleKeyDown)
+    return () => document.removeEventListener("keydown", handleKeyDown)
+  }, [])
+
+  return { open, setOpen }
+}


### PR DESCRIPTION
## Summary
- Search modal with instant federated results grouped by collection
- Cmd+K / Ctrl+K keyboard shortcut + mobile search icon
- Keyboard navigation (arrows, enter, escape)
- GTM events: `search_open`, `search`, `search_result_click`
- Status pills for lots and bookings
- Collection-specific display formatting

## Test Plan
- [x] Search modal opens on click, Cmd+K, and mobile icon
- [x] Results grouped by collection with correct icons
- [x] Prices show buyer name + commodities + date
- [x] Lots show produce name + breed + quantity + price + status pill
- [x] Keyboard navigation works
- [ ] Verify GTM events fire in GA4