### PR TITLE
fix: blast verify-reminder remaining count + build errors

### DIFF
--- a/apps/admin-fnp/app/dashboard/farmnport/agrochemicals/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/agrochemicals/new/page.tsx
@@ -21,6 +21,7 @@ export default function CreateAgroChemicalPage() {
         name: "",
         brand_id: "",
         agrochemical_category_id: "",
+        video_id: "",
         front_label: undefined,
         back_label: undefined,
         images: [],

--- a/apps/admin-fnp/app/dashboard/farmnport/animal-health-categories/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/animal-health-categories/[slug]/edit/page.tsx
@@ -237,8 +237,8 @@ export default function EditAnimalHealthCategoryPage({ params }: { params: Promi
                                                             entityType="animal_health_category"
                                                             maxImages={5}
                                                             value={field.value || []}
-                                                            onChange={field.onChange
-                                                            }}
+                                                            onChange={field.onChange}
+
                                                         />
                                                     </FormControl>
                                                     <FormMessage />

--- a/apps/admin-fnp/app/dashboard/farmnport/feed-categories/[slug]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/feed-categories/[slug]/edit/page.tsx
@@ -237,8 +237,8 @@ export default function EditFeedCategoryPage({ params }: { params: Promise<{ slu
                                                             entityType="feed_category"
                                                             maxImages={5}
                                                             value={field.value || []}
-                                                            onChange={field.onChange
-                                                            }}
+                                                            onChange={field.onChange}
+
                                                         />
                                                     </FormControl>
                                                     <FormMessage />

--- a/apps/admin-fnp/app/dashboard/farmnport/lots/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/lots/new/page.tsx
@@ -47,6 +47,7 @@ interface NewLotForm {
   expires_at: string
   main_image: ImageModel[]
   images: ImageModel[]
+  video_id: string
 }
 
 export default function NewAdminLotPage() {
@@ -68,6 +69,7 @@ export default function NewAdminLotPage() {
       expires_at: "",
       main_image: [],
       images: [],
+      video_id: "",
     },
   })
 
@@ -86,6 +88,7 @@ export default function NewAdminLotPage() {
       expires_at: new Date(data.expires_at).toISOString(),
       main_image: data.main_image?.[0] ?? undefined,
       images: data.images ?? [],
+      video_id: data.video_id,
     }),
     onSuccess: () => {
       toast({ description: "Lot created successfully" })

--- a/apps/admin-fnp/app/dashboard/farmnport/orders/booking-preorders/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/orders/booking-preorders/new/page.tsx
@@ -213,6 +213,7 @@ export default function NewPreOrderPage() {
     cancellation_fee: "0",
     transferable: false,
     delivery_dates: [] as Date[],
+    video_id: "",
   })
 
   const mutation = useMutation({

--- a/apps/admin-fnp/components/structures/forms/agroChemicalForm.tsx
+++ b/apps/admin-fnp/components/structures/forms/agroChemicalForm.tsx
@@ -63,6 +63,7 @@ export function AgroChemicalForm({ agroChemical, mode = "create" }: AgroChemical
             name: agroChemical?.name,
             brand_id: agroChemical?.brand_id,
             agrochemical_category_id: agroChemical?.agrochemical_category_id,
+            video_id: agroChemical?.video_id || "",
             front_label: agroChemical?.front_label,
             back_label: agroChemical?.back_label,
             images: agroChemical?.images || [],

--- a/apps/admin-fnp/components/structures/views/blast-view.tsx
+++ b/apps/admin-fnp/components/structures/views/blast-view.tsx
@@ -276,7 +276,16 @@ export function BlastView({ source }: { source?: "farmnport" | "menus" } = {}) {
           <div className="flex items-center gap-3">
             <Icons.messageSquare className="w-4 h-4 text-muted-foreground" />
             <span className="text-sm font-semibold">New Blast</span>
-            {clientsQuery.isFetching
+            {blastTemplate === "verify-reminder" ? (
+              verifyStatusQuery.isFetching
+                ? <span className="text-xs text-muted-foreground flex items-center gap-1"><Icons.spinner className="w-3 h-3 animate-spin" /> loading…</span>
+                : verifyStatusQuery.data
+                  ? <div className="flex items-center gap-1.5">
+                      <span className="text-xs px-2 py-0.5 rounded bg-muted text-muted-foreground font-medium">{verifyStatusQuery.data.remaining} remaining</span>
+                      <span className="text-xs text-muted-foreground">{verifyStatusQuery.data.sent} already sent</span>
+                    </div>
+                  : null
+            ) : clientsQuery.isFetching
               ? <span className="text-xs text-muted-foreground flex items-center gap-1"><Icons.spinner className="w-3 h-3 animate-spin" /> loading…</span>
               : clients.length > 0
                 ? <div className="flex items-center gap-1.5">

--- a/apps/admin-fnp/lib/query.ts
+++ b/apps/admin-fnp/lib/query.ts
@@ -487,6 +487,7 @@ export function adminCreateLot(data: {
   expires_at: string
   main_image?: ImageModel
   images?: ImageModel[]
+  video_id?: string
 }) {
   return api.post(`${baseUrl}/lots/admin/create`, data)
 }


### PR DESCRIPTION
## Summary
- Blast verify-reminder template now shows remaining/sent counts instead of generic total matched
- Fixed build errors from youtube gallery feature (missing video_id in forms, syntax errors in category pages)

## Test plan
- [ ] Open admin blast page, select Verify account reminder template
- [ ] Confirm badge shows remaining count, not total matched