### PR TITLE
Fix CI workflow for frontend builds

### DIFF
--- a/.github/workflows/build-client.yml
+++ b/.github/workflows/build-client.yml
@@ -3,7 +3,7 @@ name: Build & Push client-fnp
 on:
   push:
     tags:
-      - 'v*'
+      - '*.*.*'
 
 jobs:
   build:
@@ -35,7 +35,8 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: apps/client-fnp
+          context: .
+          file: apps/client-fnp/Dockerfile
           platforms: linux/arm64
           push: true
           tags: |


### PR DESCRIPTION
## Summary
- Match plain semver tags (6.1.0) instead of v-prefixed tags
- Fix build context to repo root with explicit Dockerfile path

## Test plan
- [ ] Next tag push triggers GitHub Actions build