### PR TITLE
add skeleton loaders to product detail pages

### DIFF
--- a/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/[slug]/loading.tsx
+++ b/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/[slug]/loading.tsx
@@ -1,0 +1,82 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-background">
+      {/* Breadcrumb */}
+      <div className="border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-4 w-10" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-32" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-20" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-24" />
+          </div>
+        </div>
+      </div>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {/* Header Section */}
+        <div className="grid lg:grid-cols-[450px,1fr] gap-12 mb-16">
+          {/* Left - Image */}
+          <div className="flex flex-col gap-4">
+            <Skeleton className="aspect-square w-full rounded-xl" />
+          </div>
+
+          {/* Right - Product Info */}
+          <div className="space-y-6">
+            {/* Title + Brand */}
+            <div>
+              <Skeleton className="h-9 w-3/4" />
+              <Skeleton className="h-4 w-24 mt-2" />
+            </div>
+
+            {/* Category badge */}
+            <div className="flex items-center gap-3">
+              <Skeleton className="h-8 w-28 rounded-md" />
+            </div>
+
+            <div className="h-px bg-border" />
+
+            {/* Overview */}
+            <div>
+              <Skeleton className="h-6 w-24 mb-3" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-5/6 mt-1" />
+              <Skeleton className="h-4 w-4/6 mt-1" />
+            </div>
+
+            {/* Active Ingredients */}
+            <div>
+              <Skeleton className="h-6 w-36 mb-3" />
+              <Skeleton className="h-4 w-48 mt-1" />
+            </div>
+
+            {/* Used On & Targets Grid */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="rounded-xl border bg-card p-4">
+                <Skeleton className="h-4 w-16 mb-3" />
+                <div className="space-y-2">
+                  {Array.from({ length: 4 }).map((_, i) => (
+                    <Skeleton key={i} className="h-4 w-24" />
+                  ))}
+                </div>
+              </div>
+              <div className="rounded-xl border bg-card p-4">
+                <Skeleton className="h-4 w-28 mb-3" />
+                <div className="space-y-2">
+                  {Array.from({ length: 4 }).map((_, i) => (
+                    <Skeleton key={i} className="h-4 w-32" />
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/client-fnp/app/(landing)/animal-health-guides/[category]/[slug]/loading.tsx
+++ b/apps/client-fnp/app/(landing)/animal-health-guides/[category]/[slug]/loading.tsx
@@ -1,0 +1,67 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-4 w-10" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-32" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-20" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-24" />
+          </div>
+        </div>
+      </div>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="grid lg:grid-cols-[450px,1fr] gap-12 mb-16">
+          <div className="flex flex-col gap-4">
+            <Skeleton className="aspect-square w-full rounded-xl" />
+          </div>
+          <div className="space-y-6">
+            <div>
+              <Skeleton className="h-9 w-3/4" />
+              <Skeleton className="h-4 w-24 mt-2" />
+            </div>
+            <div className="flex items-center gap-3">
+              <Skeleton className="h-8 w-28 rounded-md" />
+            </div>
+            <div className="h-px bg-border" />
+            <div>
+              <Skeleton className="h-6 w-24 mb-3" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-5/6 mt-1" />
+              <Skeleton className="h-4 w-4/6 mt-1" />
+            </div>
+            <div>
+              <Skeleton className="h-6 w-36 mb-3" />
+              <Skeleton className="h-4 w-48 mt-1" />
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="rounded-xl border bg-card p-4">
+                <Skeleton className="h-4 w-16 mb-3" />
+                <div className="space-y-2">
+                  {Array.from({ length: 4 }).map((_, i) => (
+                    <Skeleton key={i} className="h-4 w-24" />
+                  ))}
+                </div>
+              </div>
+              <div className="rounded-xl border bg-card p-4">
+                <Skeleton className="h-4 w-28 mb-3" />
+                <div className="space-y-2">
+                  {Array.from({ length: 4 }).map((_, i) => (
+                    <Skeleton key={i} className="h-4 w-32" />
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/apps/client-fnp/app/(landing)/book/[slug]/loading.tsx
+++ b/apps/client-fnp/app/(landing)/book/[slug]/loading.tsx
@@ -1,0 +1,43 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-4 w-10" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-28" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-24" />
+          </div>
+        </div>
+      </div>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Skeleton className="h-9 w-2/3 mb-2" />
+        <Skeleton className="h-4 w-24 mb-6" />
+        <div className="h-px bg-border mb-6" />
+        <div className="grid lg:grid-cols-[1fr_300px] gap-8">
+          <div className="space-y-4">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-5/6" />
+            <Skeleton className="h-4 w-4/6" />
+            <Skeleton className="h-64 w-full rounded-xl mt-4" />
+            <Skeleton className="h-4 w-full mt-4" />
+            <Skeleton className="h-4 w-3/4" />
+          </div>
+          <div className="space-y-4">
+            <div className="rounded-xl border bg-card p-4 space-y-3">
+              <Skeleton className="h-5 w-24" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-10 w-full rounded-md mt-2" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/apps/client-fnp/app/(landing)/bookings/[slug]/loading.tsx
+++ b/apps/client-fnp/app/(landing)/bookings/[slug]/loading.tsx
@@ -1,0 +1,43 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-4 w-10" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-28" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-24" />
+          </div>
+        </div>
+      </div>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Skeleton className="h-9 w-2/3 mb-2" />
+        <Skeleton className="h-4 w-24 mb-6" />
+        <div className="h-px bg-border mb-6" />
+        <div className="grid lg:grid-cols-[1fr_300px] gap-8">
+          <div className="space-y-4">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-5/6" />
+            <Skeleton className="h-4 w-4/6" />
+            <Skeleton className="h-64 w-full rounded-xl mt-4" />
+            <Skeleton className="h-4 w-full mt-4" />
+            <Skeleton className="h-4 w-3/4" />
+          </div>
+          <div className="space-y-4">
+            <div className="rounded-xl border bg-card p-4 space-y-3">
+              <Skeleton className="h-5 w-24" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-10 w-full rounded-md mt-2" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/apps/client-fnp/app/(landing)/buy-agrochemicals/[slug]/loading.tsx
+++ b/apps/client-fnp/app/(landing)/buy-agrochemicals/[slug]/loading.tsx
@@ -1,0 +1,70 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-4 w-10" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-32" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-24" />
+          </div>
+        </div>
+      </div>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="grid lg:grid-cols-[480px_1fr_300px] gap-6 items-start">
+          {/* Left - Image */}
+          <div className="flex flex-col gap-4">
+            <Skeleton className="aspect-square w-full rounded-xl" />
+            <div className="grid grid-cols-4 gap-2">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="aspect-square rounded-lg" />
+              ))}
+            </div>
+          </div>
+          {/* Middle - Info */}
+          <div className="space-y-5">
+            <div>
+              <Skeleton className="h-8 w-3/4" />
+              <Skeleton className="h-4 w-24 mt-2" />
+            </div>
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-7 w-24 rounded-md" />
+              <Skeleton className="h-7 w-20 rounded-md" />
+            </div>
+            <div className="h-px bg-border" />
+            <div>
+              <Skeleton className="h-5 w-20 mb-2" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-5/6 mt-1" />
+              <Skeleton className="h-4 w-3/6 mt-1" />
+            </div>
+            {/* Tabs placeholder */}
+            <div className="flex gap-4 border-b pb-2">
+              <Skeleton className="h-5 w-20" />
+              <Skeleton className="h-5 w-28" />
+              <Skeleton className="h-5 w-16" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-4/5" />
+              <Skeleton className="h-4 w-3/5" />
+            </div>
+          </div>
+          {/* Right - Price / Cart */}
+          <div className="rounded-xl border bg-card p-5 space-y-4">
+            <Skeleton className="h-8 w-24" />
+            <Skeleton className="h-4 w-32" />
+            <div className="h-px bg-border" />
+            <Skeleton className="h-10 w-full rounded-md" />
+            <Skeleton className="h-10 w-full rounded-md" />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/apps/client-fnp/app/(landing)/buy-animal-health/[slug]/loading.tsx
+++ b/apps/client-fnp/app/(landing)/buy-animal-health/[slug]/loading.tsx
@@ -1,0 +1,70 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-4 w-10" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-32" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-24" />
+          </div>
+        </div>
+      </div>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="grid lg:grid-cols-[480px_1fr_300px] gap-6 items-start">
+          {/* Left - Image */}
+          <div className="flex flex-col gap-4">
+            <Skeleton className="aspect-square w-full rounded-xl" />
+            <div className="grid grid-cols-4 gap-2">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="aspect-square rounded-lg" />
+              ))}
+            </div>
+          </div>
+          {/* Middle - Info */}
+          <div className="space-y-5">
+            <div>
+              <Skeleton className="h-8 w-3/4" />
+              <Skeleton className="h-4 w-24 mt-2" />
+            </div>
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-7 w-24 rounded-md" />
+              <Skeleton className="h-7 w-20 rounded-md" />
+            </div>
+            <div className="h-px bg-border" />
+            <div>
+              <Skeleton className="h-5 w-20 mb-2" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-5/6 mt-1" />
+              <Skeleton className="h-4 w-3/6 mt-1" />
+            </div>
+            {/* Tabs placeholder */}
+            <div className="flex gap-4 border-b pb-2">
+              <Skeleton className="h-5 w-20" />
+              <Skeleton className="h-5 w-28" />
+              <Skeleton className="h-5 w-16" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-4/5" />
+              <Skeleton className="h-4 w-3/5" />
+            </div>
+          </div>
+          {/* Right - Price / Cart */}
+          <div className="rounded-xl border bg-card p-5 space-y-4">
+            <Skeleton className="h-8 w-24" />
+            <Skeleton className="h-4 w-32" />
+            <div className="h-px bg-border" />
+            <Skeleton className="h-10 w-full rounded-md" />
+            <Skeleton className="h-10 w-full rounded-md" />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/apps/client-fnp/app/(landing)/buy-documents/[slug]/loading.tsx
+++ b/apps/client-fnp/app/(landing)/buy-documents/[slug]/loading.tsx
@@ -1,0 +1,70 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-4 w-10" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-32" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-24" />
+          </div>
+        </div>
+      </div>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="grid lg:grid-cols-[480px_1fr_300px] gap-6 items-start">
+          {/* Left - Image */}
+          <div className="flex flex-col gap-4">
+            <Skeleton className="aspect-square w-full rounded-xl" />
+            <div className="grid grid-cols-4 gap-2">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="aspect-square rounded-lg" />
+              ))}
+            </div>
+          </div>
+          {/* Middle - Info */}
+          <div className="space-y-5">
+            <div>
+              <Skeleton className="h-8 w-3/4" />
+              <Skeleton className="h-4 w-24 mt-2" />
+            </div>
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-7 w-24 rounded-md" />
+              <Skeleton className="h-7 w-20 rounded-md" />
+            </div>
+            <div className="h-px bg-border" />
+            <div>
+              <Skeleton className="h-5 w-20 mb-2" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-5/6 mt-1" />
+              <Skeleton className="h-4 w-3/6 mt-1" />
+            </div>
+            {/* Tabs placeholder */}
+            <div className="flex gap-4 border-b pb-2">
+              <Skeleton className="h-5 w-20" />
+              <Skeleton className="h-5 w-28" />
+              <Skeleton className="h-5 w-16" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-4/5" />
+              <Skeleton className="h-4 w-3/5" />
+            </div>
+          </div>
+          {/* Right - Price / Cart */}
+          <div className="rounded-xl border bg-card p-5 space-y-4">
+            <Skeleton className="h-8 w-24" />
+            <Skeleton className="h-4 w-32" />
+            <div className="h-px bg-border" />
+            <Skeleton className="h-10 w-full rounded-md" />
+            <Skeleton className="h-10 w-full rounded-md" />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/apps/client-fnp/app/(landing)/buy-equipment/[slug]/loading.tsx
+++ b/apps/client-fnp/app/(landing)/buy-equipment/[slug]/loading.tsx
@@ -1,0 +1,70 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-4 w-10" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-32" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-24" />
+          </div>
+        </div>
+      </div>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="grid lg:grid-cols-[480px_1fr_300px] gap-6 items-start">
+          {/* Left - Image */}
+          <div className="flex flex-col gap-4">
+            <Skeleton className="aspect-square w-full rounded-xl" />
+            <div className="grid grid-cols-4 gap-2">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="aspect-square rounded-lg" />
+              ))}
+            </div>
+          </div>
+          {/* Middle - Info */}
+          <div className="space-y-5">
+            <div>
+              <Skeleton className="h-8 w-3/4" />
+              <Skeleton className="h-4 w-24 mt-2" />
+            </div>
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-7 w-24 rounded-md" />
+              <Skeleton className="h-7 w-20 rounded-md" />
+            </div>
+            <div className="h-px bg-border" />
+            <div>
+              <Skeleton className="h-5 w-20 mb-2" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-5/6 mt-1" />
+              <Skeleton className="h-4 w-3/6 mt-1" />
+            </div>
+            {/* Tabs placeholder */}
+            <div className="flex gap-4 border-b pb-2">
+              <Skeleton className="h-5 w-20" />
+              <Skeleton className="h-5 w-28" />
+              <Skeleton className="h-5 w-16" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-4/5" />
+              <Skeleton className="h-4 w-3/5" />
+            </div>
+          </div>
+          {/* Right - Price / Cart */}
+          <div className="rounded-xl border bg-card p-5 space-y-4">
+            <Skeleton className="h-8 w-24" />
+            <Skeleton className="h-4 w-32" />
+            <div className="h-px bg-border" />
+            <Skeleton className="h-10 w-full rounded-md" />
+            <Skeleton className="h-10 w-full rounded-md" />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/apps/client-fnp/app/(landing)/buy-feeds/[slug]/loading.tsx
+++ b/apps/client-fnp/app/(landing)/buy-feeds/[slug]/loading.tsx
@@ -1,0 +1,70 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-4 w-10" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-32" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-24" />
+          </div>
+        </div>
+      </div>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="grid lg:grid-cols-[480px_1fr_300px] gap-6 items-start">
+          {/* Left - Image */}
+          <div className="flex flex-col gap-4">
+            <Skeleton className="aspect-square w-full rounded-xl" />
+            <div className="grid grid-cols-4 gap-2">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="aspect-square rounded-lg" />
+              ))}
+            </div>
+          </div>
+          {/* Middle - Info */}
+          <div className="space-y-5">
+            <div>
+              <Skeleton className="h-8 w-3/4" />
+              <Skeleton className="h-4 w-24 mt-2" />
+            </div>
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-7 w-24 rounded-md" />
+              <Skeleton className="h-7 w-20 rounded-md" />
+            </div>
+            <div className="h-px bg-border" />
+            <div>
+              <Skeleton className="h-5 w-20 mb-2" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-5/6 mt-1" />
+              <Skeleton className="h-4 w-3/6 mt-1" />
+            </div>
+            {/* Tabs placeholder */}
+            <div className="flex gap-4 border-b pb-2">
+              <Skeleton className="h-5 w-20" />
+              <Skeleton className="h-5 w-28" />
+              <Skeleton className="h-5 w-16" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-4/5" />
+              <Skeleton className="h-4 w-3/5" />
+            </div>
+          </div>
+          {/* Right - Price / Cart */}
+          <div className="rounded-xl border bg-card p-5 space-y-4">
+            <Skeleton className="h-8 w-24" />
+            <Skeleton className="h-4 w-32" />
+            <div className="h-px bg-border" />
+            <Skeleton className="h-10 w-full rounded-md" />
+            <Skeleton className="h-10 w-full rounded-md" />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/apps/client-fnp/app/(landing)/buy-plant-nutrition/[slug]/loading.tsx
+++ b/apps/client-fnp/app/(landing)/buy-plant-nutrition/[slug]/loading.tsx
@@ -1,0 +1,70 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-4 w-10" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-32" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-24" />
+          </div>
+        </div>
+      </div>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="grid lg:grid-cols-[480px_1fr_300px] gap-6 items-start">
+          {/* Left - Image */}
+          <div className="flex flex-col gap-4">
+            <Skeleton className="aspect-square w-full rounded-xl" />
+            <div className="grid grid-cols-4 gap-2">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="aspect-square rounded-lg" />
+              ))}
+            </div>
+          </div>
+          {/* Middle - Info */}
+          <div className="space-y-5">
+            <div>
+              <Skeleton className="h-8 w-3/4" />
+              <Skeleton className="h-4 w-24 mt-2" />
+            </div>
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-7 w-24 rounded-md" />
+              <Skeleton className="h-7 w-20 rounded-md" />
+            </div>
+            <div className="h-px bg-border" />
+            <div>
+              <Skeleton className="h-5 w-20 mb-2" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-5/6 mt-1" />
+              <Skeleton className="h-4 w-3/6 mt-1" />
+            </div>
+            {/* Tabs placeholder */}
+            <div className="flex gap-4 border-b pb-2">
+              <Skeleton className="h-5 w-20" />
+              <Skeleton className="h-5 w-28" />
+              <Skeleton className="h-5 w-16" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-4/5" />
+              <Skeleton className="h-4 w-3/5" />
+            </div>
+          </div>
+          {/* Right - Price / Cart */}
+          <div className="rounded-xl border bg-card p-5 space-y-4">
+            <Skeleton className="h-8 w-24" />
+            <Skeleton className="h-4 w-32" />
+            <div className="h-px bg-border" />
+            <Skeleton className="h-10 w-full rounded-md" />
+            <Skeleton className="h-10 w-full rounded-md" />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/apps/client-fnp/app/(landing)/buy-seed-products/[slug]/loading.tsx
+++ b/apps/client-fnp/app/(landing)/buy-seed-products/[slug]/loading.tsx
@@ -1,0 +1,70 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-4 w-10" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-32" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-24" />
+          </div>
+        </div>
+      </div>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="grid lg:grid-cols-[480px_1fr_300px] gap-6 items-start">
+          {/* Left - Image */}
+          <div className="flex flex-col gap-4">
+            <Skeleton className="aspect-square w-full rounded-xl" />
+            <div className="grid grid-cols-4 gap-2">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="aspect-square rounded-lg" />
+              ))}
+            </div>
+          </div>
+          {/* Middle - Info */}
+          <div className="space-y-5">
+            <div>
+              <Skeleton className="h-8 w-3/4" />
+              <Skeleton className="h-4 w-24 mt-2" />
+            </div>
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-7 w-24 rounded-md" />
+              <Skeleton className="h-7 w-20 rounded-md" />
+            </div>
+            <div className="h-px bg-border" />
+            <div>
+              <Skeleton className="h-5 w-20 mb-2" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-5/6 mt-1" />
+              <Skeleton className="h-4 w-3/6 mt-1" />
+            </div>
+            {/* Tabs placeholder */}
+            <div className="flex gap-4 border-b pb-2">
+              <Skeleton className="h-5 w-20" />
+              <Skeleton className="h-5 w-28" />
+              <Skeleton className="h-5 w-16" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-4/5" />
+              <Skeleton className="h-4 w-3/5" />
+            </div>
+          </div>
+          {/* Right - Price / Cart */}
+          <div className="rounded-xl border bg-card p-5 space-y-4">
+            <Skeleton className="h-8 w-24" />
+            <Skeleton className="h-4 w-32" />
+            <div className="h-px bg-border" />
+            <Skeleton className="h-10 w-full rounded-md" />
+            <Skeleton className="h-10 w-full rounded-md" />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/apps/client-fnp/app/(landing)/documents/[slug]/loading.tsx
+++ b/apps/client-fnp/app/(landing)/documents/[slug]/loading.tsx
@@ -1,0 +1,43 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-4 w-10" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-28" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-24" />
+          </div>
+        </div>
+      </div>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Skeleton className="h-9 w-2/3 mb-2" />
+        <Skeleton className="h-4 w-24 mb-6" />
+        <div className="h-px bg-border mb-6" />
+        <div className="grid lg:grid-cols-[1fr_300px] gap-8">
+          <div className="space-y-4">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-5/6" />
+            <Skeleton className="h-4 w-4/6" />
+            <Skeleton className="h-64 w-full rounded-xl mt-4" />
+            <Skeleton className="h-4 w-full mt-4" />
+            <Skeleton className="h-4 w-3/4" />
+          </div>
+          <div className="space-y-4">
+            <div className="rounded-xl border bg-card p-4 space-y-3">
+              <Skeleton className="h-5 w-24" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-10 w-full rounded-md mt-2" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/apps/client-fnp/app/(landing)/equipment-guides/[category]/[slug]/loading.tsx
+++ b/apps/client-fnp/app/(landing)/equipment-guides/[category]/[slug]/loading.tsx
@@ -1,0 +1,67 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-4 w-10" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-32" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-20" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-24" />
+          </div>
+        </div>
+      </div>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="grid lg:grid-cols-[450px,1fr] gap-12 mb-16">
+          <div className="flex flex-col gap-4">
+            <Skeleton className="aspect-square w-full rounded-xl" />
+          </div>
+          <div className="space-y-6">
+            <div>
+              <Skeleton className="h-9 w-3/4" />
+              <Skeleton className="h-4 w-24 mt-2" />
+            </div>
+            <div className="flex items-center gap-3">
+              <Skeleton className="h-8 w-28 rounded-md" />
+            </div>
+            <div className="h-px bg-border" />
+            <div>
+              <Skeleton className="h-6 w-24 mb-3" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-5/6 mt-1" />
+              <Skeleton className="h-4 w-4/6 mt-1" />
+            </div>
+            <div>
+              <Skeleton className="h-6 w-36 mb-3" />
+              <Skeleton className="h-4 w-48 mt-1" />
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="rounded-xl border bg-card p-4">
+                <Skeleton className="h-4 w-16 mb-3" />
+                <div className="space-y-2">
+                  {Array.from({ length: 4 }).map((_, i) => (
+                    <Skeleton key={i} className="h-4 w-24" />
+                  ))}
+                </div>
+              </div>
+              <div className="rounded-xl border bg-card p-4">
+                <Skeleton className="h-4 w-28 mb-3" />
+                <div className="space-y-2">
+                  {Array.from({ length: 4 }).map((_, i) => (
+                    <Skeleton key={i} className="h-4 w-32" />
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/apps/client-fnp/app/(landing)/feed-guides/[slug]/loading.tsx
+++ b/apps/client-fnp/app/(landing)/feed-guides/[slug]/loading.tsx
@@ -1,0 +1,67 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-4 w-10" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-32" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-20" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-24" />
+          </div>
+        </div>
+      </div>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="grid lg:grid-cols-[450px,1fr] gap-12 mb-16">
+          <div className="flex flex-col gap-4">
+            <Skeleton className="aspect-square w-full rounded-xl" />
+          </div>
+          <div className="space-y-6">
+            <div>
+              <Skeleton className="h-9 w-3/4" />
+              <Skeleton className="h-4 w-24 mt-2" />
+            </div>
+            <div className="flex items-center gap-3">
+              <Skeleton className="h-8 w-28 rounded-md" />
+            </div>
+            <div className="h-px bg-border" />
+            <div>
+              <Skeleton className="h-6 w-24 mb-3" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-5/6 mt-1" />
+              <Skeleton className="h-4 w-4/6 mt-1" />
+            </div>
+            <div>
+              <Skeleton className="h-6 w-36 mb-3" />
+              <Skeleton className="h-4 w-48 mt-1" />
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="rounded-xl border bg-card p-4">
+                <Skeleton className="h-4 w-16 mb-3" />
+                <div className="space-y-2">
+                  {Array.from({ length: 4 }).map((_, i) => (
+                    <Skeleton key={i} className="h-4 w-24" />
+                  ))}
+                </div>
+              </div>
+              <div className="rounded-xl border bg-card p-4">
+                <Skeleton className="h-4 w-28 mb-3" />
+                <div className="space-y-2">
+                  {Array.from({ length: 4 }).map((_, i) => (
+                    <Skeleton key={i} className="h-4 w-32" />
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/apps/client-fnp/app/(landing)/feeding-programs/[slug]/loading.tsx
+++ b/apps/client-fnp/app/(landing)/feeding-programs/[slug]/loading.tsx
@@ -1,0 +1,43 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-4 w-10" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-28" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-24" />
+          </div>
+        </div>
+      </div>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Skeleton className="h-9 w-2/3 mb-2" />
+        <Skeleton className="h-4 w-24 mb-6" />
+        <div className="h-px bg-border mb-6" />
+        <div className="grid lg:grid-cols-[1fr_300px] gap-8">
+          <div className="space-y-4">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-5/6" />
+            <Skeleton className="h-4 w-4/6" />
+            <Skeleton className="h-64 w-full rounded-xl mt-4" />
+            <Skeleton className="h-4 w-full mt-4" />
+            <Skeleton className="h-4 w-3/4" />
+          </div>
+          <div className="space-y-4">
+            <div className="rounded-xl border bg-card p-4 space-y-3">
+              <Skeleton className="h-5 w-24" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-10 w-full rounded-md mt-2" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/apps/client-fnp/app/(landing)/lots/[slug]/loading.tsx
+++ b/apps/client-fnp/app/(landing)/lots/[slug]/loading.tsx
@@ -1,0 +1,43 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-4 w-10" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-28" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-24" />
+          </div>
+        </div>
+      </div>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Skeleton className="h-9 w-2/3 mb-2" />
+        <Skeleton className="h-4 w-24 mb-6" />
+        <div className="h-px bg-border mb-6" />
+        <div className="grid lg:grid-cols-[1fr_300px] gap-8">
+          <div className="space-y-4">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-5/6" />
+            <Skeleton className="h-4 w-4/6" />
+            <Skeleton className="h-64 w-full rounded-xl mt-4" />
+            <Skeleton className="h-4 w-full mt-4" />
+            <Skeleton className="h-4 w-3/4" />
+          </div>
+          <div className="space-y-4">
+            <div className="rounded-xl border bg-card p-4 space-y-3">
+              <Skeleton className="h-5 w-24" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-10 w-full rounded-md mt-2" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/apps/client-fnp/app/(landing)/plant-nutrition-guides/[category]/[slug]/loading.tsx
+++ b/apps/client-fnp/app/(landing)/plant-nutrition-guides/[category]/[slug]/loading.tsx
@@ -1,0 +1,67 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-4 w-10" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-32" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-20" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-24" />
+          </div>
+        </div>
+      </div>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="grid lg:grid-cols-[450px,1fr] gap-12 mb-16">
+          <div className="flex flex-col gap-4">
+            <Skeleton className="aspect-square w-full rounded-xl" />
+          </div>
+          <div className="space-y-6">
+            <div>
+              <Skeleton className="h-9 w-3/4" />
+              <Skeleton className="h-4 w-24 mt-2" />
+            </div>
+            <div className="flex items-center gap-3">
+              <Skeleton className="h-8 w-28 rounded-md" />
+            </div>
+            <div className="h-px bg-border" />
+            <div>
+              <Skeleton className="h-6 w-24 mb-3" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-5/6 mt-1" />
+              <Skeleton className="h-4 w-4/6 mt-1" />
+            </div>
+            <div>
+              <Skeleton className="h-6 w-36 mb-3" />
+              <Skeleton className="h-4 w-48 mt-1" />
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="rounded-xl border bg-card p-4">
+                <Skeleton className="h-4 w-16 mb-3" />
+                <div className="space-y-2">
+                  {Array.from({ length: 4 }).map((_, i) => (
+                    <Skeleton key={i} className="h-4 w-24" />
+                  ))}
+                </div>
+              </div>
+              <div className="rounded-xl border bg-card p-4">
+                <Skeleton className="h-4 w-28 mb-3" />
+                <div className="space-y-2">
+                  {Array.from({ length: 4 }).map((_, i) => (
+                    <Skeleton key={i} className="h-4 w-32" />
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/apps/client-fnp/app/(landing)/seed-guides/[slug]/loading.tsx
+++ b/apps/client-fnp/app/(landing)/seed-guides/[slug]/loading.tsx
@@ -1,0 +1,67 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-4 w-10" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-32" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-20" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-24" />
+          </div>
+        </div>
+      </div>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="grid lg:grid-cols-[450px,1fr] gap-12 mb-16">
+          <div className="flex flex-col gap-4">
+            <Skeleton className="aspect-square w-full rounded-xl" />
+          </div>
+          <div className="space-y-6">
+            <div>
+              <Skeleton className="h-9 w-3/4" />
+              <Skeleton className="h-4 w-24 mt-2" />
+            </div>
+            <div className="flex items-center gap-3">
+              <Skeleton className="h-8 w-28 rounded-md" />
+            </div>
+            <div className="h-px bg-border" />
+            <div>
+              <Skeleton className="h-6 w-24 mb-3" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-5/6 mt-1" />
+              <Skeleton className="h-4 w-4/6 mt-1" />
+            </div>
+            <div>
+              <Skeleton className="h-6 w-36 mb-3" />
+              <Skeleton className="h-4 w-48 mt-1" />
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div className="rounded-xl border bg-card p-4">
+                <Skeleton className="h-4 w-16 mb-3" />
+                <div className="space-y-2">
+                  {Array.from({ length: 4 }).map((_, i) => (
+                    <Skeleton key={i} className="h-4 w-24" />
+                  ))}
+                </div>
+              </div>
+              <div className="rounded-xl border bg-card p-4">
+                <Skeleton className="h-4 w-28 mb-3" />
+                <div className="space-y-2">
+                  {Array.from({ length: 4 }).map((_, i) => (
+                    <Skeleton key={i} className="h-4 w-32" />
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/apps/client-fnp/app/(landing)/spray-programs/[slug]/loading.tsx
+++ b/apps/client-fnp/app/(landing)/spray-programs/[slug]/loading.tsx
@@ -1,0 +1,43 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-4 w-10" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-28" />
+            <span className="mx-1 text-muted-foreground">/</span>
+            <Skeleton className="h-4 w-24" />
+          </div>
+        </div>
+      </div>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Skeleton className="h-9 w-2/3 mb-2" />
+        <Skeleton className="h-4 w-24 mb-6" />
+        <div className="h-px bg-border mb-6" />
+        <div className="grid lg:grid-cols-[1fr_300px] gap-8">
+          <div className="space-y-4">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-5/6" />
+            <Skeleton className="h-4 w-4/6" />
+            <Skeleton className="h-64 w-full rounded-xl mt-4" />
+            <Skeleton className="h-4 w-full mt-4" />
+            <Skeleton className="h-4 w-3/4" />
+          </div>
+          <div className="space-y-4">
+            <div className="rounded-xl border bg-card p-4 space-y-3">
+              <Skeleton className="h-5 w-24" />
+              <Skeleton className="h-4 w-full" />
+              <Skeleton className="h-4 w-3/4" />
+              <Skeleton className="h-10 w-full rounded-md mt-2" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "6.5.1",
+  "version": "6.6.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- 19 skeleton loading states for all product detail pages
- Guide pages, buy/shop pages, and content pages covered
- Shows structured skeleton UI while server components fetch data

## Test plan
- [ ] Navigate to any agrochemical guide page and observe skeleton
- [ ] Navigate to any buy page and observe skeleton
- [ ] Navigate to spray programs / feeding programs and observe skeleton