### PR TITLE
SEO improvements for prices, guides, and listing pages

### DIFF
--- a/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/[slug]/page.tsx
@@ -42,7 +42,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     'View dosage rates, label information, and application guidelines on farmnport.com.',
   ].filter(Boolean).join('. ')
 
-  return buildGuideMetadata(chemical, categorySingularTitle, 'Dosage, Label & Guide', description, `/agrochemical-guides/${category}/${slug}`, chemical.images?.[0]?.img?.src)
+  const keywords = `${chemical.name.toLowerCase()}, ${categorySingular} zimbabwe, ${ingredients ? ingredients.toLowerCase() + ', ' : ''}${crops ? crops.toLowerCase() + ', ' : ''}agrochemical guide zimbabwe, ${category} dosage rates`
+
+  return buildGuideMetadata(chemical, categorySingularTitle, 'Dosage, Label & Guide', description, `/agrochemical-guides/${category}/${slug}`, chemical.images?.[0]?.img?.src, keywords)
 }
 
 interface GuidePageProps {
@@ -104,6 +106,17 @@ export default async function AgroChemicalGuidePage({ params }: GuidePageProps) 
         ? `Dosage rates available for ${chemical.dosage_rates.map((r: any) => r.crop).join(', ')}`
         : undefined
 
+    const breadcrumbJsonLd = {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://farmnport.com" },
+            { "@type": "ListItem", "position": 2, "name": "Agrochemical Guides", "item": "https://farmnport.com/agrochemical-guides" },
+            { "@type": "ListItem", "position": 3, "name": chemical.agrochemical_category?.name || category, "item": `https://farmnport.com/agrochemical-guides/${category}` },
+            { "@type": "ListItem", "position": 4, "name": chemical.name, "item": `https://farmnport.com/agrochemical-guides/${category}/${slug}` },
+        ],
+    }
+
     const structuredData = {
         "@context": "https://schema.org",
         "@type": "Product",
@@ -131,6 +144,7 @@ export default async function AgroChemicalGuidePage({ params }: GuidePageProps) 
     return (
         <div className="min-h-screen bg-background">
             {/* JSON-LD Structured Data */}
+            <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
             <script
                 type="application/ld+json"
                 dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}

--- a/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/page.tsx
+++ b/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/page.tsx
@@ -25,10 +25,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title: `${name} Zimbabwe – Products, Dosage Rates & Labels | farmnport.com`,
     description,
+    keywords: `${name.toLowerCase()} zimbabwe, ${name.toLowerCase()} products, ${name.toLowerCase()} dosage rates, agrochemical guides zimbabwe, crop protection ${name.toLowerCase()}`,
     alternates: { canonical: `/agrochemical-guides/${category}` },
     openGraph: {
       title: `${name} Zimbabwe – Agrochemical Guides`,
       description: `Browse ${name.toLowerCase()} products for Zimbabwe farmers. Compare active ingredients, dosage rates, and application guidelines.`,
+      url: `https://farmnport.com/agrochemical-guides/${category}`,
       siteName: 'farmnport',
       type: 'website',
     },
@@ -60,8 +62,19 @@ export default async function AgroChemicalCategoryPage({ params }: CategoryPageP
         .map((word: string) => word.charAt(0).toUpperCase() + word.slice(1))
         .join(' ')
 
+    const breadcrumbJsonLd = {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://farmnport.com" },
+            { "@type": "ListItem", "position": 2, "name": "Agrochemical Guides", "item": "https://farmnport.com/agrochemical-guides" },
+            { "@type": "ListItem", "position": 3, "name": categoryName, "item": `https://farmnport.com/agrochemical-guides/${category}` },
+        ],
+    }
+
     return (
         <div className="min-h-screen bg-gradient-to-b from-background to-muted/20">
+            <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
             {/* Breadcrumb */}
             <div className="border-b">
                 <div className="max-w-7xl mx-auto px-6 lg:px-8 py-3">

--- a/apps/client-fnp/app/(landing)/agrochemical-guides/page.tsx
+++ b/apps/client-fnp/app/(landing)/agrochemical-guides/page.tsx
@@ -5,10 +5,12 @@ import { serverFetch } from "@/lib/serverFetch"
 export const metadata = {
   title: 'Agrochemical Guides Zimbabwe – Herbicides, Fungicides, Insecticides & More | farmnport.com',
   description: 'Browse agrochemical product guides for Zimbabwe farmers. Herbicides, fungicides, insecticides, acaricides, and fertilizers — active ingredients, dosage rates, and application guidelines.',
+  keywords: 'agrochemical guides zimbabwe, herbicides zimbabwe, fungicides zimbabwe, insecticides zimbabwe, crop protection products, agrochemical dosage rates, pesticides zimbabwe',
   alternates: { canonical: '/agrochemical-guides' },
   openGraph: {
     title: 'Agrochemical Guides Zimbabwe',
     description: 'Browse agrochemical product guides for Zimbabwe farmers. Herbicides, fungicides, insecticides, acaricides — dosage rates and application guidelines.',
+    url: 'https://farmnport.com/agrochemical-guides',
     siteName: 'farmnport',
     type: 'website',
   },
@@ -20,8 +22,19 @@ export default async function AgrochemicalGuidesPage() {
     const initialChemicals = chemicalsRes?.data || []
     const initialTotal = chemicalsRes?.total || 0
 
+    const breadcrumbJsonLd = {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://farmnport.com" },
+            { "@type": "ListItem", "position": 2, "name": "Guides", "item": "https://farmnport.com/guides" },
+            { "@type": "ListItem", "position": 3, "name": "Agrochemical Guides", "item": "https://farmnport.com/agrochemical-guides" },
+        ],
+    }
+
     return (
         <main className="bg-gradient-to-b from-background to-muted/20">
+            <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
             {/* Products Section */}
             <section className="py-6 lg:py-8 bg-muted/30">
                 <div className="mx-auto max-w-7xl px-6 lg:px-8">

--- a/apps/client-fnp/app/(landing)/animal-health-guides/[category]/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/animal-health-guides/[category]/[slug]/page.tsx
@@ -37,7 +37,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     'View dosage rates and usage guidelines on farmnport.com.',
   ].filter(Boolean).join('. ')
 
-  return buildGuideMetadata(product, categorySingularTitle, 'Dosage & Guide', description, `/animal-health-guides/${category}/${slug}`, product.images?.[0]?.img?.src)
+  const keywords = `${product.name.toLowerCase()}, ${categorySingular} zimbabwe, ${ingredients ? ingredients.toLowerCase() + ', ' : ''}${usedOn ? usedOn.toLowerCase() + ', ' : ''}animal health guide zimbabwe, veterinary ${category}`
+
+  return buildGuideMetadata(product, categorySingularTitle, 'Dosage & Guide', description, `/animal-health-guides/${category}/${slug}`, product.images?.[0]?.img?.src, keywords)
 }
 
 interface GuidePageProps {
@@ -104,6 +106,17 @@ export default async function AnimalHealthGuidePage({ params }: GuidePageProps) 
     const usageInfo = product.dosage_rates?.length > 0
         ? `Dosage rates available for ${product.dosage_rates.map((r: any) => r.animal).join(', ')}`
         : undefined
+
+    const breadcrumbJsonLd = {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://farmnport.com" },
+            { "@type": "ListItem", "position": 2, "name": "Animal Health Guides", "item": "https://farmnport.com/animal-health-guides" },
+            { "@type": "ListItem", "position": 3, "name": product.animal_health_category?.name || category, "item": `https://farmnport.com/animal-health-guides/${category}` },
+            { "@type": "ListItem", "position": 4, "name": product.name, "item": `https://farmnport.com/animal-health-guides/${category}/${slug}` },
+        ],
+    }
 
     const structuredData = {
         "@context": "https://schema.org",
@@ -237,6 +250,7 @@ export default async function AnimalHealthGuidePage({ params }: GuidePageProps) 
     return (
         <div className="min-h-screen bg-background">
             {/* JSON-LD Structured Data */}
+            <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
             <script
                 type="application/ld+json"
                 dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}

--- a/apps/client-fnp/app/(landing)/animal-health-guides/[category]/page.tsx
+++ b/apps/client-fnp/app/(landing)/animal-health-guides/[category]/page.tsx
@@ -11,10 +11,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title: `${name} Zimbabwe – Animal Health Products & Guides | farmnport.com`,
     description: `Browse ${name.toLowerCase()} products for poultry and livestock in Zimbabwe. Compare dosage rates, active ingredients, and usage guidelines.`,
+    keywords: `${name.toLowerCase()} zimbabwe, ${name.toLowerCase()} products, animal health ${name.toLowerCase()}, veterinary ${name.toLowerCase()} zimbabwe, poultry ${name.toLowerCase()}`,
     alternates: { canonical: `/animal-health-guides/${category}` },
     openGraph: {
       title: `${name} Zimbabwe – Animal Health Guides`,
       description: `Browse ${name.toLowerCase()} products for poultry and livestock in Zimbabwe. Compare dosage rates and usage guidelines.`,
+      url: `https://farmnport.com/animal-health-guides/${category}`,
       siteName: 'farmnport',
       type: 'website',
     },
@@ -48,8 +50,19 @@ export default async function AnimalHealthCategoryPage({ params }: CategoryPageP
 
     const categoryName = products[0]?.animal_health_category?.name || category
 
+    const breadcrumbJsonLd = {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://farmnport.com" },
+            { "@type": "ListItem", "position": 2, "name": "Animal Health Guides", "item": "https://farmnport.com/animal-health-guides" },
+            { "@type": "ListItem", "position": 3, "name": categoryName, "item": `https://farmnport.com/animal-health-guides/${category}` },
+        ],
+    }
+
     return (
         <div className="min-h-screen bg-gradient-to-b from-background to-muted/20">
+            <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
             {/* Breadcrumb */}
             <div className="border-b">
                 <div className="max-w-7xl mx-auto px-6 lg:px-8 py-3">

--- a/apps/client-fnp/app/(landing)/animal-health-guides/page.tsx
+++ b/apps/client-fnp/app/(landing)/animal-health-guides/page.tsx
@@ -5,10 +5,12 @@ import { AllAnimalHealthClient } from "./AllAnimalHealthClient"
 export const metadata = {
   title: 'Animal Health Product Guides Zimbabwe – Vaccines, Antibiotics & Supplements | farmnport.com',
   description: 'Browse animal health product guides for poultry and livestock in Zimbabwe. Vaccines, antibiotics, nutrition supplements, anti-protozoals, and biosecurity disinfectants — dosage rates and usage guidelines.',
+  keywords: 'animal health products zimbabwe, poultry vaccines zimbabwe, livestock antibiotics, veterinary products zimbabwe, animal health guides, poultry supplements zimbabwe',
   alternates: { canonical: '/animal-health-guides' },
   openGraph: {
     title: 'Animal Health Product Guides Zimbabwe',
     description: 'Browse animal health product guides for poultry and livestock in Zimbabwe. Vaccines, antibiotics, supplements — dosage rates and usage guidelines.',
+    url: 'https://farmnport.com/animal-health-guides',
     siteName: 'farmnport',
     type: 'website',
   },
@@ -32,8 +34,19 @@ async function getAllProducts() {
 export default async function AnimalHealthGuidesPage() {
     const { data: products, total } = await getAllProducts()
 
+    const breadcrumbJsonLd = {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://farmnport.com" },
+            { "@type": "ListItem", "position": 2, "name": "Guides", "item": "https://farmnport.com/guides" },
+            { "@type": "ListItem", "position": 3, "name": "Animal Health Guides", "item": "https://farmnport.com/animal-health-guides" },
+        ],
+    }
+
     return (
         <main className="bg-gradient-to-b from-background to-muted/20">
+            <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
             <section className="py-6 lg:py-8 bg-muted/30">
                 <div className="mx-auto max-w-7xl px-6 lg:px-8">
                     <nav className="flex text-sm text-muted-foreground mb-6">

--- a/apps/client-fnp/app/(landing)/bookings/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/bookings/[slug]/page.tsx
@@ -82,6 +82,7 @@ export default async function PreOrderDetailPage({ params }: Props) {
             "availability": preorder.status === "active" ? "https://schema.org/InStock" : "https://schema.org/SoldOut",
             "itemCondition": "https://schema.org/NewCondition",
             "priceValidUntil": new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
+            "validFrom": new Date().toISOString().split('T')[0],
             "seller": { "@type": "Organization", "name": "farmnport" },
         },
     }

--- a/apps/client-fnp/app/(landing)/buy-agrochemicals/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/buy-agrochemicals/[slug]/page.tsx
@@ -49,6 +49,7 @@ export default async function BuyAgroChemicalPage({ params }: BuyAgroChemicalPag
             "availability": chemical.available_for_sale ? "https://schema.org/InStock" : "https://schema.org/OutOfStock",
             "itemCondition": "https://schema.org/NewCondition",
             "priceValidUntil": new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
+            "validFrom": new Date().toISOString().split('T')[0],
             "seller": { "@type": "Organization", "name": "farmnport" }
         }
     }

--- a/apps/client-fnp/app/(landing)/buy-animal-health/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/buy-animal-health/[slug]/page.tsx
@@ -49,6 +49,7 @@ export default async function BuyAnimalHealthProductPage({ params }: BuyAnimalHe
             "availability": product.available_for_sale ? "https://schema.org/InStock" : "https://schema.org/OutOfStock",
             "itemCondition": "https://schema.org/NewCondition",
             "priceValidUntil": new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
+            "validFrom": new Date().toISOString().split('T')[0],
             "seller": { "@type": "Organization", "name": "farmnport" }
         }
     }

--- a/apps/client-fnp/app/(landing)/buy-documents/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/buy-documents/[slug]/page.tsx
@@ -96,6 +96,7 @@ export default async function BuyDocumentDetailPage({ params }: Props) {
             "seller": { "@type": "Organization", "name": "farmnport" },
             "itemCondition": "https://schema.org/NewCondition",
             "priceValidUntil": new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
+            "validFrom": new Date().toISOString().split('T')[0],
         },
         "additionalProperty": [
             { "@type": "PropertyValue", "name": "File Type", "value": doc.file_type?.toUpperCase() || "PDF" },
@@ -103,8 +104,20 @@ export default async function BuyDocumentDetailPage({ params }: Props) {
         ],
     }
 
+    const breadcrumbJsonLd = {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://farmnport.com" },
+            { "@type": "ListItem", "position": 2, "name": "Buy", "item": "https://farmnport.com/buy" },
+            { "@type": "ListItem", "position": 3, "name": "Documents", "item": "https://farmnport.com/buy-documents" },
+            { "@type": "ListItem", "position": 4, "name": doc.title, "item": `https://farmnport.com/buy-documents/${slug}` },
+        ],
+    }
+
     return (
         <div className="min-h-screen bg-background">
+            <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
             <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }} />
             <div className="border-b">
                 <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">

--- a/apps/client-fnp/app/(landing)/buy-equipment/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/buy-equipment/[slug]/page.tsx
@@ -46,6 +46,7 @@ export default async function BuyEquipmentProductPage({ params }: BuyEquipmentPr
             "availability": product.available_for_sale ? "https://schema.org/InStock" : "https://schema.org/OutOfStock",
             "itemCondition": "https://schema.org/NewCondition",
             "priceValidUntil": new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
+            "validFrom": new Date().toISOString().split('T')[0],
             "seller": { "@type": "Organization", "name": "farmnport" }
         }
     } : null

--- a/apps/client-fnp/app/(landing)/buy-feeds/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/buy-feeds/[slug]/page.tsx
@@ -61,6 +61,7 @@ export default async function BuyFeedPage({ params }: BuyFeedPageProps) {
             "availability": product.available_for_sale ? "https://schema.org/InStock" : "https://schema.org/OutOfStock",
             "itemCondition": "https://schema.org/NewCondition",
             "priceValidUntil": new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
+            "validFrom": new Date().toISOString().split('T')[0],
             "seller": { "@type": "Organization", "name": "farmnport" }
         }
     }

