### PR TITLE
Add broker badge and brokerage label for Urban Fresh

### DIFF
--- a/apps/client-fnp/components/layouts/buyer-contacts.tsx
+++ b/apps/client-fnp/components/layouts/buyer-contacts.tsx
@@ -27,6 +27,11 @@ export function BuyerContactsCard({ buyer, user }: BuyerContactsCardProps) {
           {buyer.verified && (
             <BadgeCheck className="h-4 w-4 flex-shrink-0 text-green-700" aria-hidden="true" />
           )}
+          {buyer.sub_type === "broker" && buyer.broker_label && (
+            <Badge variant="secondary" className="bg-amber-50 text-amber-700 border-amber-200 hover:bg-amber-50 text-[10px] rounded-md">
+              {buyer.broker_label}
+            </Badge>
+          )}
           {buyer.has_prices && (
             <Badge variant="secondary" className="bg-green-50 text-green-700 border-green-200 hover:bg-green-50 text-[10px] rounded-md">
               Pricing Available

--- a/apps/client-fnp/components/layouts/client.tsx
+++ b/apps/client-fnp/components/layouts/client.tsx
@@ -91,7 +91,7 @@ export function Client({ slug, type, user, latestPrices }: ClientPageProps) {
               <div className="flex-1 min-w-0 text-center sm:text-left">
                 <h1 className="text-xl sm:text-2xl font-bold tracking-tight mb-1">{name}</h1>
                 <div className="flex flex-wrap items-center justify-center sm:justify-start gap-1.5 mb-2">
-                  <Badge variant="secondary" className="text-[10px]">{capitalizeFirstLetter(client.type)}</Badge>
+                  <Badge variant="secondary" className="text-[10px]">{client.sub_type === "broker" && client.broker_label ? client.broker_label : capitalizeFirstLetter(client.type)}</Badge>
                   {client.verified ? (
                     <Badge className="bg-green-100 text-green-800 hover:bg-green-100 border-green-200 text-[10px]">
                       <Icons.verified className="h-3 w-3 mr-1" />Verified
@@ -236,7 +236,7 @@ export function Client({ slug, type, user, latestPrices }: ClientPageProps) {
             {/* Produces */}
             {produces.length > 0 && (
               <div className="border rounded-lg p-4">
-                <h3 className="text-sm font-semibold mb-3">{client.type === "buyer" ? "Products They Buy" : "Products They Sell"}</h3>
+                <h3 className="text-sm font-semibold mb-3">{client.sub_type === "broker" ? "Products Under Brokerage" : client.type === "buyer" ? "Products They Buy" : "Products They Sell"}</h3>
                 <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2">
                   {produces.map((p) => (
                     <span key={p} className="text-xs px-3 py-2 rounded-md bg-muted/50 text-muted-foreground text-center">{p}</span>

--- a/apps/client-fnp/lib/schemas.ts
+++ b/apps/client-fnp/lib/schemas.ts
@@ -128,6 +128,8 @@ export const ApplicationUserSchema = z.object({
     updated: z.string(),
     confirmed: z.boolean(),
     type: z.string().nonempty(),
+    sub_type: z.string().optional(),
+    broker_label: z.string().optional(),
     phase: z.string(),
     admin: z.object({
         id: z.string(),


### PR DESCRIPTION
## Summary
- Show broker_label badge instead of "Buyer" when client has sub_type=broker
- Show "Products Under Brokerage" instead of "Products They Buy" for brokers
- Add sub_type and broker_label to frontend schema