### PR TITLE
Add YouTube video gallery to product pages

### DIFF
--- a/apps/admin-fnp/app/dashboard/farmnport/animal-health-products/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/animal-health-products/[slug]/edit/page.tsx
@@ -90,6 +90,7 @@ export default function EditAnimalHealthProductPage({ params }: { params: Promis
             was_price: product?.was_price ?? 0,
             weight_grams: product?.weight_grams ?? 0,
             is_test: (product as any)?.is_test ?? false,
+            video_id: (product as any)?.video_id ?? "",
             variants: product?.variants || [],
             precautions: product?.precautions || [],
             status: product?.status ?? "active",
@@ -124,6 +125,7 @@ export default function EditAnimalHealthProductPage({ params }: { params: Promis
             pickup_location_ids: product.pickup_location_ids ?? [],
             delivery_location_ids: product.delivery_location_ids ?? [],
             is_test: (product as any).is_test ?? false,
+            video_id: (product as any).video_id ?? "",
         } : undefined,
         resolver: zodResolver(FormAnimalHealthProductSchema),
     })
@@ -403,6 +405,22 @@ export default function EditAnimalHealthProductPage({ params }: { params: Promis
                                         </FormItem>
                                     )}
                                 />
+                            </div>
+                        </div>
+
+                        {/* YouTube Video ID */}
+                        <div className="border-b border-gray-900/10 dark:border-gray-100/10 pb-12">
+                            <div className="px-1">
+                                <label className="block text-sm/6 font-medium text-gray-900 dark:text-white mb-2">YouTube Video ID</label>
+                                <FormField control={form.control} name="video_id" render={({ field }) => (
+                                    <FormItem>
+                                        <FormControl>
+                                            <Input placeholder="e.g. dQw4w9WgXcQ" {...field} />
+                                        </FormControl>
+                                        <p className="mt-1 text-xs text-gray-500">The video ID from the YouTube URL (after watch?v=)</p>
+                                        <FormMessage />
+                                    </FormItem>
+                                )} />
                             </div>
                         </div>
 

--- a/apps/admin-fnp/app/dashboard/farmnport/animal-health-products/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/animal-health-products/new/page.tsx
@@ -45,6 +45,7 @@ export default function NewAnimalHealthProductPage() {
             was_price: 0,
             weight_grams: 0,
             variants: [],
+            video_id: "",
         },
         resolver: zodResolver(FormAnimalHealthProductSchema),
     })