--- a/apps/client-fnp/app/(landing)/buy-plant-nutrition/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/buy-plant-nutrition/[slug]/page.tsx
@@ -48,6 +48,7 @@ export default async function BuyPlantNutritionProductPage({ params }: BuyPlantN
             "availability": product.available_for_sale ? "https://schema.org/InStock" : "https://schema.org/OutOfStock",
             "itemCondition": "https://schema.org/NewCondition",
             "priceValidUntil": new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
+            "validFrom": new Date().toISOString().split('T')[0],
             "seller": { "@type": "Organization", "name": "farmnport" }
         }
     }

--- a/apps/client-fnp/app/(landing)/buy-seed-products/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/buy-seed-products/[slug]/page.tsx
@@ -51,6 +51,7 @@ export default async function BuySeedProductPage({ params }: Props) {
             "availability": product.available_for_sale ? "https://schema.org/InStock" : "https://schema.org/OutOfStock",
             "itemCondition": "https://schema.org/NewCondition",
             "priceValidUntil": new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
+            "validFrom": new Date().toISOString().split('T')[0],
             "seller": { "@type": "Organization", "name": "farmnport" }
         }
     }

--- a/apps/client-fnp/app/(landing)/buyers/[product]/page.tsx
+++ b/apps/client-fnp/app/(landing)/buyers/[product]/page.tsx
@@ -25,6 +25,14 @@ export async function generateMetadata({ params }: Props,  parent: ResolvingMeta
     },
     title: `${name} Buyers in Zimbabwe | farmnport.com`,
     description,
+    keywords: `${name.toLowerCase()} buyers zimbabwe, sell ${product.toLowerCase()} zimbabwe, ${product.toLowerCase()} market zimbabwe, ${product.toLowerCase()} buyers, where to sell ${product.toLowerCase()} zimbabwe`,
+    openGraph: {
+      title: `${name} Buyers in Zimbabwe | farmnport.com`,
+      description,
+      url: `https://farmnport.com/buyers/${product.toLowerCase()}`,
+      siteName: 'farmnport',
+      type: 'website',
+    },
   }
 }
 
@@ -37,8 +45,19 @@ export default async function BuyersProductPage({ params }: BuyerProductPageProp
   const user = await retrieveUser()
   const { product } = await params
 
+  const breadcrumbJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://farmnport.com" },
+      { "@type": "ListItem", "position": 2, "name": "Buyers", "item": "https://farmnport.com/buyers" },
+      { "@type": "ListItem", "position": 3, "name": `${capitalizeFirstLetter(plural(product))} Buyers`, "item": `https://farmnport.com/buyers/${product}` },
+    ],
+  }
+
   return (
     <main>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
       <div className="container pt-6">
         <nav className="flex items-center gap-1.5 text-xs text-muted-foreground mb-4">
           <Link href="/" className="hover:text-foreground transition-colors">Home</Link>

--- a/apps/client-fnp/app/(landing)/documents/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/documents/[slug]/page.tsx
@@ -70,6 +70,7 @@ export default async function DocumentGuidePage({ params }: Props) {
             "price": (doc.price_cents / 100).toFixed(2),
             "priceCurrency": "USD",
             "availability": "https://schema.org/InStock",
+            "validFrom": new Date().toISOString().split('T')[0],
         } : undefined,
     }
 

