### PR TITLE
Add OG images to listing pages

### DIFF
--- a/apps/client-fnp/app/(landing)/agrochemical-guides/page.tsx
+++ b/apps/client-fnp/app/(landing)/agrochemical-guides/page.tsx
@@ -13,6 +13,13 @@ export const metadata = {
     url: 'https://farmnport.com/agrochemical-guides',
     siteName: 'farmnport',
     type: 'website',
+    images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Agrochemical Guides Zimbabwe",
+    description: "Browse agrochemical product guides for Zimbabwe farmers. Herbicides, fungicides, insecticides, acaricides — dosage rates and application guidelines.",
+    images: ["/og-image.png"],
   },
 }
 

--- a/apps/client-fnp/app/(landing)/animal-health-guides/page.tsx
+++ b/apps/client-fnp/app/(landing)/animal-health-guides/page.tsx
@@ -13,6 +13,13 @@ export const metadata = {
     url: 'https://farmnport.com/animal-health-guides',
     siteName: 'farmnport',
     type: 'website',
+    images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Animal Health Product Guides Zimbabwe",
+    description: "Browse animal health product guides for poultry and livestock in Zimbabwe. Vaccines, antibiotics, supplements — dosage rates and usage guidelines.",
+    images: ["/og-image.png"],
   },
 }
 

--- a/apps/client-fnp/app/(landing)/bookings/page.tsx
+++ b/apps/client-fnp/app/(landing)/bookings/page.tsx
@@ -25,11 +25,13 @@ export const metadata = {
         siteName: "farmnport",
         type: "website" as const,
         url: "https://farmnport.com/bookings",
+        images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
     },
     twitter: {
         card: "summary_large_image" as const,
         title: "Farm Bookings & Pre-Orders Zimbabwe – Prices & Availability",
         description: "Book day-old chicks, livestock and seasonal farm produce in advance. View prices and secure your order with a deposit.",
+        images: ["/og-image.png"],
     },
 }
 

--- a/apps/client-fnp/app/(landing)/buy-agrochemicals/page.tsx
+++ b/apps/client-fnp/app/(landing)/buy-agrochemicals/page.tsx
@@ -13,11 +13,13 @@ export const metadata = {
         siteName: "farmnport",
         type: "website" as const,
         url: "https://farmnport.com/buy-agrochemicals",
+        images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
     },
     twitter: {
         card: "summary_large_image" as const,
         title: "Buy Agrochemicals Zimbabwe – Prices & Dosage Guides",
         description: "Browse herbicides, fungicides, insecticides and plant growth regulators. Compare prices, view dosage guides and spray programs for Zimbabwe crops.",
+        images: ["/og-image.png"],
     },
 }
 

--- a/apps/client-fnp/app/(landing)/buy-animal-health/page.tsx
+++ b/apps/client-fnp/app/(landing)/buy-animal-health/page.tsx
@@ -13,11 +13,13 @@ export const metadata = {
         siteName: "farmnport",
         type: "website" as const,
         url: "https://farmnport.com/buy-animal-health",
+        images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
     },
     twitter: {
         card: "summary_large_image" as const,
         title: "Buy Animal Health Products Zimbabwe – Prices & Guides",
         description: "Shop dips, dewormers, vaccines and veterinary supplements for cattle, poultry and livestock. Compare prices, view dosage rates and order online.",
+        images: ["/og-image.png"],
     },
 }
 

--- a/apps/client-fnp/app/(landing)/buy-documents/page.tsx
+++ b/apps/client-fnp/app/(landing)/buy-documents/page.tsx
@@ -15,11 +15,13 @@ export const metadata = {
         siteName: "farmnport",
         type: "website" as const,
         url: "https://farmnport.com/buy-documents",
+        images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
     },
     twitter: {
         card: "summary_large_image" as const,
         title: "Farm Building Plans & Documents | farmnport.com",
         description: "Download pig sty, goat pen, chicken house and cattle kraal design plans. Instant PDF download.",
+        images: ["/og-image.png"],
     },
 }
 

--- a/apps/client-fnp/app/(landing)/buy-equipment/page.tsx
+++ b/apps/client-fnp/app/(landing)/buy-equipment/page.tsx
@@ -13,11 +13,13 @@ export const metadata = {
         siteName: "farmnport",
         type: "website" as const,
         url: "https://farmnport.com/buy-equipment",
+        images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
     },
     twitter: {
         card: "summary_large_image" as const,
         title: "Buy Farm Equipment Online — Zimbabwe",
         description: "Shop our complete range of quality agricultural equipment and machinery for Zimbabwe farmers.",
+        images: ["/og-image.png"],
     },
 }
 