@@ -148,6 +149,19 @@ export default function NewAnimalHealthProductPage() {
                                     </p>
                                 </div>
                             </div>
+                        </div>
+
+                        <div className="px-1">
+                            <label className="block text-sm/6 font-medium text-gray-900 dark:text-white mb-2">YouTube Video ID</label>
+                            <FormField control={form.control} name="video_id" render={({ field }) => (
+                                <FormItem>
+                                    <FormControl>
+                                        <Input placeholder="e.g. dQw4w9WgXcQ" {...field} />
+                                    </FormControl>
+                                    <p className="mt-1 text-xs text-gray-500">The video ID from the YouTube URL (after watch?v=)</p>
+                                    <FormMessage />
+                                </FormItem>
+                            )} />
                         </div>
 
                         <ProductPricingSection />

--- a/apps/admin-fnp/app/dashboard/farmnport/equipment/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/equipment/[slug]/edit/page.tsx
@@ -87,6 +87,7 @@ export default function EditEquipmentProductPage({ params }: { params: Promise<{
             was_price: product?.was_price ?? 0,
             weight_grams: product?.weight_grams ?? 0,
             is_test: (product as any)?.is_test ?? false,
+            video_id: (product as any)?.video_id ?? "",
             variants: product?.variants || [],
             status: product?.status ?? "active",
             delivery_available: product?.delivery_available ?? false,
@@ -118,6 +119,7 @@ export default function EditEquipmentProductPage({ params }: { params: Promise<{
             pickup_location_ids: product.pickup_location_ids ?? [],
             delivery_location_ids: product.delivery_location_ids ?? [],
             is_test: (product as any).is_test ?? false,
+            video_id: (product as any).video_id ?? "",
         } : undefined,
         resolver: zodResolver(FormEquipmentProductSchema),
     })
@@ -398,6 +400,22 @@ export default function EditEquipmentProductPage({ params }: { params: Promise<{
                                         </FormItem>
                                     )}
                                 />
+                            </div>
+                        </div>
+
+                        {/* YouTube Video ID */}
+                        <div className="border-b border-gray-900/10 dark:border-gray-100/10 pb-12">
+                            <div className="px-1">
+                                <label className="block text-sm/6 font-medium text-gray-900 dark:text-white mb-2">YouTube Video ID</label>
+                                <FormField control={form.control} name="video_id" render={({ field }) => (
+                                    <FormItem>
+                                        <FormControl>
+                                            <Input placeholder="e.g. dQw4w9WgXcQ" {...field} />
+                                        </FormControl>
+                                        <p className="mt-1 text-xs text-gray-500">The video ID from the YouTube URL (after watch?v=)</p>
+                                        <FormMessage />
+                                    </FormItem>
+                                )} />
                             </div>
                         </div>
 

--- a/apps/admin-fnp/app/dashboard/farmnport/equipment/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/equipment/new/page.tsx
@@ -70,6 +70,7 @@ export default function NewEquipmentProductPage() {
             was_price: 0,
             weight_grams: 0,
             variants: [],
+            video_id: "",
             is_test: false,
             status: "active",
             delivery_available: false,
@@ -324,6 +325,22 @@ export default function NewEquipmentProductPage() {
                                         </FormItem>
                                     )}
                                 />
+                            </div>
+                        </div>
+
+                        {/* YouTube Video ID */}
+                        <div className="border-b border-gray-900/10 dark:border-gray-100/10 pb-12">
+                            <div className="px-1">
+                                <label className="block text-sm/6 font-medium text-gray-900 dark:text-white mb-2">YouTube Video ID</label>
+                                <FormField control={form.control} name="video_id" render={({ field }) => (
+                                    <FormItem>
+                                        <FormControl>
+                                            <Input placeholder="e.g. dQw4w9WgXcQ" {...field} />
+                                        </FormControl>
+                                        <p className="mt-1 text-xs text-gray-500">The video ID from the YouTube URL (after watch?v=)</p>
+                                        <FormMessage />
+                                    </FormItem>
+                                )} />
                             </div>
                         </div>
 

--- a/apps/admin-fnp/app/dashboard/farmnport/feed-products/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/feed-products/[slug]/edit/page.tsx
@@ -81,6 +81,7 @@ const EditFeedProductSchema = z.object({
     was_price: z.coerce.number().nonnegative().default(0),
     weight_grams: z.coerce.number().int().nonnegative().default(0),
     is_test: z.boolean().default(false),
+    video_id: z.string().optional().default(""),
     delivery_available: z.boolean().default(false),
     pickup_available: z.boolean().default(false),
 }).refine(data => !data.available_for_sale || data.weight_grams > 0, {
@@ -169,6 +170,7 @@ export default function EditFeedProductPage({ params }: { params: Promise<{ slug
             was_price: product?.was_price ?? 0,
             weight_grams: product?.weight_grams ?? 0,
             is_test: (product as any)?.is_test ?? false,
+            video_id: (product as any)?.video_id ?? "",
             delivery_available: (product as any)?.delivery_available ?? false,
             pickup_available: (product as any)?.pickup_available ?? false,
         },
@@ -200,6 +202,7 @@ export default function EditFeedProductPage({ params }: { params: Promise<{ slug
             delivery_available: (product as any).delivery_available ?? false,
             pickup_available: (product as any).pickup_available ?? false,
             is_test: (product as any).is_test ?? false,
+            video_id: (product as any).video_id ?? "",
         } : undefined,
         resolver: zodResolver(EditFeedProductSchema),
     })
@@ -984,6 +987,21 @@ export default function EditFeedProductPage({ params }: { params: Promise<{ slug
                             ))}
                         </div>
                     )}
+                </div>
+
+                <div className="border-b border-gray-900/10 dark:border-gray-100/10 pb-12">
+                    <div className="px-1">
+                        <label className="block text-sm/6 font-medium text-gray-900 dark:text-white mb-2">YouTube Video ID</label>
+                        <FormField control={form.control} name="video_id" render={({ field }) => (
+                            <FormItem>
+                                <FormControl>
+                                    <Input placeholder="e.g. dQw4w9WgXcQ" {...field} />
+                                </FormControl>
+                                <p className="mt-1 text-xs text-gray-500">The video ID from the YouTube URL (after watch?v=)</p>
+                                <FormMessage />
+                            </FormItem>
+                        )} />
+                    </div>
                 </div>
 
                 <ProductPricingSection />

--- a/apps/admin-fnp/app/dashboard/farmnport/feed-products/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/feed-products/new/page.tsx
@@ -77,6 +77,7 @@ const NewFeedProductSchema = z.object({
     was_price: z.coerce.number().nonnegative().default(0),
     weight_grams: z.coerce.number().int().nonnegative().default(0),
     is_test: z.boolean().default(false),
+    video_id: z.string().optional().default(""),
 }).refine(data => !data.available_for_sale || data.weight_grams > 0, {
     message: "Weight is required before enabling available for sale",
     path: ["weight_grams"],
@@ -113,6 +114,7 @@ export default function NewFeedProductPage() {
             sale_price: 0,
             was_price: 0,
             weight_grams: 0,
+            video_id: "",
         },
         resolver: zodResolver(NewFeedProductSchema),
     })
@@ -862,6 +864,21 @@ export default function NewFeedProductPage() {
                             ))}
                         </div>
                     )}
+                </div>
+
+                <div className="border-b border-gray-900/10 dark:border-gray-100/10 pb-12">
+                    <div className="px-1">
+                        <label className="block text-sm/6 font-medium text-gray-900 dark:text-white mb-2">YouTube Video ID</label>
+                        <FormField control={form.control} name="video_id" render={({ field }) => (
+                            <FormItem>
+                                <FormControl>
+                                    <Input placeholder="e.g. dQw4w9WgXcQ" {...field} />
+                                </FormControl>
+                                <p className="mt-1 text-xs text-gray-500">The video ID from the YouTube URL (after watch?v=)</p>
+                                <FormMessage />
+                            </FormItem>
+                        )} />
+                    </div>
                 </div>
 
                 <ProductPricingSection />

--- a/apps/admin-fnp/app/dashboard/farmnport/lots/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/lots/[slug]/edit/page.tsx
@@ -329,6 +329,11 @@ function EditForm({ lot, slug }: { lot: any; slug: string }) {
                       imageClassName="flex items-center justify-center w-32 h-32 overflow-hidden bg-gray-50"
                     />
                   </div>
+                  <div>
+                    <label className="block text-sm/6 font-medium text-gray-900 dark:text-white mb-2">YouTube Video ID</label>
+                    <Input placeholder="e.g. dQw4w9WgXcQ" defaultValue={(lot as any).video_id || ""} readOnly />
+                    <p className="mt-1 text-xs text-gray-500">The video ID from the YouTube URL (after watch?v=)</p>
+                  </div>
                 </div>
               </div>
             </div>

--- a/apps/admin-fnp/app/dashboard/farmnport/lots/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/lots/new/page.tsx
@@ -157,6 +157,18 @@ export default function NewAdminLotPage() {
                       </FormItem>
                     )} />
                   </div>
+                  <div>
+                    <label className="block text-sm/6 font-medium text-gray-900 dark:text-white mb-2">YouTube Video ID</label>
+                    <FormField control={form.control} name="video_id" render={({ field }) => (
+                      <FormItem>
+                        <FormControl>
+                          <Input placeholder="e.g. dQw4w9WgXcQ" {...field} />
+                        </FormControl>
+                        <p className="mt-1 text-xs text-gray-500">The video ID from the YouTube URL (after watch?v=)</p>
+                        <FormMessage />
+                      </FormItem>
+                    )} />
+                  </div>
                 </div>
               </div>
             </div>

--- a/apps/admin-fnp/app/dashboard/farmnport/orders/booking-preorders/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/orders/booking-preorders/new/page.tsx
@@ -312,6 +312,19 @@ export default function NewPreOrderPage() {
               </div>
             </div>
             <div className="sm:col-span-3">
+              <label className={labelCls}>YouTube Video ID</label>
+              <div className="mt-2">
+                <input
+                  type="text"
+                  value={form.video_id || ""}
+                  onChange={(e) => set("video_id", e.target.value)}
+                  placeholder="e.g. dQw4w9WgXcQ"
+                  className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                />
+                <p className="mt-1 text-xs text-gray-500">The video ID from the YouTube URL (after watch?v=)</p>
+              </div>
+            </div>
+            <div className="sm:col-span-3">
               <label className={labelCls}>Status</label>
               <div className="mt-2">
                 <Select value={form.status} onValueChange={(v) => set("status", v)}>

--- a/apps/admin-fnp/app/dashboard/farmnport/seed-products/[id]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/seed-products/[id]/edit/page.tsx
@@ -61,6 +61,7 @@ const Schema = z.object({
     was_price: z.coerce.number().default(0),
     weight_grams: z.coerce.number().int().nonnegative().default(0),
     is_test: z.boolean().default(false),
+    video_id: z.string().optional().default(""),
     delivery_available: z.boolean().default(false),
     pickup_available: z.boolean().default(false),
 }).refine((data) => !!data.brand_id || !!data.seller_id, {
@@ -126,6 +127,7 @@ function EditForm({ product, id }: { product: any; id: string }) {
             was_price: (product?.was_price || 0) / 100,
             weight_grams: product?.weight_grams ?? 0,
             is_test: (product as any)?.is_test ?? false,
+            video_id: (product as any)?.video_id ?? "",
             delivery_available: product?.delivery_available || false,
             pickup_available: (product as any)?.pickup_available || false,
         },
@@ -530,6 +532,25 @@ function EditForm({ product, id }: { product: any; id: string }) {
                                         ))}
                                     </div>
                                 )}
+                            </div>
+                        </div>
+
+                        <div className="grid grid-cols-1 gap-x-8 gap-y-10 border-b border-gray-900/10 pb-12 md:grid-cols-3 dark:border-white/10">
+                            <div>
+                                <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">Video</h2>
+                                <p className="mt-1 text-sm/6 text-gray-600 dark:text-gray-400">Optional YouTube video for this product.</p>
+                            </div>
+                            <div className="md:col-span-2">
+                                <label className="block text-sm/6 font-medium text-gray-900 dark:text-white mb-2">YouTube Video ID</label>
+                                <FormField control={form.control} name="video_id" render={({ field }) => (
+                                    <FormItem>
+                                        <FormControl>
+                                            <Input placeholder="e.g. dQw4w9WgXcQ" className={inputClass} {...field} />
+                                        </FormControl>
+                                        <p className="mt-1 text-xs text-gray-500">The video ID from the YouTube URL (after watch?v=)</p>
+                                        <FormMessage />
+                                    </FormItem>
+                                )} />
                             </div>
                         </div>
 

--- a/apps/admin-fnp/app/dashboard/farmnport/seed-products/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/seed-products/new/page.tsx
@@ -56,6 +56,7 @@ const Schema = z.object({
     was_price: z.coerce.number().default(0),
     weight_grams: z.coerce.number().int().nonnegative().default(0),
     is_test: z.boolean().default(false),
+    video_id: z.string().optional().default(""),
 })
 
 type FormModel = z.infer<typeof Schema>
@@ -71,6 +72,7 @@ export default function NewSeedProductPage() {
             days_to_maturity: "", yield_potential: "", soil_requirements: "",
             seed_treatment: "", management_tips: "",
             planting_guide: [], precautions: [], variants: [],
+            video_id: "",
         },
         resolver: zodResolver(Schema),
     })
