### PR TITLE
fix: blast verify-reminder limit 100

### DIFF
--- a/apps/admin-fnp/components/structures/views/blast-view.tsx
+++ b/apps/admin-fnp/components/structures/views/blast-view.tsx
@@ -347,7 +347,7 @@ export function BlastView({ source }: { source?: "farmnport" | "menus" } = {}) {
                     ? <><Icons.spinner className="w-3.5 h-3.5 animate-spin" /> Sending test…</>
                     : <><Icons.send className="w-3.5 h-3.5" /> Send test to me</>}
                 </button>
-                <button onClick={() => verifyMutation.mutate({ limit: 500 })}
+                <button onClick={() => verifyMutation.mutate({ limit: 100 })}
                   disabled={verifyMutation.isPending || (verifyStatusQuery.data?.remaining === 0)}
                   className="h-8 px-4 rounded-md bg-primary text-white text-xs font-bold hover:bg-primary/90 disabled:opacity-40 flex items-center gap-1.5 shadow-sm">
                   {verifyMutation.isPending

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- Changed verify-reminder send limit from 500 to 100 per batch
- NATS was dropping messages as slow consumer when 443 were sent at once