--- a/apps/client-fnp/app/(landing)/farmers/[product]/page.tsx
+++ b/apps/client-fnp/app/(landing)/farmers/[product]/page.tsx
@@ -24,6 +24,14 @@ export async function generateMetadata({ params }: Props,  parent: ResolvingMeta
     },
     title: `${name} Farmers in Zimbabwe | farmnport.com`,
     description,
+    keywords: `${name.toLowerCase()} farmers zimbabwe, ${product.toLowerCase()} farmers, ${product.toLowerCase()} suppliers zimbabwe, buy ${product.toLowerCase()} zimbabwe, ${product.toLowerCase()} producers`,
+    openGraph: {
+      title: `${name} Farmers in Zimbabwe | farmnport.com`,
+      description,
+      url: `https://farmnport.com/farmers/${product.toLowerCase()}`,
+      siteName: 'farmnport',
+      type: 'website',
+    },
   }
 }
 
@@ -36,8 +44,19 @@ export default async function FarmersProductPage({ params }: FarmerProductPagePr
   const user = await retrieveUser()
   const { product } = await params
 
+  const breadcrumbJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://farmnport.com" },
+      { "@type": "ListItem", "position": 2, "name": "Farmers", "item": "https://farmnport.com/farmers" },
+      { "@type": "ListItem", "position": 3, "name": `${capitalizeFirstLetter(plural(product))} Farmers`, "item": `https://farmnport.com/farmers/${product}` },
+    ],
+  }
+
   return (
     <main>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
       <div className="container pt-6">
         <nav className="flex items-center gap-1.5 text-xs text-muted-foreground mb-4">
           <Link href="/" className="hover:text-foreground transition-colors">Home</Link>

--- a/apps/client-fnp/app/(landing)/feed-guides/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/feed-guides/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next"
 import Image from "next/image"
 import { AlertTriangle } from "lucide-react"
 import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
@@ -9,9 +10,42 @@ import { WantToBuyCTA } from "@/components/shared/WantToBuyCTA"
 import { GuideProductTitle } from "@/components/shared/GuideProductTitle"
 import { ShareBar } from "@/components/shared/ShareBar"
 import { SidebarPromo } from "@/components/ads/SidebarPromo"
+import { capitalizeFirstLetter } from "@/lib/utilities"
 
 interface FeedDetailPageProps {
     params: Promise<{ slug: string }>
+}
+
+export async function generateMetadata({ params }: FeedDetailPageProps): Promise<Metadata> {
+    const { slug } = await params
+    let product: any = null
+    try {
+        const res = await fetch(`${BaseURL}/feed/${slug}`, { cache: "no-store" })
+        if (res.ok) product = await res.json()
+    } catch {}
+
+    if (!product) {
+        return { title: 'Feed Guide | farmnport.com', robots: { index: false } }
+    }
+
+    const name = product.name || capitalizeFirstLetter(slug.replace(/-/g, ' '))
+    const brand = product.brand?.name ? ` by ${product.brand.name}` : ''
+    const animal = product.animal ? ` for ${product.animal}` : ''
+    const description = `${name}${brand} — ${product.phase || 'livestock'} feed guide${animal}. View nutritional specs, feeding instructions, and mixing recommendations.`
+
+    return {
+        title: `${name} — Feed Guide Zimbabwe | farmnport.com`,
+        description,
+        keywords: `${name.toLowerCase()}, ${product.animal?.toLowerCase() || 'livestock'} feed zimbabwe, ${product.phase?.toLowerCase() || ''} feed, feed guide zimbabwe, ${slug}`.replace(/, ,/g, ','),
+        alternates: { canonical: `/feed-guides/${slug}` },
+        openGraph: {
+            title: `${name} — Feed Guide Zimbabwe`,
+            description,
+            url: `https://farmnport.com/feed-guides/${slug}`,
+            siteName: "farmnport",
+            type: "website",
+        },
+    }
 }
 
 const fetchOptions: RequestInit = { cache: "no-store" }
@@ -40,6 +74,16 @@ export default async function FeedDetailPage({ params }: FeedDetailPageProps) {
     const url = `${baseUrl}/feeds/${slug}`
     const imageUrl = product.images?.[0]?.img?.src || `${baseUrl}/default-feed.png`
 
+    const breadcrumbJsonLd = {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://farmnport.com" },
+            { "@type": "ListItem", "position": 2, "name": "Feed Guides", "item": "https://farmnport.com/feed-guides" },
+            { "@type": "ListItem", "position": 3, "name": product.name, "item": `https://farmnport.com/feed-guides/${slug}` },
+        ],
+    }
+
     const structuredData = {
         "@context": "https://schema.org",
         "@type": "Product",
@@ -58,6 +102,7 @@ export default async function FeedDetailPage({ params }: FeedDetailPageProps) {
 
     return (
         <div className="min-h-screen bg-background">
+            <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
             <script
                 type="application/ld+json"
                 dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}

--- a/apps/client-fnp/app/(landing)/feed-guides/page.tsx
+++ b/apps/client-fnp/app/(landing)/feed-guides/page.tsx
@@ -1,6 +1,21 @@
 import Link from "next/link"
+import type { Metadata } from "next"
 import { BaseURL } from "@/lib/schemas"
 import { FeedListingClient } from "./FeedListingClient"
+
+export const metadata: Metadata = {
+    title: "Livestock Feed Guides Zimbabwe — Animal Feed Products & Nutrition | farmnport.com",
+    description: "Browse livestock feed product guides for Zimbabwe farmers. Compare poultry, cattle, pig, and goat feeds — nutritional specs, feeding instructions, and brands.",
+    keywords: "livestock feed zimbabwe, animal feed products, poultry feed zimbabwe, cattle feed, pig feed, broiler feed guide, layer feed guide, stock feed zimbabwe",
+    alternates: { canonical: "/feed-guides" },
+    openGraph: {
+        title: "Livestock Feed Guides Zimbabwe — Animal Feed Products & Nutrition",
+        description: "Browse livestock feed product guides for Zimbabwe farmers. Compare feeds by animal type, phase, and nutritional specs.",
+        url: "https://farmnport.com/feed-guides",
+        siteName: "farmnport",
+        type: "website",
+    },
+}
 
 const fetchOptions: RequestInit = process.env.NODE_ENV === "production"
     ? { next: { revalidate: 3600 } } as RequestInit
@@ -20,8 +35,19 @@ async function getFeedProducts() {
 export default async function FeedProductsPage() {
     const { data, total } = await getFeedProducts()
 
+    const breadcrumbJsonLd = {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://farmnport.com" },
+            { "@type": "ListItem", "position": 2, "name": "Guides", "item": "https://farmnport.com/guides" },
+            { "@type": "ListItem", "position": 3, "name": "Feed Guides", "item": "https://farmnport.com/feed-guides" },
+        ],
+    }
+
     return (
         <main>
+            <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
             <div className="mx-auto max-w-7xl px-6 lg:px-8 min-h-[70lvh]">
                 <div className="pt-10 pb-6">
                     <nav className="flex text-sm text-muted-foreground mb-4">

--- a/apps/client-fnp/app/(landing)/feeding-programs/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/feeding-programs/[slug]/page.tsx
@@ -1,9 +1,36 @@
+import type { Metadata } from "next"
 import { serverFetch } from "@/lib/serverFetch"
 import { notFound } from "next/navigation"
+import { capitalizeFirstLetter } from "@/lib/utilities"
 import { FeedingProgramDetailClient } from "./FeedingProgramDetailClient"
 
 interface FeedingProgramDetailPageProps {
     params: Promise<{ slug: string }>
+}
+
+export async function generateMetadata({ params }: FeedingProgramDetailPageProps): Promise<Metadata> {
+    const { slug } = await params
+    let program: any = null
+    try {
+        program = await serverFetch(`/feedingprograms/${slug}`)
+    } catch {}
+
+    const name = program?.name || program?.farm_produce_name || capitalizeFirstLetter(slug.replace(/-/g, ' '))
+    const description = `${name} feeding program for Zimbabwe farmers. View feed formulations, schedules, and nutritional targets for optimal livestock performance.`
+
+    return {
+        title: `${name} Feeding Program Zimbabwe | farmnport.com`,
+        description,
+        keywords: `${name.toLowerCase()} feeding program, ${name.toLowerCase()} feed schedule zimbabwe, livestock nutrition ${name.toLowerCase()}, ${slug} feed plan`,
+        alternates: { canonical: `/feeding-programs/${slug}` },
+        openGraph: {
+            title: `${name} Feeding Program Zimbabwe`,
+            description,
+            url: `https://farmnport.com/feeding-programs/${slug}`,
+            siteName: "farmnport",
+            type: "website",
+        },
+    }
 }
 
 export default async function FeedingProgramDetailPage({ params }: FeedingProgramDetailPageProps) {
@@ -21,5 +48,22 @@ export default async function FeedingProgramDetailPage({ params }: FeedingProgra
         notFound()
     }
 
-    return <FeedingProgramDetailClient program={program} slug={slug} />
+    const programName = program.name || program.farm_produce_name || capitalizeFirstLetter(slug.replace(/-/g, ' '))
+
+    const breadcrumbJsonLd = {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://farmnport.com" },
+            { "@type": "ListItem", "position": 2, "name": "Feeding Programs", "item": "https://farmnport.com/feeding-programs" },
+            { "@type": "ListItem", "position": 3, "name": programName, "item": `https://farmnport.com/feeding-programs/${slug}` },
+        ],
+    }
+
+    return (
+        <>
+            <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+            <FeedingProgramDetailClient program={program} slug={slug} />
+        </>
+    )
 }

--- a/apps/client-fnp/app/(landing)/feeding-programs/page.tsx
+++ b/apps/client-fnp/app/(landing)/feeding-programs/page.tsx
@@ -6,7 +6,15 @@ import { capitalizeFirstLetter } from "@/lib/utilities"
 export const metadata = {
     title: "Feeding Programs Zimbabwe — Livestock Nutrition Schedules | farmnport.com",
     description: "Browse structured feeding programs for livestock in Zimbabwe — formulations, schedules, and nutritional targets by animal type.",
-    alternates: { canonical: "https://farmnport.com/feeding-programs" },
+    keywords: "feeding programs zimbabwe, livestock feed schedule, poultry feeding program, cattle feeding program zimbabwe, broiler feed schedule, pig feeding plan",
+    alternates: { canonical: "/feeding-programs" },
+    openGraph: {
+        title: "Feeding Programs Zimbabwe — Livestock Nutrition Schedules",
+        description: "Browse structured feeding programs for livestock in Zimbabwe — formulations, schedules, and nutritional targets by animal type.",
+        url: "https://farmnport.com/feeding-programs",
+        siteName: "farmnport",
+        type: "website",
+    },
 }
 
 function getAnimalGroup(farmProduceName: string): string {
@@ -45,8 +53,19 @@ export default async function FeedingProgramsPage() {
         programs: items,
     }))
 
+    const breadcrumbJsonLd = {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://farmnport.com" },
+            { "@type": "ListItem", "position": 2, "name": "Programs", "item": "https://farmnport.com/programs" },
+            { "@type": "ListItem", "position": 3, "name": "Feeding Programs", "item": "https://farmnport.com/feeding-programs" },
+        ],
+    }
+
     return (
         <div className="min-h-screen">
+            <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
             <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-6">
                 <nav className="flex items-center gap-1.5 text-xs text-muted-foreground mb-6">
                     <Link href="/" className="hover:text-foreground transition-colors">Home</Link>

--- a/apps/client-fnp/app/(landing)/lots/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/lots/[slug]/page.tsx
@@ -85,6 +85,7 @@ export default async function LotDetailPage({ params }: Props) {
             "availability": isExpired ? "https://schema.org/SoldOut" : "https://schema.org/InStock",
             "itemCondition": "https://schema.org/NewCondition",
             "priceValidUntil": lot.expires_at || new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
+            "validFrom": new Date().toISOString().split('T')[0],
             "seller": { "@type": "Organization", "name": "farmnport" },
         },
     }

--- a/apps/client-fnp/app/(landing)/plant-nutrition-guides/[category]/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/plant-nutrition-guides/[category]/[slug]/page.tsx
@@ -39,7 +39,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     'View application rates and usage guidelines on farmnport.com.',
   ].filter(Boolean).join('. ')
 
-  return buildGuideMetadata(product, categorySingularTitle, 'Application Rates & Guide', description, `/plant-nutrition-guides/${category}/${slug}`, product.images?.[0]?.img?.src)
+  const keywords = `${product.name.toLowerCase()}, ${categorySingular} zimbabwe, ${ingredients ? ingredients.toLowerCase() + ', ' : ''}${crops ? crops.toLowerCase() + ', ' : ''}plant nutrition guide zimbabwe, ${category} application rates`
+
+  return buildGuideMetadata(product, categorySingularTitle, 'Application Rates & Guide', description, `/plant-nutrition-guides/${category}/${slug}`, product.images?.[0]?.img?.src, keywords)
 }
 
 interface GuidePageProps {
@@ -96,6 +98,17 @@ export default async function PlantNutritionGuidePage({ params }: GuidePageProps
         ? `${product.name} is a ${product.plant_nutrition_category.name}. View active ingredients and application rates.`
         : `Plant nutrition guide for ${product.name}. Complete information on active ingredients and application rates.`
 
+    const breadcrumbJsonLd = {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://farmnport.com" },
+            { "@type": "ListItem", "position": 2, "name": "Plant Nutrition Guides", "item": "https://farmnport.com/plant-nutrition-guides" },
+            { "@type": "ListItem", "position": 3, "name": product.plant_nutrition_category?.name || category, "item": `https://farmnport.com/plant-nutrition-guides/${categorySlug}` },
+            { "@type": "ListItem", "position": 4, "name": product.name, "item": `https://farmnport.com/plant-nutrition-guides/${category}/${slug}` },
+        ],
+    }
+
     const structuredData = {
         "@context": "https://schema.org",
         "@type": "Product",
@@ -114,6 +127,7 @@ export default async function PlantNutritionGuidePage({ params }: GuidePageProps
 
     return (
         <div className="min-h-screen bg-background">
+            <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
             <script
                 type="application/ld+json"
                 dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}

--- a/apps/client-fnp/app/(landing)/plant-nutrition-guides/[category]/page.tsx
+++ b/apps/client-fnp/app/(landing)/plant-nutrition-guides/[category]/page.tsx
@@ -11,10 +11,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title: `${name} Zimbabwe – Application Rates & Product Guides | farmnport.com`,
     description: `Browse ${name.toLowerCase()} products for Zimbabwe crops. Compare application rates, active ingredients, and usage guidelines for better crop nutrition.`,
+    keywords: `${name.toLowerCase()} zimbabwe, ${name.toLowerCase()} products, plant nutrition ${name.toLowerCase()}, crop nutrition zimbabwe, ${name.toLowerCase()} application rates`,
     alternates: { canonical: `/plant-nutrition-guides/${category}` },
     openGraph: {
       title: `${name} Zimbabwe – Plant Nutrition Guides`,
       description: `Browse ${name.toLowerCase()} products for Zimbabwe crops. Compare application rates and usage guidelines.`,
+      url: `https://farmnport.com/plant-nutrition-guides/${category}`,
       siteName: 'farmnport',
       type: 'website',
     },
@@ -46,8 +48,19 @@ export default async function PlantNutritionCategoryPage({ params }: CategoryPag
 
     const categoryName = products[0]?.plant_nutrition_category?.name || category.replace(/-/g, ' ')
 
+    const breadcrumbJsonLd = {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://farmnport.com" },
+            { "@type": "ListItem", "position": 2, "name": "Plant Nutrition Guides", "item": "https://farmnport.com/plant-nutrition-guides" },
+            { "@type": "ListItem", "position": 3, "name": categoryName, "item": `https://farmnport.com/plant-nutrition-guides/${category}` },
+        ],
+    }
+
     return (
         <main className="bg-gradient-to-b from-background to-muted/20">
+            <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
             <section className="py-6 lg:py-8 bg-muted/30">
                 <div className="mx-auto max-w-7xl px-6 lg:px-8">
                     <nav className="flex text-sm text-muted-foreground mb-6">

--- a/apps/client-fnp/app/(landing)/plant-nutrition-guides/page.tsx
+++ b/apps/client-fnp/app/(landing)/plant-nutrition-guides/page.tsx
@@ -5,10 +5,12 @@ import { serverFetch } from "@/lib/serverFetch"
 export const metadata = {
   title: 'Plant Nutrition Guides Zimbabwe – Fertilizers, Foliar Feeds & Biostimulants | farmnport.com',
   description: 'Browse plant nutrition product guides for Zimbabwe farmers. Fertilizers, foliar feeds, biostimulants — application rates, active ingredients, and usage guidelines for better crop nutrition.',
+  keywords: 'plant nutrition zimbabwe, fertilizers zimbabwe, foliar feeds zimbabwe, biostimulants, crop nutrition products, application rates zimbabwe, plant growth regulators',
   alternates: { canonical: '/plant-nutrition-guides' },
   openGraph: {
     title: 'Plant Nutrition Guides Zimbabwe',
     description: 'Browse plant nutrition product guides for Zimbabwe farmers. Fertilizers, foliar feeds, biostimulants — application rates and usage guidelines.',
+    url: 'https://farmnport.com/plant-nutrition-guides',
     siteName: 'farmnport',
     type: 'website',
   },
@@ -20,8 +22,19 @@ export default async function PlantNutritionGuidesPage() {
     const initialProducts = productsRes?.data || []
     const initialTotal = productsRes?.total || 0
 
+    const breadcrumbJsonLd = {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://farmnport.com" },
+            { "@type": "ListItem", "position": 2, "name": "Guides", "item": "https://farmnport.com/guides" },
+            { "@type": "ListItem", "position": 3, "name": "Plant Nutrition Guides", "item": "https://farmnport.com/plant-nutrition-guides" },
+        ],
+    }
+
     return (
         <main className="bg-gradient-to-b from-background to-muted/20">
+            <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
             <section className="py-6 lg:py-8 bg-muted/30">
                 <div className="mx-auto max-w-7xl px-6 lg:px-8">
                     <nav className="flex text-sm text-muted-foreground mb-6">

--- a/apps/client-fnp/app/(landing)/prices/[produce]/[category]/page.tsx
+++ b/apps/client-fnp/app/(landing)/prices/[produce]/[category]/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link"
 import { BuyerProducePriceHistory } from "@/components/structures/buyer-produce-price-history"
 import type { Metadata } from "next"
 import { capitalizeFirstLetter } from "@/lib/utilities"
@@ -25,14 +26,16 @@ export async function generateMetadata({ params }: SheetCategoryPageProps): Prom
   const description = dateLabel
     ? `${clientName} ${categoryName.toLowerCase()} livestock prices in Zimbabwe as of ${dateLabel}. View grade-by-grade pricing including liveweight and per-head rates on farmnport.com.`
     : `${clientName} ${categoryName.toLowerCase()} livestock price history in Zimbabwe. Browse all upload dates and grade-by-grade pricing on farmnport.com.`
+  const keywords = `${clientName.toLowerCase()} ${categoryName.toLowerCase()} prices, ${categoryName.toLowerCase()} prices zimbabwe, ${clientName.toLowerCase()} livestock prices`
   return {
     title,
     description,
+    keywords,
     alternates: { canonical: `/prices/${sheet}/${category}` },
     openGraph: {
       title,
       description,
-      url: `/prices/${sheet}/${category}`,
+      url: `https://farmnport.com/prices/${sheet}/${category}`,
       siteName: "farmnport",
       type: "website",
     },
@@ -42,13 +45,36 @@ export async function generateMetadata({ params }: SheetCategoryPageProps): Prom
 export default async function BuyerCategoryPage({ params }: SheetCategoryPageProps) {
   const { produce: sheet, category } = await params
   const { clientSlug, clientName, effectiveDate } = parseSheetSlug(sheet)
+  const categoryName = capitalizeFirstLetter(category)
+
+  const breadcrumbJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://farmnport.com" },
+      { "@type": "ListItem", "position": 2, "name": "Prices", "item": "https://farmnport.com/prices" },
+      { "@type": "ListItem", "position": 3, "name": `${clientName} ${categoryName}`, "item": `https://farmnport.com/prices/${sheet}/${category}` },
+    ],
+  }
 
   return (
-    <BuyerProducePriceHistory
-      clientSlug={clientSlug}
-      clientName={clientName}
-      produce={category}
-      effectiveDate={effectiveDate}
-    />
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+      <div className="mx-auto max-w-7xl px-6 lg:px-8 pt-4">
+        <nav className="flex items-center gap-1.5 text-xs text-muted-foreground mb-4">
+          <Link href="/" className="hover:text-foreground transition-colors">Home</Link>
+          <span>/</span>
+          <Link href="/prices" className="hover:text-foreground transition-colors">Prices</Link>
+          <span>/</span>
+          <span className="text-foreground font-medium">{clientName} {categoryName}</span>
+        </nav>
+      </div>
+      <BuyerProducePriceHistory
+        clientSlug={clientSlug}
+        clientName={clientName}
+        produce={category}
+        effectiveDate={effectiveDate}
+      />
+    </>
   )
 }

--- a/apps/client-fnp/app/(landing)/prices/[produce]/page.tsx
+++ b/apps/client-fnp/app/(landing)/prices/[produce]/page.tsx
@@ -8,41 +8,28 @@ interface ProducePageProps {
   searchParams: Promise<{ code?: string; type?: string }>
 }
 
-const CODE_NAMES: Record<string, string> = {
-  bull: "Bull",
-  cow: "Cow",
-  heifer: "Heifer",
-  steer: "Steer",
-  ox: "Ox",
-  weaners: "Weaners",
-  tollies: "Tollies",
-  sheep: "Sheep",
-  ewe: "Ewe",
-  ram: "Ram",
-  boar: "Boar",
-  sow: "Sow",
-  porker: "Porker",
-  baconer: "Baconer",
-  boran: "Boran",
-  brahman: "Brahman",
-  tuli: "Tuli",
-  nkone: "Nkone",
-  simbra: "Simbra",
-  simmental: "Simmental",
-  mashona: "Mashona",
-  bonsmara: "Bonsmara",
-  angus: "Angus",
-  sussex: "Sussex",
-  hereford: "Hereford",
-  crossbreed: "Crossbreed",
-  communal: "Communal",
-  dairy: "Dairy",
-}
+const BASE = process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3744"
 
 const TYPE_NAMES: Record<string, string> = {
   lwt: "Liveweight",
   cdm: "Cold Dress Mass",
   ph: "Per Head",
+}
+
+async function getGradeName(produce: string, code: string): Promise<string> {
+  try {
+    const res = await fetch(`${BASE}/v1/prices/series/summary`, { next: { revalidate: 3600 } })
+    if (!res.ok) return capitalizeFirstLetter(code)
+    const data = await res.json()
+    const series = data?.data ?? []
+    const match = series.find((s: any) =>
+      s.code?.toLowerCase() === code.toLowerCase() &&
+      s.category?.toLowerCase() === produce.toLowerCase()
+    )
+    return match?.name ?? capitalizeFirstLetter(code)
+  } catch {
+    return capitalizeFirstLetter(code)
+  }
 }
 
 const PRODUCE_SEO: Record<string, { keywords: string; description: string }> = {
@@ -86,7 +73,7 @@ export async function generateMetadata({ params, searchParams }: ProducePageProp
   const produceName = capitalizeFirstLetter(produce.replace(/-/g, ' '))
   const seo = PRODUCE_SEO[produce.toLowerCase()]
 
-  const codeName = code ? CODE_NAMES[code.toLowerCase()] ?? capitalizeFirstLetter(code) : ""
+  const codeName = code ? await getGradeName(produce, code) : ""
   const typeName = type ? TYPE_NAMES[type.toLowerCase()] ?? "" : ""
 
   // Build SEO strings based on whether code/type filters are active

--- a/apps/client-fnp/app/(landing)/prices/[produce]/page.tsx
+++ b/apps/client-fnp/app/(landing)/prices/[produce]/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link"
 import { ProduceBoardRouter } from "@/components/structures/produce-board-router"
 import type { Metadata } from "next"
 import { capitalizeFirstLetter } from "@/lib/utilities"
@@ -7,17 +8,116 @@ interface ProducePageProps {
   searchParams: Promise<{ code?: string; type?: string }>
 }
 
-export async function generateMetadata({ params }: ProducePageProps): Promise<Metadata> {
+const CODE_NAMES: Record<string, string> = {
+  bull: "Bull",
+  cow: "Cow",
+  heifer: "Heifer",
+  steer: "Steer",
+  ox: "Ox",
+  weaners: "Weaners",
+  tollies: "Tollies",
+  sheep: "Sheep",
+  ewe: "Ewe",
+  ram: "Ram",
+  boar: "Boar",
+  sow: "Sow",
+  porker: "Porker",
+  baconer: "Baconer",
+  boran: "Boran",
+  brahman: "Brahman",
+  tuli: "Tuli",
+  nkone: "Nkone",
+  simbra: "Simbra",
+  simmental: "Simmental",
+  mashona: "Mashona",
+  bonsmara: "Bonsmara",
+  angus: "Angus",
+  sussex: "Sussex",
+  hereford: "Hereford",
+  crossbreed: "Crossbreed",
+  communal: "Communal",
+  dairy: "Dairy",
+}
+
+const TYPE_NAMES: Record<string, string> = {
+  lwt: "Liveweight",
+  cdm: "Cold Dress Mass",
+  ph: "Per Head",
+}
+
+const PRODUCE_SEO: Record<string, { keywords: string; description: string }> = {
+  beef: {
+    keywords: "beef prices zimbabwe, cold dress mass beef, beef market rates, beef per kg zimbabwe, beef grades zimbabwe",
+    description: "Current beef prices in Zimbabwe from verified buyers. Compare cold dress mass rates by grade — super, choice, commercial, manufacturing. Updated weekly in USD.",
+  },
+  cattle: {
+    keywords: "cattle prices zimbabwe, liveweight cattle prices, cattle market rates, cattle per kg zimbabwe, livestock prices",
+    description: "Current liveweight cattle prices in Zimbabwe from verified buyers. Compare rates by grade and weight category across all major buyers. Updated weekly in USD.",
+  },
+  chicken: {
+    keywords: "chicken prices zimbabwe, broiler prices, chicken market rates, poultry prices zimbabwe, chicken per kg",
+    description: "Current chicken and broiler prices in Zimbabwe from verified buyers. Compare live bird and dressed prices by weight category. Updated weekly in USD.",
+  },
+  pork: {
+    keywords: "pork prices zimbabwe, pig prices, pork market rates, pork per kg zimbabwe, pig carcass prices",
+    description: "Current pork and pig prices in Zimbabwe from verified buyers. Compare cold dress mass rates by grade. Updated weekly in USD.",
+  },
+  goat: {
+    keywords: "goat prices zimbabwe, goat meat prices, goat market rates, chevon prices zimbabwe, goat per kg",
+    description: "Current goat prices in Zimbabwe from verified buyers. Compare liveweight and cold dress mass rates. Updated weekly in USD.",
+  },
+  mutton: {
+    keywords: "mutton prices zimbabwe, sheep prices, lamb prices zimbabwe, mutton market rates, mutton per kg",
+    description: "Current mutton and lamb prices in Zimbabwe from verified buyers. Compare cold dress mass rates by grade. Updated weekly in USD.",
+  },
+  lamb: {
+    keywords: "lamb prices zimbabwe, lamb market rates, lamb per kg zimbabwe, sheep prices, lamb cold dress mass",
+    description: "Current lamb prices in Zimbabwe from verified buyers. Compare cold dress mass and liveweight rates by grade. Updated weekly in USD.",
+  },
+  sheep: {
+    keywords: "sheep prices zimbabwe, sheep market rates, ewe prices, ram prices zimbabwe, sheep per head",
+    description: "Current sheep prices in Zimbabwe from verified buyers. Compare ewe, ram, and lamb prices by weight and grade. Updated weekly in USD.",
+  },
+}
+
+export async function generateMetadata({ params, searchParams }: ProducePageProps): Promise<Metadata> {
   const { produce } = await params
+  const { code, type } = await searchParams
   const produceName = capitalizeFirstLetter(produce.replace(/-/g, ' '))
+  const seo = PRODUCE_SEO[produce.toLowerCase()]
+
+  const codeName = code ? CODE_NAMES[code.toLowerCase()] ?? capitalizeFirstLetter(code) : ""
+  const typeName = type ? TYPE_NAMES[type.toLowerCase()] ?? "" : ""
+
+  // Build SEO strings based on whether code/type filters are active
+  const hasFilters = codeName || typeName
+  const filterLabel = [codeName, typeName].filter(Boolean).join(" ")
+
+  const title = hasFilters
+    ? `${filterLabel} ${produceName} Prices Zimbabwe | farmnport.com`
+    : `${produceName} Prices Zimbabwe – Current Market Rates | farmnport.com`
+
+  const description = hasFilters
+    ? `Current ${filterLabel.toLowerCase()} ${produceName.toLowerCase()} prices in Zimbabwe from verified buyers. Compare rates by grade updated weekly in USD on farmnport.com.`
+    : seo?.description ?? `Compare current ${produceName.toLowerCase()} prices from verified buyers across Zimbabwe. Grade-by-grade pricing updated weekly in USD on farmnport.com.`
+
+  const filterKeywords = hasFilters
+    ? `${filterLabel.toLowerCase()} ${produceName.toLowerCase()} prices zimbabwe, ${filterLabel.toLowerCase()} prices, ${codeName.toLowerCase()} prices zimbabwe`
+    : ""
+  const keywords = [
+    filterKeywords,
+    seo?.keywords ?? `${produceName.toLowerCase()} prices zimbabwe, ${produceName.toLowerCase()} market rates, ${produceName.toLowerCase()} per kg zimbabwe`,
+  ].filter(Boolean).join(", ")
+
   return {
-    title: `${produceName} Prices Zimbabwe – Current Market Rates | farmnport.com`,
-    description: `Browse current ${produceName.toLowerCase()} prices from buyers across Zimbabwe.`,
+    title,
+    description,
+    keywords,
     alternates: { canonical: `/prices/${produce}` },
     openGraph: {
-      title: `${produceName} Prices Zimbabwe – Current Market Rates`,
-      description: `Browse current ${produceName.toLowerCase()} prices from buyers across Zimbabwe.`,
-      url: `/prices/${produce}`,
+      title,
+      description,
+      url: `https://farmnport.com/prices/${produce}`,
       siteName: 'farmnport',
       type: 'website',
     },
@@ -27,10 +127,46 @@ export async function generateMetadata({ params }: ProducePageProps): Promise<Me
 export default async function ProducePricePage({ params, searchParams }: ProducePageProps) {
   const { produce } = await params
   const { code, type } = await searchParams
+  const produceName = capitalizeFirstLetter(produce.replace(/-/g, ' '))
+
+  const breadcrumbJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://farmnport.com" },
+      { "@type": "ListItem", "position": 2, "name": "Prices", "item": "https://farmnport.com/prices" },
+      { "@type": "ListItem", "position": 3, "name": `${produceName} Prices`, "item": `https://farmnport.com/prices/${produce}` },
+    ],
+  }
+
+  const webPageJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": `${produceName} Prices Zimbabwe`,
+    "description": PRODUCE_SEO[produce.toLowerCase()]?.description ?? `Compare current ${produceName.toLowerCase()} prices from verified buyers across Zimbabwe.`,
+    "url": `https://farmnport.com/prices/${produce}`,
+    "isPartOf": { "@type": "WebSite", "name": "farmnport", "url": "https://farmnport.com" },
+    "about": {
+      "@type": "Product",
+      "name": produceName,
+      "category": "Agricultural Commodities",
+    },
+  }
 
   return (
     <>
-      <h1 className="sr-only">{capitalizeFirstLetter(produce)} Prices Zimbabwe</h1>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(webPageJsonLd) }} />
+      <div className="mx-auto max-w-7xl px-6 lg:px-8 pt-4">
+        <nav className="flex items-center gap-1.5 text-xs text-muted-foreground mb-4">
+          <Link href="/" className="hover:text-foreground transition-colors">Home</Link>
+          <span>/</span>
+          <Link href="/prices" className="hover:text-foreground transition-colors">Prices</Link>
+          <span>/</span>
+          <span className="text-foreground font-medium">{produceName}</span>
+        </nav>
+      </div>
+      <h1 className="sr-only">{produceName} Prices Zimbabwe – Current Market Rates</h1>
       <ProduceBoardRouter produce={produce} code={code ?? ""} priceType={type ?? ""} />
     </>
   )

--- a/apps/client-fnp/app/(landing)/prices/head/page.tsx
+++ b/apps/client-fnp/app/(landing)/prices/head/page.tsx
@@ -1,24 +1,55 @@
+import Link from "next/link"
 import { PricesHeadBoard } from "@/components/structures/prices-head-board"
 import type { Metadata } from "next"
 
 export const metadata: Metadata = {
   title: "Livestock Prices Per Head Zimbabwe – Breed Cattle Market Rates | farmnport.com",
-  description: "Current per-head prices for Boran, Brahman, Simbra, Tuli, Heifer, Steer and more from verified buyers across Zimbabwe. Updated weekly.",
-  keywords: "livestock prices per head zimbabwe, boran cattle price, brahman price, simbra price, tuli cattle, heifer price, steer price, breed cattle zimbabwe",
+  description: "Current per-head prices for Boran, Brahman, Simbra, Tuli, Nkone, Heifer, Steer and more from verified buyers across Zimbabwe. Compare breed cattle prices updated weekly in USD.",
+  keywords: "livestock prices per head zimbabwe, boran cattle price, brahman price, simbra price, tuli cattle price, nkone cattle price, heifer price, steer price, breed cattle zimbabwe, cattle prices per head",
   alternates: { canonical: "/prices/head" },
   openGraph: {
-    title: "Livestock Prices Per Head Zimbabwe",
-    description: "Current per-head prices for Boran, Brahman, Simbra, Tuli and more from verified buyers across Zimbabwe.",
-    url: "/prices/head",
+    title: "Livestock Prices Per Head Zimbabwe – Breed Cattle Market Rates",
+    description: "Current per-head prices for Boran, Brahman, Simbra, Tuli, Nkone and more from verified buyers across Zimbabwe. Updated weekly.",
+    url: "https://farmnport.com/prices/head",
     siteName: "farmnport",
     type: "website",
   },
 }
 
 export default function PricesHeadPage() {
+  const breadcrumbJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://farmnport.com" },
+      { "@type": "ListItem", "position": 2, "name": "Prices", "item": "https://farmnport.com/prices" },
+      { "@type": "ListItem", "position": 3, "name": "Per Head Prices", "item": "https://farmnport.com/prices/head" },
+    ],
+  }
+
+  const webPageJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Livestock Prices Per Head Zimbabwe",
+    "description": "Current per-head prices for Boran, Brahman, Simbra, Tuli, Nkone, Heifer, Steer and more from verified buyers across Zimbabwe.",
+    "url": "https://farmnport.com/prices/head",
+    "isPartOf": { "@type": "WebSite", "name": "farmnport", "url": "https://farmnport.com" },
+  }
+
   return (
     <>
-      <h1 className="sr-only">Livestock Prices Per Head Zimbabwe</h1>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(webPageJsonLd) }} />
+      <div className="mx-auto max-w-7xl px-6 lg:px-8 pt-4">
+        <nav className="flex items-center gap-1.5 text-xs text-muted-foreground mb-4">
+          <Link href="/" className="hover:text-foreground transition-colors">Home</Link>
+          <span>/</span>
+          <Link href="/prices" className="hover:text-foreground transition-colors">Prices</Link>
+          <span>/</span>
+          <span className="text-foreground font-medium">Per Head</span>
+        </nav>
+      </div>
+      <h1 className="sr-only">Livestock Prices Per Head Zimbabwe – Breed Cattle Market Rates</h1>
       <PricesHeadBoard />
     </>
   )

--- a/apps/client-fnp/app/(landing)/prices/page.tsx
+++ b/apps/client-fnp/app/(landing)/prices/page.tsx
@@ -4,11 +4,12 @@ import { PricesBoard } from "@/components/structures/prices-board"
 export const metadata = {
   title: 'Agricultural Market Prices Zimbabwe – Livestock, Produce & More | farmnport.com',
   description: 'Compare current agricultural prices from verified buyers across Zimbabwe. Liveweight cattle, cold dress mass, beef, lamb, mutton, goat, chicken, pork — updated weekly in USD and ZiG.',
+  keywords: 'agricultural prices zimbabwe, livestock prices, cattle prices zimbabwe, beef prices, chicken prices, pork prices, goat prices, mutton prices, farm produce prices, market rates zimbabwe',
   alternates: { canonical: '/prices' },
   openGraph: {
-    title: 'Agricultural Market Prices Zimbabwe',
-    description: 'Compare current agricultural prices from verified buyers across Zimbabwe.',
-    url: '/prices',
+    title: 'Agricultural Market Prices Zimbabwe – Livestock, Produce & More',
+    description: 'Compare current agricultural prices from verified buyers across Zimbabwe. Liveweight cattle, cold dress mass, beef, lamb, mutton, goat, chicken, pork — updated weekly.',
+    url: 'https://farmnport.com/prices',
     siteName: 'farmnport',
     type: 'website',
   },

--- a/apps/client-fnp/app/(landing)/spray-programs/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/spray-programs/[slug]/page.tsx
@@ -1,9 +1,36 @@
+import type { Metadata } from "next"
 import { serverFetch } from "@/lib/serverFetch"
 import { notFound } from "next/navigation"
+import { capitalizeFirstLetter } from "@/lib/utilities"
 import { SprayProgramDetailClient } from "./SprayProgramDetailClient"
 
 interface SprayProgramDetailPageProps {
     params: Promise<{ slug: string }>
+}
+
+export async function generateMetadata({ params }: SprayProgramDetailPageProps): Promise<Metadata> {
+    const { slug } = await params
+    let program: any = null
+    try {
+        program = await serverFetch(`/sprayprograms/${slug}`)
+    } catch {}
+
+    const name = program?.name || capitalizeFirstLetter(slug.replace(/-/g, ' '))
+    const description = `${name} spray program for Zimbabwe crops. View application timings, recommended agrochemicals, and dosage rates for each growth stage.`
+
+    return {
+        title: `${name} Spray Program Zimbabwe | farmnport.com`,
+        description,
+        keywords: `${name.toLowerCase()} spray program, ${name.toLowerCase()} crop protection, spray schedule zimbabwe, ${slug} agrochemical program`,
+        alternates: { canonical: `/spray-programs/${slug}` },
+        openGraph: {
+            title: `${name} Spray Program Zimbabwe`,
+            description,
+            url: `https://farmnport.com/spray-programs/${slug}`,
+            siteName: "farmnport",
+            type: "website",
+        },
+    }
 }
 
 export default async function SprayProgramDetailPage({ params }: SprayProgramDetailPageProps) {
@@ -21,5 +48,20 @@ export default async function SprayProgramDetailPage({ params }: SprayProgramDet
         notFound()
     }
 
-    return <SprayProgramDetailClient program={program} slug={slug} />
+    const breadcrumbJsonLd = {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://farmnport.com" },
+            { "@type": "ListItem", "position": 2, "name": "Spray Programs", "item": "https://farmnport.com/spray-programs" },
+            { "@type": "ListItem", "position": 3, "name": program.name || capitalizeFirstLetter(slug.replace(/-/g, ' ')), "item": `https://farmnport.com/spray-programs/${slug}` },
+        ],
+    }
+
+    return (
+        <>
+            <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+            <SprayProgramDetailClient program={program} slug={slug} />
+        </>
+    )
 }

--- a/apps/client-fnp/app/(landing)/spray-programs/page.tsx
+++ b/apps/client-fnp/app/(landing)/spray-programs/page.tsx
@@ -1,6 +1,21 @@
 import Link from "next/link"
+import type { Metadata } from "next"
 import { serverFetch } from "@/lib/serverFetch"
 import { SprayProgramsClient } from "./SprayProgramsClient"
+
+export const metadata: Metadata = {
+    title: "Spray Programs Zimbabwe — Crop Protection Schedules | farmnport.com",
+    description: "Browse spray program schedules for Zimbabwe crops. Step-by-step agrochemical application timings for every growth stage, from planting to harvest.",
+    keywords: "spray programs zimbabwe, crop protection schedule, agrochemical spray program, crop spraying schedule zimbabwe, pest control program, fungicide spray schedule",
+    alternates: { canonical: "/spray-programs" },
+    openGraph: {
+        title: "Spray Programs Zimbabwe — Crop Protection Schedules",
+        description: "Browse spray program schedules for Zimbabwe crops. Step-by-step agrochemical application timings for every growth stage.",
+        url: "https://farmnport.com/spray-programs",
+        siteName: "farmnport",
+        type: "website",
+    },
+}
 
 export default async function SprayProgramsPage() {
     let programs: any[] = []
@@ -12,8 +27,19 @@ export default async function SprayProgramsPage() {
         console.error("Error fetching spray programs:", error)
     }
 
+    const breadcrumbJsonLd = {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://farmnport.com" },
+            { "@type": "ListItem", "position": 2, "name": "Programs", "item": "https://farmnport.com/programs" },
+            { "@type": "ListItem", "position": 3, "name": "Spray Programs", "item": "https://farmnport.com/spray-programs" },
+        ],
+    }
+
     return (
         <main>
+            <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
             {/* Header */}
             <section className="border-b">
                 <div className="mx-auto max-w-7xl px-6 lg:px-8 pt-10 pb-8">

--- a/apps/client-fnp/app/(resources)/buyer/[slug]/page.tsx
+++ b/apps/client-fnp/app/(resources)/buyer/[slug]/page.tsx
@@ -23,10 +23,11 @@ export async function generateMetadata({ params }: Props,  parent: ResolvingMeta
     },
     title: `${name} - Buyer in Zimbabwe | farmnport.com`,
     description: `${name} is an agricultural buyer in Zimbabwe. View what produce they purchase, payment terms, pricing, and contact details on farmnport.com. Sell your farm products directly to ${name} in Zimbabwe.`,
+    keywords: `${name.toLowerCase()}, ${name.toLowerCase()} buyer zimbabwe, sell to ${name.toLowerCase()}, agricultural buyer zimbabwe, farm produce buyer`,
     openGraph: {
       title: `${name} - Buyer in Zimbabwe`,
       description: `${name} is an agricultural buyer in Zimbabwe. See what produce they purchase, payment terms, and pricing. Sell directly to ${name} on farmnport.com.`,
-      url: `${AppURL}/buyer/${slug.toLowerCase()}`,
+      url: `https://farmnport.com/buyer/${slug.toLowerCase()}`,
       siteName: 'farmnport',
       type: 'profile',
     },
@@ -44,8 +45,19 @@ type BuyerPageProps ={
     const name = unSlug(slug)
     const latestPrices = await fetchLatestBuyerPrices(slug)
 
+    const breadcrumbJsonLd = {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://farmnport.com" },
+        { "@type": "ListItem", "position": 2, "name": "Buyers", "item": "https://farmnport.com/buyers" },
+        { "@type": "ListItem", "position": 3, "name": name, "item": `https://farmnport.com/buyer/${slug}` },
+      ],
+    }
+
     return(
     <main className="min-h-[70lvh]">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
       <h1 className="sr-only">{name} - Buyer in Zimbabwe</h1>
       <Client slug={slug} type="buyer" user={user} latestPrices={latestPrices}/>
     </main>

--- a/apps/client-fnp/app/(resources)/farmer/[slug]/page.tsx
+++ b/apps/client-fnp/app/(resources)/farmer/[slug]/page.tsx
@@ -22,10 +22,11 @@ export async function generateMetadata({ params }: Props,  parent: ResolvingMeta
     },
     title: `${name} - Farmer in Zimbabwe | farmnport.com`,
     description: `${name} is a farmer in Zimbabwe. View their farm profile, available produce, farming operations, and contact details on farmnport.com. Connect directly with ${name} to buy agricultural products in Zimbabwe.`,
+    keywords: `${name.toLowerCase()}, ${name.toLowerCase()} farmer zimbabwe, buy from ${name.toLowerCase()}, zimbabwe farmer, farm produce supplier`,
     openGraph: {
       title: `${name} - Farmer in Zimbabwe`,
       description: `${name} is a farmer in Zimbabwe. View their farm profile, available produce, and contact details. Connect directly with ${name} on farmnport.com.`,
-      url: `${AppURL}/farmer/${slug.toLowerCase()}`,
+      url: `https://farmnport.com/farmer/${slug.toLowerCase()}`,
       siteName: 'farmnport',
       type: 'profile',
     },
@@ -43,8 +44,19 @@ export default async function BuyerPage({ params }:  BuyerPageProps) {
 
   const name = unSlug(slug)
 
+  const breadcrumbJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://farmnport.com" },
+      { "@type": "ListItem", "position": 2, "name": "Farmers", "item": "https://farmnport.com/farmers" },
+      { "@type": "ListItem", "position": 3, "name": name, "item": `https://farmnport.com/farmer/${slug}` },
+    ],
+  }
+
   return(
     <main className="min-h-[70lvh]">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
       <h1 className="sr-only">{name} - Farmer in Zimbabwe</h1>
       <Client slug={slug} type="farmer" user={user}/>
     </main>

--- a/apps/client-fnp/app/sitemap.ts
+++ b/apps/client-fnp/app/sitemap.ts
@@ -49,6 +49,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     feedingPrograms,
     sprayPrograms,
     clients,
+    seriesSummary,
   ] = await Promise.all([
     fetchFarmProduce(),
     fetchAgroChemicalCategories(),
@@ -59,6 +60,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     fetchFeedingPrograms(),
     fetchSprayPrograms(),
     fetchClients(),
+    fetchSeriesSummary(),
   ])
 
   // Farm produce → /buyers/{slug} and /farmers/{slug}
@@ -94,14 +96,26 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.7,
   }))
 