--- a/apps/client-fnp/app/(landing)/buy-feeds/page.tsx
+++ b/apps/client-fnp/app/(landing)/buy-feeds/page.tsx
@@ -13,11 +13,13 @@ export const metadata = {
         siteName: "farmnport",
         type: "website" as const,
         url: "https://farmnport.com/buy-feeds",
+        images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
     },
     twitter: {
         card: "summary_large_image" as const,
         title: "Buy Animal Feeds Zimbabwe – Prices & Product Range",
         description: "Shop poultry feeds, cattle feeds, pig feeds and pet food from top brands. Compare prices and order online.",
+        images: ["/og-image.png"],
     },
 }
 

--- a/apps/client-fnp/app/(landing)/buy-plant-nutrition/page.tsx
+++ b/apps/client-fnp/app/(landing)/buy-plant-nutrition/page.tsx
@@ -13,11 +13,13 @@ export const metadata = {
         siteName: "farmnport",
         type: "website" as const,
         url: "https://farmnport.com/buy-plant-nutrition",
+        images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
     },
     twitter: {
         card: "summary_large_image" as const,
         title: "Buy Plant Nutrition & Fertilizers Zimbabwe – Prices & Guides",
         description: "Shop foliar feeds, soil amendments and crop nutrition products. Compare prices, view application rates and order online.",
+        images: ["/og-image.png"],
     },
 }
 

--- a/apps/client-fnp/app/(landing)/buy-seed-products/page.tsx
+++ b/apps/client-fnp/app/(landing)/buy-seed-products/page.tsx
@@ -13,11 +13,13 @@ export const metadata = {
         siteName: "farmnport",
         type: "website" as const,
         url: "https://farmnport.com/buy-seed-products",
+        images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
     },
     twitter: {
         card: "summary_large_image" as const,
         title: "Buy Seed Products Zimbabwe – Prices & Varieties",
         description: "Shop maize seed, vegetable seed and pasture seed from certified suppliers. Compare prices, view varieties and order online.",
+        images: ["/og-image.png"],
     },
 }
 

--- a/apps/client-fnp/app/(landing)/feed-guides/page.tsx
+++ b/apps/client-fnp/app/(landing)/feed-guides/page.tsx
@@ -14,6 +14,13 @@ export const metadata: Metadata = {
         url: "https://farmnport.com/feed-guides",
         siteName: "farmnport",
         type: "website",
+        images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
+    },
+    twitter: {
+        card: "summary_large_image",
+        title: "Livestock Feed Guides Zimbabwe — Animal Feed Products & Nutrition",
+        description: "Browse livestock feed product guides for Zimbabwe farmers. Compare feeds by animal type, phase, and nutritional specs.",
+        images: ["/og-image.png"],
     },
 }
 

--- a/apps/client-fnp/app/(landing)/feeding-programs/page.tsx
+++ b/apps/client-fnp/app/(landing)/feeding-programs/page.tsx
@@ -14,6 +14,13 @@ export const metadata = {
         url: "https://farmnport.com/feeding-programs",
         siteName: "farmnport",
         type: "website",
+        images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
+    },
+    twitter: {
+        card: "summary_large_image",
+        title: "Feeding Programs Zimbabwe — Livestock Nutrition Schedules",
+        description: "Browse structured feeding programs for livestock in Zimbabwe — formulations, schedules, and nutritional targets by animal type.",
+        images: ["/og-image.png"],
     },
 }
 

--- a/apps/client-fnp/app/(landing)/plant-nutrition-guides/page.tsx
+++ b/apps/client-fnp/app/(landing)/plant-nutrition-guides/page.tsx
@@ -13,6 +13,13 @@ export const metadata = {
     url: 'https://farmnport.com/plant-nutrition-guides',
     siteName: 'farmnport',
     type: 'website',
+    images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Plant Nutrition Guides Zimbabwe",
+    description: "Browse plant nutrition product guides for Zimbabwe farmers. Fertilizers, foliar feeds, biostimulants — application rates and usage guidelines.",
+    images: ["/og-image.png"],
   },
 }
 

--- a/apps/client-fnp/app/(landing)/spray-programs/page.tsx
+++ b/apps/client-fnp/app/(landing)/spray-programs/page.tsx
@@ -14,6 +14,13 @@ export const metadata: Metadata = {
         url: "https://farmnport.com/spray-programs",
         siteName: "farmnport",
         type: "website",
+        images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
+    },
+    twitter: {
+        card: "summary_large_image",
+        title: "Spray Programs Zimbabwe — Crop Protection Schedules",
+        description: "Browse spray program schedules for Zimbabwe crops. Step-by-step agrochemical application timings for every growth stage.",
+        images: ["/og-image.png"],
     },
 }
 

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- Add default OG image and Twitter card to 14 listing pages missing social sharing images

## Test plan
- [ ] Share /buy-agrochemicals on WhatsApp — should show farmnport OG image