@@ -372,6 +374,21 @@ export default function NewSeedProductPage() {
                                     ))}
                                 </div>
                             )}
+                        </div>
+
+                        <div className="border-b border-gray-900/10 dark:border-white/10 pb-12">
+                            <div className="px-1">
+                                <label className="block text-sm/6 font-medium text-gray-900 dark:text-white mb-2">YouTube Video ID</label>
+                                <FormField control={form.control} name="video_id" render={({ field }) => (
+                                    <FormItem>
+                                        <FormControl>
+                                            <Input placeholder="e.g. dQw4w9WgXcQ" {...field} />
+                                        </FormControl>
+                                        <p className="mt-1 text-xs text-gray-500">The video ID from the YouTube URL (after watch?v=)</p>
+                                        <FormMessage />
+                                    </FormItem>
+                                )} />
+                            </div>
                         </div>
 
                         <ProductPricingSection />

--- a/apps/admin-fnp/components/structures/forms/agroChemicalForm.tsx
+++ b/apps/admin-fnp/components/structures/forms/agroChemicalForm.tsx
@@ -626,6 +626,32 @@ export function AgroChemicalForm({ agroChemical, mode = "create" }: AgroChemical
 
                 <div>
                     <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
+                        Product Video
+                    </h2>
+                    <p className="mt-1 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">
+                        Add a YouTube video ID to display on the product page.
+                    </p>
+                    <div className="mt-6 max-w-md">
+                        <FormField
+                            control={form.control}
+                            name="video_id"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormControl>
+                                        <Input placeholder="e.g. dQw4w9WgXcQ" {...field} />
+                                    </FormControl>
+                                    <p className="mt-1 text-xs text-gray-500">
+                                        The video ID from the YouTube URL (after watch?v=)
+                                    </p>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+                    </div>
+                </div>
+
+                <div>
+                    <h2 className="text-base/7 font-semibold text-gray-900 dark:text-white">
                         Active Ingredients
                     </h2>
                     <p className="mt-1 max-w-2xl text-sm/6 text-gray-600 dark:text-gray-400">

--- a/apps/admin-fnp/lib/schemas.ts
+++ b/apps/admin-fnp/lib/schemas.ts
@@ -481,6 +481,7 @@ export const AgroChemicalSchema = z.object({
   front_label: z.custom<ImageModel>().optional(),
   back_label: z.custom<ImageModel>().optional(),
   images: z.array(z.custom<ImageModel>()).max(5, "Maximum 5 images allowed"),
+  video_id: z.string().optional().default(""),
   active_ingredients: z.array(z.object({
     id: z.string(),
     name: z.string(),
@@ -773,6 +774,7 @@ export const AnimalHealthProductSchema = z.object({
   front_label: z.custom<ImageModel>().optional(),
   back_label: z.custom<ImageModel>().optional(),
   images: z.array(z.custom<ImageModel>()).max(5, "Maximum 5 images allowed"),
+  video_id: z.string().optional().default(""),
   active_ingredients: z.array(z.object({
     id: z.string(),
     name: z.string(),
@@ -878,6 +880,7 @@ export const EquipmentProductSchema = z.object({
   front_label: z.custom<ImageModel>().optional(),
   back_label: z.custom<ImageModel>().optional(),
   images: z.array(z.custom<ImageModel>()).max(5, "Maximum 5 images allowed"),
+  video_id: z.string().optional().default(""),
   specifications: z.array(z.string()).default([]),
   stock_level: z.coerce.number().int().nonnegative().default(0),
   available_for_sale: z.boolean().default(false),
@@ -1066,6 +1069,7 @@ export const FeedProductSchema = z.object({
   front_label: z.custom<ImageModel>().optional(),
   back_label: z.custom<ImageModel>().optional(),
   images: z.array(z.custom<ImageModel>()).max(5, "Maximum 5 images allowed"),
+  video_id: z.string().optional().default(""),
   active_ingredients: z.array(z.object({
     id: z.string(),
     name: z.string(),

--- a/apps/client-fnp/app/(landing)/bookings/[slug]/PreOrderDetailClient.tsx
+++ b/apps/client-fnp/app/(landing)/bookings/[slug]/PreOrderDetailClient.tsx
@@ -199,6 +199,7 @@ export default function PreOrderDetailPage({ preorder, depositEnabled = false }:
                 ]}
                 name={event.name}
                 height={400}
+                videoId={event.video_id}
               />
               {event.is_test && <span className="absolute top-3 right-3 z-10 bg-orange-500 text-white text-xs font-bold px-2 py-1 rounded">TEST</span>}
             </div>

--- a/apps/client-fnp/app/(landing)/lots/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/lots/[slug]/page.tsx
@@ -156,6 +156,7 @@ export default async function LotDetailPage({ params }: Props) {
                                     <LotImageGallery
                                         mainImage={(bidsData?.accepted as any)?.supply_images?.main_image ?? lot.main_image}
                                         images={(bidsData?.accepted as any)?.supply_images?.images ?? lot.images ?? []}
+                                        videoId={lot.video_id}
                                     />
                                 )}
 

--- a/apps/client-fnp/components/shared/ProductImageGallery.tsx
+++ b/apps/client-fnp/components/shared/ProductImageGallery.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react"
 import Image from "next/image"
-import { ChevronLeft, ChevronRight, Expand, Share2, Link2, Check } from "lucide-react"
+import { ChevronLeft, ChevronRight, Expand, Share2, Link2, Check, Play } from "lucide-react"
 import { sendGTMEvent } from "@next/third-parties/google"
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden"
@@ -20,17 +20,20 @@ interface ProductImageGalleryProps {
     name: string
     height?: number
     fallback?: React.ReactNode
+    videoId?: string
 }
 
-export function ProductImageGallery({ images, name, height = 520, fallback }: ProductImageGalleryProps) {
+export function ProductImageGallery({ images, name, height = 520, fallback, videoId }: ProductImageGalleryProps) {
     const [selected, setSelected] = useState(0)
     const [open, setOpen] = useState(false)
     const [copied, setCopied] = useState(false)
+    const videoIndex = videoId ? images.length : -1
+    const isVideo = videoId && selected === videoIndex
 
     return (
         <>
             <div className="flex gap-2">
-                {images.length > 1 && (
+                {(images.length > 1 || videoId) && (
                     <div className="hidden md:flex flex-col gap-2 shrink-0 p-1">
                         {images.map((img, idx) => (
                             <button
@@ -48,32 +51,55 @@ export function ProductImageGallery({ images, name, height = 520, fallback }: Pr
                                 )}
                             </button>
                         ))}
+                        {videoId && (
+                            <button
+                                onClick={() => setSelected(videoIndex)}
+                                onMouseEnter={() => setSelected(videoIndex)}
+                                className={`relative w-16 h-16 rounded-lg overflow-hidden bg-muted/50 transition-colors flex items-center justify-center ${
+                                    isVideo ? "ring-2 ring-primary" : "opacity-60 hover:opacity-100"
+                                }`}
+                            >
+                                <Play className="w-5 h-5 fill-current" />
+                            </button>
+                        )}
                     </div>
                 )}
-                <button
-                    className="relative flex-1 aspect-square bg-muted/30 dark:bg-white rounded-xl border overflow-hidden shadow-sm cursor-pointer group"
-                    onClick={() => images[selected]?.img?.src && setOpen(true)}
-                >
-                    {images[selected]?.img?.src ? (
-                        <Image
-                            src={images[selected].img.src}
-                            alt={name}
-                            fill
-                            sizes="(max-width: 1024px) 100vw, 450px"
-                            className="object-contain p-8"
-                            priority
+                {isVideo ? (
+                    <div className="relative flex-1 aspect-square bg-black rounded-xl border overflow-hidden shadow-sm">
+                        <iframe
+                            src={`https://www.youtube.com/embed/${videoId}?rel=0`}
+                            title={`${name} video`}
+                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                            allowFullScreen
+                            className="absolute inset-0 w-full h-full"
                         />
-                    ) : (
-                        <FpPlaceholder />
-                    )}
-                    {images[selected]?.img?.src && (
-                        <span className="absolute bottom-3 right-3 md:top-3 md:bottom-auto w-8 h-8 flex items-center justify-center rounded-full bg-background text-foreground shadow-sm">
-                            <Expand className="w-4 h-4" />
-                        </span>
-                    )}
-                </button>
+                    </div>
+                ) : (
+                    <button
+                        className="relative flex-1 aspect-square bg-muted/30 dark:bg-white rounded-xl border overflow-hidden shadow-sm cursor-pointer group"
+                        onClick={() => images[selected]?.img?.src && setOpen(true)}
+                    >
+                        {images[selected]?.img?.src ? (
+                            <Image
+                                src={images[selected].img.src}
+                                alt={name}
+                                fill
+                                sizes="(max-width: 1024px) 100vw, 450px"
+                                className="object-contain p-8"
+                                priority
+                            />
+                        ) : (
+                            <FpPlaceholder />
+                        )}
+                        {images[selected]?.img?.src && (
+                            <span className="absolute bottom-3 right-3 md:top-3 md:bottom-auto w-8 h-8 flex items-center justify-center rounded-full bg-background text-foreground shadow-sm">
+                                <Expand className="w-4 h-4" />
+                            </span>
+                        )}
+                    </button>
+                )}
             </div>
-            {images.length > 1 && (
+            {(images.length > 1 || videoId) && (
                 <div className="flex md:hidden gap-2 overflow-x-auto px-1 py-1">
                     {images.map((img, idx) => (
                         <button
@@ -90,7 +116,26 @@ export function ProductImageGallery({ images, name, height = 520, fallback }: Pr
                             )}
                         </button>
                     ))}
+                    {videoId && (
+                        <button
+                            onClick={() => setSelected(videoIndex)}
+                            className={`relative w-14 h-14 rounded-lg overflow-hidden bg-muted/50 shrink-0 transition-colors flex items-center justify-center ${
+                                isVideo ? "ring-2 ring-primary" : "opacity-60 hover:opacity-100"
+                            }`}
+                        >
+                            <Play className="w-4 h-4 fill-current" />
+                        </button>
+                    )}
                 </div>
+            )}
+            {videoId && !isVideo && (
+                <button
+                    onClick={() => setSelected(videoIndex)}
+                    className="flex items-center gap-2 w-full py-2.5 px-4 rounded-lg border bg-muted/30 hover:bg-muted/50 transition-colors text-sm text-muted-foreground hover:text-foreground"
+                >
+                    <Play className="w-4 h-4 fill-current" />
+                    Watch Product Video
+                </button>
             )}
 
             <Dialog open={open} onOpenChange={setOpen}>
@@ -98,7 +143,7 @@ export function ProductImageGallery({ images, name, height = 520, fallback }: Pr
                     <VisuallyHidden><DialogTitle>{name}</DialogTitle></VisuallyHidden>
 
                     <div className="flex h-full max-md:flex-col">
-                        {images.length > 1 && (
+                        {(images.length > 1 || videoId) && (
                             <div className="hidden md:flex flex-col gap-1.5 p-3 overflow-y-auto shrink-0 w-20">
                                 {images.map((img, idx) => (
                                     <button
@@ -116,20 +161,31 @@ export function ProductImageGallery({ images, name, height = 520, fallback }: Pr
                                         )}
                                     </button>
                                 ))}
+                                {videoId && (
+                                    <button
+                                        onClick={() => setSelected(videoIndex)}
+                                        onMouseEnter={() => setSelected(videoIndex)}
+                                        className={`relative w-14 h-14 rounded-lg overflow-hidden bg-muted/50 shrink-0 transition-colors flex items-center justify-center ${
+                                            isVideo ? "ring-2 ring-primary" : "opacity-60 hover:opacity-100"
+                                        }`}
+                                    >
+                                        <Play className="w-5 h-5 fill-current" />
+                                    </button>
+                                )}
                             </div>
                         )}
 
                         <div className="relative flex-1 flex items-center justify-center">
-                            {images.length > 1 && (
+                            {(images.length > 1 || videoId) && (
                                 <>
                                     <button
-                                        onClick={() => setSelected((selected - 1 + images.length) % images.length)}
+                                        onClick={() => { const total = videoId ? images.length + 1 : images.length; setSelected((selected - 1 + total) % total) }}
                                         className="absolute left-3 z-50 w-9 h-9 flex items-center justify-center rounded-full bg-background/80 hover:bg-muted text-foreground transition-colors"
                                     >
                                         <ChevronLeft className="w-5 h-5" />
                                     </button>
                                     <button
-                                        onClick={() => setSelected((selected + 1) % images.length)}
+                                        onClick={() => { const total = videoId ? images.length + 1 : images.length; setSelected((selected + 1) % total) }}
                                         className="absolute right-3 z-50 w-9 h-9 flex items-center justify-center rounded-full bg-background/80 hover:bg-muted text-foreground transition-colors"
                                     >
                                         <ChevronRight className="w-5 h-5" />
@@ -138,7 +194,15 @@ export function ProductImageGallery({ images, name, height = 520, fallback }: Pr
                             )}
 
                             <div className="relative w-[60%] h-[70%] max-md:w-[90%] max-md:h-[80%]">
-                                {images[selected]?.img?.src && (
+                                {isVideo ? (
+                                    <iframe
+                                        src={`https://www.youtube.com/embed/${videoId}?rel=0&autoplay=1`}
+                                        title={`${name} video`}
+                                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                                        allowFullScreen
+                                        className="absolute inset-0 w-full h-full rounded-lg"
+                                    />
+                                ) : images[selected]?.img?.src ? (
                                     <Image
                                         src={images[selected].img.src}
                                         alt={name}
@@ -146,11 +210,11 @@ export function ProductImageGallery({ images, name, height = 520, fallback }: Pr
                                         sizes="(max-width: 768px) 90vw, 60vw"
                                         className="object-contain"
                                     />
-                                )}
+                                ) : null}
                             </div>
                         </div>
 
-                        {images.length > 1 && (
+                        {(images.length > 1 || videoId) && (
                             <div className="flex md:hidden gap-1.5 justify-center px-3 py-2 shrink-0">
                                 {images.map((_, idx) => (
                                     <button
@@ -161,6 +225,14 @@ export function ProductImageGallery({ images, name, height = 520, fallback }: Pr
                                         }`}
                                     />
                                 ))}
+                                {videoId && (
+                                    <button
+                                        onClick={() => setSelected(videoIndex)}
+                                        className={`w-2 h-2 rounded-full transition-colors ${
+                                            isVideo ? "bg-primary" : "bg-muted-foreground/30"
+                                        }`}
+                                    />
+                                )}
                             </div>
                         )}
 

--- a/apps/client-fnp/components/shop/BuyProductInteractive.tsx
+++ b/apps/client-fnp/components/shop/BuyProductInteractive.tsx
@@ -78,7 +78,7 @@ const [mounted, setMounted] = useState(false)
       <div className="grid lg:grid-cols-[480px_1fr_300px] gap-6 items-start">
 
         {/* ── Column 1: Image ── */}
-        <ProductImageGallery images={images} name={product.name} />
+        <ProductImageGallery images={images} name={product.name} videoId={product.video_id} />
 
         {/* ── Column 2: Product info ── */}
         <div className="space-y-5">

--- a/apps/client-fnp/components/ui/lot-image-gallery.tsx
+++ b/apps/client-fnp/components/ui/lot-image-gallery.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react"
 import Image from "next/image"
-import { ChevronLeft, ChevronRight } from "lucide-react"
+import { ChevronLeft, ChevronRight, Play } from "lucide-react"
 
 interface LotImage {
   img: { id: string; src: string }
@@ -11,76 +11,113 @@ interface LotImage {
 interface Props {
   mainImage?: LotImage | null
   images?: LotImage[]
+  videoId?: string
 }
 
-export function LotImageGallery({ mainImage, images = [] }: Props) {
+export function LotImageGallery({ mainImage, images = [], videoId }: Props) {
   const all = [
     ...(mainImage ? [mainImage] : []),
     ...(images ?? []),
   ]
 
   const [selected, setSelected] = useState(0)
+  const videoIndex = videoId ? all.length : -1
+  const isVideo = videoId && selected === videoIndex
+  const total = videoId ? all.length + 1 : all.length
 
-  if (all.length === 0) return null
+  if (all.length === 0 && !videoId) return null
 
-  const prev = () => setSelected((s) => (s - 1 + all.length) % all.length)
-  const next = () => setSelected((s) => (s + 1) % all.length)
+  const prev = () => setSelected((s) => (s - 1 + total) % total)
+  const next = () => setSelected((s) => (s + 1) % total)
 
   return (
-    <div className="flex gap-3">
-      {/* Thumbnail strip */}
-      {all.length > 1 && (
-        <div className="flex flex-col gap-2 shrink-0">
-          {all.map((img, i) => (
-            <button
-              key={img.img.id}
-              type="button"
-              onClick={() => setSelected(i)}
-              className={`w-16 h-16 rounded-lg overflow-hidden border-2 transition-colors shrink-0 ${
-                selected === i ? "border-primary" : "border-border hover:border-muted-foreground"
-              }`}
-            >
-              <Image
-                src={img.img.src}
-                alt={`Photo ${i + 1}`}
-                width={64}
-                height={64}
-                className="object-cover w-full h-full"
-              />
-            </button>
-          ))}
-        </div>
-      )}
-
-      {/* Main image */}
-      <div className="relative flex-1 rounded-xl overflow-hidden border bg-muted/10 h-80">
-        <Image
-          src={all[selected].img.src}
-          alt="Lot photo"
-          fill
-          className="object-contain"
-          sizes="(max-width: 768px) 100vw, 500px"
-        />
-
-        {all.length > 1 && (
-          <>
-            <button
-              type="button"
-              onClick={prev}
-              className="absolute left-3 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-white/90 border border-border shadow-md flex items-center justify-center hover:bg-white transition-colors z-10"
-            >
-              <ChevronLeft className="w-5 h-5 text-zinc-800" />
-            </button>
-            <button
-              type="button"
-              onClick={next}
-              className="absolute right-3 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-white/90 border border-border shadow-md flex items-center justify-center hover:bg-white transition-colors z-10"
-            >
-              <ChevronRight className="w-5 h-5 text-zinc-800" />
-            </button>
-          </>
+    <div>
+      <div className="flex gap-3">
+        {/* Thumbnail strip */}
+        {total > 1 && (
+          <div className="flex flex-col gap-2 shrink-0">
+            {all.map((img, i) => (
+              <button
+                key={img.img.id}
+                type="button"
+                onClick={() => setSelected(i)}
+                className={`w-16 h-16 rounded-lg overflow-hidden border-2 transition-colors shrink-0 ${
+                  selected === i ? "border-primary" : "border-border hover:border-muted-foreground"
+                }`}
+              >
+                <Image
+                  src={img.img.src}
+                  alt={`Photo ${i + 1}`}
+                  width={64}
+                  height={64}
+                  className="object-cover w-full h-full"
+                />
+              </button>
+            ))}
+            {videoId && (
+              <button
+                type="button"
+                onClick={() => setSelected(videoIndex)}
+                className={`w-16 h-16 rounded-lg overflow-hidden border-2 transition-colors shrink-0 flex items-center justify-center bg-muted/50 ${
+                  isVideo ? "border-primary" : "border-border hover:border-muted-foreground"
+                }`}
+              >
+                <Play className="w-5 h-5 fill-current" />
+              </button>
+            )}
+          </div>
         )}
+
+        {/* Main image / video */}
+        <div className="relative flex-1 rounded-xl overflow-hidden border bg-muted/10 h-80">
+          {isVideo ? (
+            <iframe
+              src={`https://www.youtube.com/embed/${videoId}?rel=0`}
+              title="Lot video"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+              className="absolute inset-0 w-full h-full"
+            />
+          ) : all[selected] ? (
+            <Image
+              src={all[selected].img.src}
+              alt="Lot photo"
+              fill
+              className="object-contain"
+              sizes="(max-width: 768px) 100vw, 500px"
+            />
+          ) : null}
+
+          {total > 1 && (
+            <>
+              <button
+                type="button"
+                onClick={prev}
+                className="absolute left-3 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-white/90 border border-border shadow-md flex items-center justify-center hover:bg-white transition-colors z-10"
+              >
+                <ChevronLeft className="w-5 h-5 text-zinc-800" />
+              </button>
+              <button
+                type="button"
+                onClick={next}
+                className="absolute right-3 top-1/2 -translate-y-1/2 w-9 h-9 rounded-full bg-white/90 border border-border shadow-md flex items-center justify-center hover:bg-white transition-colors z-10"
+              >
+                <ChevronRight className="w-5 h-5 text-zinc-800" />
+              </button>
+            </>
+          )}
+        </div>
       </div>
+      {videoId && !isVideo && (
+        <button
+          type="button"
+          onClick={() => setSelected(videoIndex)}
+          className="flex items-center gap-2 w-full mt-2 py-2.5 px-4 rounded-lg border bg-muted/30 hover:bg-muted/50 transition-colors text-sm text-muted-foreground hover:text-foreground"
+        >
+          <Play className="w-4 h-4 fill-current" />
+          Watch Video
+        </button>
+      )}
     </div>
   )
 }

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "6.4.2",
+  "version": "6.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- Add `videoId` prop to `ProductImageGallery` and `LotImageGallery` with embedded YouTube player, play icon thumbnail tab, and "Watch Product Video" CTA button
- Add `video_id` input field to all admin forms: agrochemicals, animal health, feeds, seeds, equipment, lots, and booking pre-orders
- Add `video_id` to all frontend schemas

## Test plan
- [ ] Open any product detail page and verify video tab appears when `video_id` is set in the DB
- [ ] Verify video plays inline and in expanded dialog
- [ ] Verify "Watch Product Video" button appears below the gallery
- [ ] Verify admin forms show the YouTube Video ID input field