-  // Produce price category routes
-  const producePriceCategories = ['beef', 'lamb', 'mutton', 'goat', 'chicken', 'pork']
-  const producePriceRoutes: MetadataRoute.Sitemap = producePriceCategories.map((slug) => ({
-    url: `${BASE_URL}/prices/${slug}`,
-    lastModified: new Date(),
-    changeFrequency: 'weekly' as const,
-    priority: 0.7,
-  }))
+  // Produce price routes — categories + individual grade pages
+  const priceCategories: string[] = [...new Set((seriesSummary as any[]).map((s: any) => s.category?.toLowerCase()).filter(Boolean))]
+  const producePriceRoutes: MetadataRoute.Sitemap = [
+    // Per-head prices page
+    { url: `${BASE_URL}/prices/head`, lastModified: new Date(), changeFrequency: 'weekly' as const, priority: 0.7 },
+    // Category pages (e.g. /prices/cattle, /prices/beef)
+    ...priceCategories.map((slug: string) => ({
+      url: `${BASE_URL}/prices/${slug}`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly' as const,
+      priority: 0.7,
+    })),
+    // Individual grade pages (e.g. /prices/cattle?code=bull&type=lwt)
+    ...seriesSummary.map((s: any) => ({
+      url: `${BASE_URL}/prices/${s.category?.toLowerCase()}?code=${s.code?.toLowerCase()}&type=lwt`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly' as const,
+      priority: 0.6,
+    })),
+  ]
 
   // Farmer and buyer profile routes
   const clientRoutes: MetadataRoute.Sitemap = clients.flatMap((client: any) => {
@@ -211,6 +225,19 @@ async function fetchSimpleApi(endpoint: string) {
     return data.data || []
   } catch (error) {
     console.error(`Error fetching ${endpoint} for sitemap:`, error)
+    return []
+  }
+}
+
+async function fetchSeriesSummary() {
+  const apiUrl = getApiUrl()
+  if (!apiUrl) return []
+  try {
+    const response = await fetch(`${apiUrl}/prices/series/summary`, { next: { revalidate: 86400 } })
+    if (!response.ok) return []
+    const data = await response.json()
+    return data?.data || []
+  } catch {
     return []
   }
 }

--- a/apps/client-fnp/components/layouts/mobile-nav.tsx
+++ b/apps/client-fnp/components/layouts/mobile-nav.tsx
@@ -60,6 +60,7 @@ const NAV_GROUPS: { name: string; subcategories: { name: string; href: string; b
       { name: "Animal Nutrition", href: "/feed-guides" },
       { name: "Plant Nutrition Guides", href: "/plant-nutrition-guides" },
       { name: "Seed Guides", href: "/seed-guides" },
+      { name: "Equipment Guides", href: "/equipment-guides" },
       { name: "All Programs", href: "/programs", bold: true },
       { name: "Spray Programs", href: "/spray-programs" },
       { name: "Feeding Programs", href: "/feeding-programs" },

--- a/apps/client-fnp/components/layouts/site-header.tsx
+++ b/apps/client-fnp/components/layouts/site-header.tsx
@@ -131,6 +131,7 @@ const NAV_GROUPS: { name: string; subcategories: { name: string; href: string; b
       { name: "Animal Nutrition", href: "/feed-guides" },
       { name: "Plant Nutrition Guides", href: "/plant-nutrition-guides" },
       { name: "Seed Guides", href: "/seed-guides" },
+      { name: "Equipment Guides", href: "/equipment-guides" },
       { name: "All Programs", href: "/programs", bold: true },
       { name: "Spray Programs", href: "/spray-programs" },
       { name: "Feeding Programs", href: "/feeding-programs" },
@@ -302,14 +303,14 @@ function MobileSearch({ router }: { router: ReturnType<typeof useRouter> }) {
         <div className="fixed inset-0 z-[60] bg-background lg:hidden">
           <div className="flex items-center gap-3 px-4 h-14 border-b">
             <form onSubmit={handleSubmit} className="flex-1 flex items-center gap-2">
-              <div className="relative flex-1 flex items-center rounded-sm bg-muted p-0.5">
+              <div className="relative flex-1 min-w-0 flex items-center rounded-sm bg-muted p-0.5">
                 <input
                   type="text"
                   autoFocus
                   value={query}
                   onChange={(e) => setQuery(e.target.value)}
                   placeholder="Search for products, guides..."
-                  className="flex-1 h-9 pl-3 pr-10 text-sm bg-transparent outline-none placeholder:text-muted-foreground/60"
+                  className="flex-1 min-w-0 h-9 pl-3 pr-10 text-sm bg-transparent outline-none placeholder:text-muted-foreground/60"
                 />
                 <button type="submit" className="absolute right-0.5 top-1/2 -translate-y-1/2 h-8 w-8 flex items-center justify-center rounded-sm bg-primary text-primary-foreground hover:bg-primary/90 transition-colors">
                   <Search className="h-4 w-4" />
@@ -350,7 +351,7 @@ export function SiteHeader() {
   return (
     <header className="sticky top-0 z-50 w-full bg-background border-b">
       {/* Main nav */}
-      <div className="container flex h-14 items-center gap-6">
+      <div className="container flex h-14 items-center gap-2 lg:gap-6">
         {/* Logo */}
         <Link href="/" className="shrink-0 font-bold text-lg">
           {siteConfig.name}

--- a/apps/client-fnp/components/shared/ProductImageGallery.tsx
+++ b/apps/client-fnp/components/shared/ProductImageGallery.tsx
@@ -51,8 +51,7 @@ export function ProductImageGallery({ images, name, height = 520, fallback }: Pr
                     </div>
                 )}
                 <button
-                    className="relative flex-1 bg-background rounded-xl overflow-hidden cursor-pointer group"
-                    style={{ height: `min(${height}px, 60vw)` }}
+                    className="relative flex-1 aspect-square bg-muted/30 dark:bg-white rounded-xl border overflow-hidden shadow-sm cursor-pointer group"
                     onClick={() => images[selected]?.img?.src && setOpen(true)}
                 >
                     {images[selected]?.img?.src ? (
@@ -60,8 +59,8 @@ export function ProductImageGallery({ images, name, height = 520, fallback }: Pr
                             src={images[selected].img.src}
                             alt={name}
                             fill
-                            sizes="(max-width: 1024px) 100vw, 480px"
-                            className="object-contain"
+                            sizes="(max-width: 1024px) 100vw, 450px"
+                            className="object-contain p-8"
                             priority
                         />
                     ) : (

--- a/apps/client-fnp/components/structures/produce-board-router.tsx
+++ b/apps/client-fnp/components/structures/produce-board-router.tsx
@@ -20,7 +20,16 @@ export function ProduceBoardRouter({
     refetchOnWindowFocus: false,
   })
 
-  if (isLoading) return null
+  if (isLoading) {
+    return (
+      <div className="mx-auto max-w-7xl px-6 lg:px-8 py-8">
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 bg-muted rounded w-1/3" />
+          <div className="h-64 bg-muted rounded" />
+        </div>
+      </div>
+    )
+  }
 
   const hasKgData = (data?.data?.data ?? []).some(
     (e: any) => (e.category.charAt(0) + e.category.slice(1).toLowerCase()).toLowerCase() === produce.toLowerCase()

--- a/apps/client-fnp/components/structures/produce-grade-board.tsx
+++ b/apps/client-fnp/components/structures/produce-grade-board.tsx
@@ -523,7 +523,12 @@ export function ProduceGradeBoard({
     } else if (codeParam) {
       match = gradeEntries.find(e => e.code.toLowerCase() === codeParam.toLowerCase())
     }
-    setSelectedKey((match ?? gradeEntries[0]).key)
+    const selected = match ?? gradeEntries[0]
+    setSelectedKey(selected.key)
+    if (!codeParam) {
+      setCodeParam(selected.code.toLowerCase())
+      setTypeParam(selected.price_type === "Cold Dress Mass" ? "cdm" : "lwt")
+    }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [produce, gradeEntries.length])
 

--- a/apps/client-fnp/lib/utilities.ts
+++ b/apps/client-fnp/lib/utilities.ts
@@ -140,7 +140,8 @@ export function buildGuideMetadata(
   titleSuffix: string,
   description: string,
   route: string,
-  imageUrl?: string
+  imageUrl?: string,
+  keywords?: string
 ) {
   const name = formatProductName(product.name)
   const brandInTitle = product.brand?.name ? ` ${formatProductName(product.brand.name)}` : ''
@@ -148,10 +149,12 @@ export function buildGuideMetadata(
   return {
     title: `${name}${brandInTitle} – ${categorySingularTitle} ${titleSuffix} | farmnport.com`,
     description,
+    ...(keywords ? { keywords } : {}),
     alternates: { canonical: route },
     openGraph: {
       title: `${name}${brandInTitle} – ${categorySingularTitle} Guide`,
       description,
+      url: `https://farmnport.com${route}`,
       siteName: 'farmnport',
       type: 'website' as const,
       images: [ogImage],

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- Add keyword-rich metadata, JSON-LD structured data, and breadcrumbs to all price pages
- Add dynamic SEO for price query params (code=bull&type=lwt generates targeted titles)
- Add missing metadata to spray programs, feeding programs, feed guides
- Add keywords and JSON-LD to all agrochemical, animal health, plant nutrition guide pages
- Add keywords and JSON-LD to buyer/farmer profile and listing pages
- Add dynamic price grade URLs to sitemap
- Fix produce board loading state (skeleton instead of blank)

## Test plan
- [ ] Check page source on /prices/cattle for meta tags and JSON-LD
- [ ] Check /prices/boran?code=pborc&type=lwt has dynamic title
- [ ] Check /spray-programs/potato-spray-program has metadata
- [ ] Verify sitemap.xml includes price grade URLs