### PR TITLE
Fix trending image cover

### DIFF
--- a/apps/client-fnp/components/sections/trending.tsx
+++ b/apps/client-fnp/components/sections/trending.tsx
@@ -96,7 +96,7 @@ export function TrendingSection() {
                   >
                     <div className="aspect-square bg-muted/30 dark:bg-white relative">
                       {item.image && (
-                        <img src={item.image} alt="" className="absolute inset-0 w-full h-full object-contain p-3" />
+                        <img src={item.image} alt="" className="absolute inset-0 w-full h-full object-cover" />
                       )}
                     </div>
                     <div className="p-3 flex flex-col flex-1 border-t">

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "6.3.2",
+  "version": "6.3.3",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- Changed trending item images from `object-contain p-3` to `object-cover` so images fill the container instead of floating with padding