### PR TITLE
refactor: shared GuideDetailLayout for all guide pages

### DIFF
--- a/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/[slug]/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from 'next'
 import { serverFetch } from "@/lib/serverFetch"
 import { ActiveIngredientsList } from "@/components/shared/ActiveIngredientUnitsKey"
-import Image from "next/image"
-import { AlertTriangle } from "lucide-react"
-import Link from "next/link"
-import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
-import { SidebarPromo } from "@/components/ads/SidebarPromo"
 import { capitalizeFirstLetter, buildGuideMetadata } from "@/lib/utilities"
 import { ProductNotFound } from "@/components/shared/ProductNotFound"
 import { guardTestItem } from "@/lib/guardTestItem"
@@ -13,9 +8,7 @@ import { SprayProgramBackLink } from "./SprayProgramBackLink"
 import { FertilizerApplicationRates } from "@/components/agrochemical/FertilizerApplicationRates"
 import { AgrochemicalDosageTable } from "@/components/agrochemical/AgrochemicalDosageTable"
 import { ProductTargets } from "@/components/agrochemical/ProductTargets"
-import { WantToBuyCTA } from "@/components/shared/WantToBuyCTA"
-import { GuideProductTitle } from "@/components/shared/GuideProductTitle"
-import { ShareBar } from "@/components/shared/ShareBar"
+import { GuideDetailLayout } from "@/components/shared/GuideDetailLayout"
 
 type Props = { params: Promise<{ category: string; slug: string }> }
 
@@ -47,53 +40,52 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return buildGuideMetadata(chemical, categorySingularTitle, 'Dosage, Label & Guide', description, `/agrochemical-guides/${category}/${slug}`, chemical.images?.[0]?.img?.src, keywords)
 }
 
+const overviewDesc: Record<string, string> = {
+    herbicides: "a herbicide used for weed management and control. It helps suppress unwanted weed growth while protecting crops when applied according to recommended guidelines.",
+    insecticides: "an insecticide formulated for effective pest control. It targets harmful insects while maintaining crop safety when used as directed.",
+    fungicides: "a fungicide designed to prevent and control fungal diseases. It provides protective and curative action to keep crops healthy throughout the growing season.",
+    acaricides: "an acaricide developed for mite and tick control. It effectively manages mite populations while being safe for crops when applied correctly.",
+    nematicides: "a nematicide used to control plant-parasitic nematodes. It protects root systems and promotes healthy crop development.",
+    rodenticides: "a rodenticide formulated for rodent control in agricultural settings. It helps protect stored crops and field produce from rodent damage.",
+    molluscicides: "a molluscicide designed to control snails and slugs. It protects crops from mollusc damage during vulnerable growth stages.",
+    bactericides: "a bactericide used to manage bacterial infections in crops. It helps prevent the spread of bacterial diseases and supports plant health.",
+}
+
+const targetLabel: Record<string, string> = {
+    herbicides: "Target Weeds",
+    insecticides: "Target Pests",
+    fungicides: "Target Diseases",
+    acaricides: "Target Mites & Ticks",
+    nematicides: "Target Nematodes",
+    rodenticides: "Target Rodents",
+    molluscicides: "Target Molluscs",
+    bactericides: "Target Bacteria",
+    "foliar-feeds": "Targets",
+    fertilizers: "Targets",
+    "plant-nutrition": "Targets",
+    biostimulants: "Targets",
+}
+
+const DISCLAIMER = "Disclaimer: The information provided on this page, including active ingredients, dosage rates, application methods, and safety guidelines, has been compiled from publicly available product labels, manufacturer datasheets, and other third-party sources. Farmnport does not manufacture, formulate, or independently verify the accuracy, completeness, or currency of this information. Product formulations, registrations, and label directions may change without notice. Always refer to the official product label accompanying the purchased product for the most up-to-date and legally binding instructions. Farmnport accepts no liability for any loss, damage, crop injury, or adverse outcome arising from the use of, or reliance on, the information presented here. Use of any agrochemical product is entirely at the user's own risk."
+
 interface GuidePageProps {
-    params: Promise<{
-        category: string
-        slug: string
-    }>
+    params: Promise<{ category: string; slug: string }>
 }
 
 export default async function AgroChemicalGuidePage({ params }: GuidePageProps) {
     const { category, slug } = await params
-
     const chemical = await serverFetch(`/agrochemical/${slug}`).catch(() => null)
 
     await guardTestItem(!!chemical?.is_test)
-
-    const categorySlug = chemical?.agrochemical_category?.slug || ""
-    const targetLabel: Record<string, string> = {
-        herbicides: "Target Weeds",
-        insecticides: "Target Pests",
-        fungicides: "Target Diseases",
-        acaricides: "Target Mites & Ticks",
-        nematicides: "Target Nematodes",
-        rodenticides: "Target Rodents",
-        molluscicides: "Target Molluscs",
-        bactericides: "Target Bacteria",
-        "foliar-feeds": "Targets",
-        fertilizers: "Targets",
-        "plant-nutrition": "Targets",
-        biostimulants: "Targets",
-    }
-    const overviewDesc: Record<string, string> = {
-        herbicides: "a herbicide used for weed management and control. It helps suppress unwanted weed growth while protecting crops when applied according to recommended guidelines.",
-        insecticides: "an insecticide formulated for effective pest control. It targets harmful insects while maintaining crop safety when used as directed.",
-        fungicides: "a fungicide designed to prevent and control fungal diseases. It provides protective and curative action to keep crops healthy throughout the growing season.",
-        acaricides: "an acaricide developed for mite and tick control. It effectively manages mite populations while being safe for crops when applied correctly.",
-        nematicides: "a nematicide used to control plant-parasitic nematodes. It protects root systems and promotes healthy crop development.",
-        rodenticides: "a rodenticide formulated for rodent control in agricultural settings. It helps protect stored crops and field produce from rodent damage.",
-        molluscicides: "a molluscicide designed to control snails and slugs. It protects crops from mollusc damage during vulnerable growth stages.",
-        bactericides: "a bactericide used to manage bacterial infections in crops. It helps prevent the spread of bacterial diseases and supports plant health.",
-    }
-    const sectionTitle = targetLabel[categorySlug] || "Targets"
-    const noTargetMsg = `No ${sectionTitle.toLowerCase()} information available.`
 
     if (!chemical) {
         return <ProductNotFound title="AgroChemical Guide Not Found" description="The agrochemical guide you're looking for doesn't exist or may have been removed." primary={{ href: "/agrochemical-guides", label: "Browse AgroChemical Guides" }} secondary={{ href: "/buy-agrochemicals", label: "Buy AgroChemicals" }} />
     }
 
-    // Generate JSON-LD structured data
+    const categorySlug = chemical?.agrochemical_category?.slug || ""
+    const sectionTitle = targetLabel[categorySlug] || "Targets"
+    const noTargetMsg = `No ${sectionTitle.toLowerCase()} information available.`
+
     const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://farmnport.com'
     const url = `${baseUrl}/agrochemical-guides/${category}/${slug}`
     const imageUrl = chemical.images?.[0]?.img?.src || `${baseUrl}/default-chemical.png`
@@ -102,10 +94,6 @@ export default async function AgroChemicalGuidePage({ params }: GuidePageProps) 
         ? `${chemical.name} is a ${chemical.agrochemical_category.name} for effective pest and disease control. View active ingredients, dosage rates, and application guidelines.`
         : `Professional agrochemical guide for ${chemical.name}. Complete information on active ingredients, dosage rates, and safe application.`
 
-    const usageInfo = chemical.dosage_rates?.length > 0
-        ? `Dosage rates available for ${chemical.dosage_rates.map((r: any) => r.crop).join(', ')}`
-        : undefined
-
     const breadcrumbJsonLd = {
         "@context": "https://schema.org",
         "@type": "BreadcrumbList",
@@ -113,7 +101,7 @@ export default async function AgroChemicalGuidePage({ params }: GuidePageProps) 
             { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://farmnport.com" },
             { "@type": "ListItem", "position": 2, "name": "Agrochemical Guides", "item": "https://farmnport.com/agrochemical-guides" },
             { "@type": "ListItem", "position": 3, "name": chemical.agrochemical_category?.name || category, "item": `https://farmnport.com/agrochemical-guides/${category}` },
-            { "@type": "ListItem", "position": 4, "name": chemical.name, "item": `https://farmnport.com/agrochemical-guides/${category}/${slug}` },
+            { "@type": "ListItem", "position": 4, "name": chemical.name, "item": url },
         ],
     }
 
@@ -138,242 +126,81 @@ export default async function AgroChemicalGuidePage({ params }: GuidePageProps) 
             })) || [])
         ],
         "applicationCategory": "Agricultural Chemical",
-        "usageInfo": usageInfo
     }
 
+    const dosageTable = chemical.dosage_rates?.length > 0 ? (
+        chemical.dosage_rates.every((r: any) => !r.crop_group_id && r.crop_group)
+            ? <FertilizerApplicationRates dosageRates={chemical.dosage_rates} />
+            : <AgrochemicalDosageTable dosageRates={chemical.dosage_rates} />
+    ) : null
+
     return (
-        <div className="min-h-screen bg-background">
-            {/* JSON-LD Structured Data */}
-            <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
-            <script
-                type="application/ld+json"
-                dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
-            />
-
-            {/* Back to Spray Program */}
-            <SprayProgramBackLink />
-
-            {/* Breadcrumb */}
-            <div className="border-b">
-                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
-                    <nav className="flex text-sm text-muted-foreground">
-                        <Link href="/" className="hover:text-foreground">Home</Link>
-                        <span className="mx-2">/</span>
-                        <Link href="/agrochemical-guides" className="hover:text-foreground">Agrochemical Guides</Link>
-                        <span className="mx-2">/</span>
-                        <Link href={`/agrochemical-guides/${category}`} className="hover:text-foreground capitalize">{chemical.agrochemical_category?.name || category}</Link>
-                        <span className="mx-2">/</span>
-                        <span className="text-foreground capitalize">{chemical.name}</span>
-                    </nav>
-                </div>
+        <GuideDetailLayout
+            product={chemical}
+            breadcrumbs={[
+                { label: "Agrochemical Guides", href: "/agrochemical-guides" },
+                { label: chemical.agrochemical_category?.name || category, href: `/agrochemical-guides/${category}` },
+                { label: chemical.name, href: url },
+            ]}
+            categoryBadge={chemical.agrochemical_category ? { label: chemical.agrochemical_category.name } : undefined}
+            buyHref={`/buy-agrochemicals/${slug}`}
+            interestHref={`/interest/agrochemical/${slug}`}
+            safetyText="Always read and follow label directions. Wear appropriate personal protective equipment (PPE) when handling agrochemicals. Store in original containers in a secure location away from children and animals. Dispose of containers properly according to local regulations."
+            disclaimerText={DISCLAIMER}
+            structuredData={structuredData}
+            breadcrumbJsonLd={breadcrumbJsonLd}
+            topContent={<SprayProgramBackLink />}
+            bottomContent={dosageTable}
+        >
+            {/* Overview */}
+            <div>
+                <h2 className="text-lg font-semibold mb-3 text-foreground">Overview</h2>
+                <p className="text-muted-foreground leading-relaxed text-sm">
+                    {chemical.product_overview ? (
+                        chemical.product_overview
+                    ) : chemical.agrochemical_category?.slug ? (
+                        <><span className="font-medium text-foreground">{capitalizeFirstLetter(chemical.name)}</span> is {overviewDesc[chemical.agrochemical_category.slug] || `a ${chemical.agrochemical_category.name.toLowerCase().replace(/s$/, '')} for effective crop protection. It provides targeted action while ensuring crop safety when used according to recommended guidelines.`}</>
+                    ) : (
+                        <><span className="font-medium text-foreground">{chemical.name}</span> is a professional agrochemical solution for crop protection and management in agricultural applications.</>
+                    )}
+                </p>
             </div>
 
-            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-                {/* Header Section */}
-                <div className="grid lg:grid-cols-[450px,1fr] gap-12 mb-16">
-                    {/* Left - Image */}
-                    <div className="flex flex-col gap-4">
-                        <div className="relative aspect-square bg-muted/30 dark:bg-white rounded-xl border overflow-hidden shadow-sm">
-                            {chemical.images && chemical.images[0] && chemical.images[0].img?.src ? (
-                                <Image
-                                    src={chemical.images[0].img.src}
-                                    alt={chemical.name}
-                                    fill
-                                    sizes="(max-width: 1024px) 100vw, 450px"
-                                    className="object-contain p-8"
-                                    priority
-                                />
-                            ) : (
-                                <div className="absolute inset-0 bg-muted/30" />
-                            )}
-                        </div>
+            {/* Active Ingredients */}
+            <div>
+                <h2 className="text-lg font-semibold mb-1 text-foreground">Active Ingredients</h2>
+                <ActiveIngredientsList activeIngredients={chemical.active_ingredients || []} />
+            </div>
 
-                        {/* Thumbnail Gallery - if multiple images */}
-                        {chemical.images && chemical.images.length > 1 && (
-                            <div className="grid grid-cols-4 gap-3">
-                                {chemical.images.slice(0, 4).map((img: any, idx: number) => (
-                                    <div
-                                        key={idx}
-                                        className="relative aspect-square bg-muted/30 dark:bg-white rounded-lg border hover:border-primary transition-colors"
-                                    >
-                                        {img.img?.src && (
-                                            <Image
-                                                src={img.img.src}
-                                                alt={`${chemical.name} ${idx + 1}`}
-                                                fill
-                                                sizes="(max-width: 1024px) 25vw, 100px"
-                                                className="object-contain p-2"
-                                            />
-                                        )}
-                                    </div>
-                                ))}
-                            </div>
-                        )}
-
-                        {/* Want to Buy CTA */}
-                        <WantToBuyCTA available_for_sale={chemical.available_for_sale} name={chemical.name} brand={chemical.brand?.name} href={`/buy-agrochemicals/${slug}`} interestHref={`/interest/agrochemical/${slug}`} />
-
-                        {/* Precautions */}
-                        {chemical.precautions && chemical.precautions.length > 0 && (
-                            <div className="rounded-lg border border-red-200 dark:border-red-900 bg-red-50/50 dark:bg-red-950/30 px-3 py-2">
-                                <h2 className="text-xs font-semibold uppercase tracking-wide text-red-700 dark:text-red-400 mb-1.5 flex items-center gap-1.5">
-                                    <AlertTriangle className="w-3.5 h-3.5" />
-                                    Precautions
-                                </h2>
-                                <ul className="space-y-0.5">
-                                    {chemical.precautions.map((precaution: string, idx: number) => (
-                                        <li key={idx} className="flex items-start gap-1.5 text-xs text-red-800 dark:text-red-300">
-                                            <span className="h-1 w-1 rounded-full bg-red-500 dark:bg-red-400 flex-shrink-0 mt-1.5" />
-                                            <span>{precaution}</span>
-                                        </li>
-                                    ))}
-                                </ul>
-                            </div>
-                        )}
-
-                        {/* Promo - fills remaining sidebar space */}
-                        <div className="flex-1">
-                            <SidebarPromo />
-                        </div>
-                    </div>
-
-                    {/* Right - Product Info */}
-                    <div className="space-y-6">
-                        {/* Product Name */}
-                        <GuideProductTitle name={chemical.name} brand={chemical.brand?.name} />
-                        <div className="mt-3 flex items-center flex-wrap gap-3">
-                            {chemical.agrochemical_category && (
-                                <div className="inline-flex items-center px-3 py-1 rounded-md text-sm font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300">
-                                    {chemical.agrochemical_category.name}
-                                </div>
-                            )}
-                            <ShareBar name={chemical.name} />
-                        </div>
-
-                        {/* Divider */}
-                        <div className="h-px bg-border" />
-
-                        {/* Overview */}
-                        <div>
-                            <h2 className="text-lg font-semibold mb-3 text-foreground">Overview</h2>
-                            <p className="text-muted-foreground leading-relaxed text-sm">
-                                {chemical.product_overview ? (
-                                    chemical.product_overview
-                                ) : chemical.agrochemical_category?.slug ? (
-                                    <><span className="font-medium text-foreground">{capitalizeFirstLetter(chemical.name)}</span> is {overviewDesc[chemical.agrochemical_category.slug] || `a ${chemical.agrochemical_category.name.toLowerCase().replace(/s$/, '')} for effective crop protection. It provides targeted action while ensuring crop safety when used according to recommended guidelines.`}</>
-                                ) : (
-                                    <><span className="font-medium text-foreground">{chemical.name}</span> is a professional agrochemical solution for crop protection and management in agricultural applications.</>
-                                )}
-                            </p>
-                        </div>
-
-                        {/* Active Ingredients Section */}
-                        <div>
-                            <h2 className="text-lg font-semibold mb-1 text-foreground">Active Ingredients</h2>
-                            <ActiveIngredientsList activeIngredients={chemical.active_ingredients || []} />
-                        </div>
-
-                        {/* AdSense Ad */}
-                        <AdSenseInFeed />
-
-                        {/* Used On & Targets Grid */}
-                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:h-[315px]">
-                            {/* Used On Section */}
-                            {chemical.dosage_rates && chemical.dosage_rates.length > 0 && (
-                                <div className="rounded-xl border bg-card p-4 overflow-y-auto">
-                                    <h2 className="text-sm font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-400 mb-3">
-                                        Used On
-                                    </h2>
-                                    <ul className="space-y-1.5">
-                                        {Array.from(new Set(chemical.dosage_rates.flatMap((rate: any) => {
-                                            if (rate.crop_group_items?.length > 0) return rate.crop_group_items
-                                            if (rate.crop) return [rate.crop]
-                                            if (rate.crop_group) return [rate.crop_group]
-                                            return []
-                                        }))).map((crop: any, idx: number) => (
-                                            <li key={idx} className="flex items-center gap-2 text-sm text-foreground">
-                                                <span className="h-1.5 w-1.5 rounded-full bg-amber-500 dark:bg-amber-400 flex-shrink-0" />
-                                                <span className="capitalize">{crop}</span>
-                                            </li>
-                                        ))}
-                                    </ul>
-                                </div>
-                            )}
-
-                            {/* Target Pests & Diseases Section */}
-                            <ProductTargets
-                                title={sectionTitle}
-                                targets={chemical.targets || []}
-                                emptyMessage={noTargetMsg}
-                            />
-                        </div>
-                    </div>
-                </div>
-
-                {/* Dosage Rates & Application Guide Section */}
+            {/* Used On & Targets Grid */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:h-[315px]">
                 {chemical.dosage_rates && chemical.dosage_rates.length > 0 && (
-                    chemical.dosage_rates.every((r: any) => !r.crop_group_id && r.crop_group)
-                        ? <FertilizerApplicationRates dosageRates={chemical.dosage_rates} />
-                        : <AgrochemicalDosageTable dosageRates={chemical.dosage_rates} />
-                )}
-
-                {/* Product Labels Section */}
-                {(chemical.front_label?.img?.src || chemical.back_label?.img?.src) && (
-                    <div className="mb-12">
-                        <h2 className="text-2xl font-bold mb-6">Product Labels</h2>
-                        <div className="grid md:grid-cols-2 gap-6">
-                            {/* Front Label */}
-                            {chemical.front_label?.img?.src && (
-                                <div className="space-y-3">
-                                    <h3 className="text-lg font-semibold">Front Label</h3>
-                                    <div className="relative aspect-[3/4] bg-white rounded-lg border overflow-hidden">
-                                        <Image
-                                            src={chemical.front_label.img.src}
-                                            alt={`${chemical.name} - Front Label`}
-                                            fill
-                                            sizes="(max-width: 768px) 100vw, 50vw"
-                                            className="object-contain p-4"
-                                        />
-                                    </div>
-                                </div>
-                            )}
-
-                            {/* Back Label */}
-                            {chemical.back_label?.img?.src && (
-                                <div className="space-y-3">
-                                    <h3 className="text-lg font-semibold">Back Label</h3>
-                                    <div className="relative aspect-[3/4] bg-white rounded-lg border overflow-hidden">
-                                        <Image
-                                            src={chemical.back_label.img.src}
-                                            alt={`${chemical.name} - Back Label`}
-                                            fill
-                                            sizes="(max-width: 768px) 100vw, 50vw"
-                                            className="object-contain p-4"
-                                        />
-                                    </div>
-                                </div>
-                            )}
-                        </div>
+                    <div className="rounded-xl border bg-card p-4 overflow-y-auto">
+                        <h2 className="text-sm font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-400 mb-3">
+                            Used On
+                        </h2>
+                        <ul className="space-y-1.5">
+                            {Array.from(new Set(chemical.dosage_rates.flatMap((rate: any) => {
+                                if (rate.crop_group_items?.length > 0) return rate.crop_group_items
+                                if (rate.crop) return [rate.crop]
+                                if (rate.crop_group) return [rate.crop_group]
+                                return []
+                            }))).map((crop: any, idx: number) => (
+                                <li key={idx} className="flex items-center gap-2 text-sm text-foreground">
+                                    <span className="h-1.5 w-1.5 rounded-full bg-amber-500 dark:bg-amber-400 flex-shrink-0" />
+                                    <span className="capitalize">{crop}</span>
+                                </li>
+                            ))}
+                        </ul>
                     </div>
                 )}
 
-                {/* Safety Warning */}
-                <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-lg p-6">
-                    <div className="flex items-start gap-3">
-                        <AlertTriangle className="w-6 h-6 text-yellow-600 dark:text-yellow-500 flex-shrink-0" />
-                        <div>
-                            <h3 className="font-semibold mb-2 text-yellow-900 dark:text-yellow-100">Safety Information</h3>
-                            <p className="text-sm text-yellow-800 dark:text-yellow-200">
-                                Always read and follow label directions. Wear appropriate personal protective equipment (PPE) when handling agrochemicals.
-                                Store in original containers in a secure location away from children and animals. Dispose of containers properly according to local regulations.
-                            </p>
-                            <p className="text-xs text-black dark:text-white mt-2">
-                                Disclaimer: The information provided on this page, including active ingredients, dosage rates, application methods, and safety guidelines, has been compiled from publicly available product labels, manufacturer datasheets, and other third-party sources. Farmnport does not manufacture, formulate, or independently verify the accuracy, completeness, or currency of this information. Product formulations, registrations, and label directions may change without notice. Always refer to the official product label accompanying the purchased product for the most up-to-date and legally binding instructions. Farmnport accepts no liability for any loss, damage, crop injury, or adverse outcome arising from the use of, or reliance on, the information presented here. Use of any agrochemical product is entirely at the user&#39;s own risk.
-                            </p>
-                        </div>
-                    </div>
-                </div>
+                <ProductTargets
+                    title={sectionTitle}
+                    targets={chemical.targets || []}
+                    emptyMessage={noTargetMsg}
+                />
             </div>
-        </div>
+        </GuideDetailLayout>
     )
 }

--- a/apps/client-fnp/app/(landing)/animal-health-guides/[category]/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/animal-health-guides/[category]/[slug]/page.tsx
@@ -1,15 +1,10 @@
 import type { Metadata } from 'next'
 import { ActiveIngredientsList } from "@/components/shared/ActiveIngredientUnitsKey"
-import Image from "next/image"
-import { AlertTriangle } from "lucide-react"
-import Link from "next/link"
-import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
 import { capitalizeFirstLetter, formatUnit, buildGuideMetadata } from "@/lib/utilities"
-import { GuideProductTitle } from "@/components/shared/GuideProductTitle"
 import { BaseURL } from "@/lib/schemas"
-import { WantToBuyCTA } from "@/components/shared/WantToBuyCTA"
-import { ShareBar } from "@/components/shared/ShareBar"
-import { SidebarPromo } from "@/components/ads/SidebarPromo"
+import { ProductTargets } from "@/components/agrochemical/ProductTargets"
+import { GuideDetailLayout } from "@/components/shared/GuideDetailLayout"
+import { ProductNotFound } from "@/components/shared/ProductNotFound"
 
 type Props = { params: Promise<{ category: string; slug: string }> }
 
@@ -42,13 +37,6 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return buildGuideMetadata(product, categorySingularTitle, 'Dosage & Guide', description, `/animal-health-guides/${category}/${slug}`, product.images?.[0]?.img?.src, keywords)
 }
 
-interface GuidePageProps {
-    params: Promise<{
-        category: string
-        slug: string
-    }>
-}
-
 const overviewDesc: Record<string, string> = {
     vaccines: "a vaccine designed to protect poultry and livestock against infectious diseases. It stimulates the immune system to build resistance when administered according to the recommended schedule.",
     antibiotics: "an antibiotic formulated for the treatment and prevention of bacterial infections in poultry and livestock. It targets harmful bacteria while supporting animal recovery when used as directed.",
@@ -57,7 +45,13 @@ const overviewDesc: Record<string, string> = {
     "biosecurity-disinfectants": "a biosecurity disinfectant designed for cleaning and sanitizing poultry and livestock housing. It helps eliminate pathogens and maintain a healthy environment.",
 }
 
+const DISCLAIMER = "Disclaimer: The information provided on this page, including active ingredients, dosage rates, application methods, and safety guidelines, has been compiled from publicly available product labels, manufacturer datasheets, and other third-party sources. Farmnport does not manufacture, formulate, or independently verify the accuracy, completeness, or currency of this information. Product formulations, registrations, and label directions may change without notice. Always refer to the official product label accompanying the purchased product for the most up-to-date and legally binding instructions. Farmnport accepts no liability for any loss, damage, crop injury, or adverse outcome arising from the use of, or reliance on, the information presented here. Use of any product is entirely at the user's own risk."
+
 const fetchOptions: RequestInit = { cache: "no-store" }
+
+interface GuidePageProps {
+    params: Promise<{ category: string; slug: string }>
+}
 
 export default async function AnimalHealthGuidePage({ params }: GuidePageProps) {
     const { category, slug } = await params
@@ -65,36 +59,10 @@ export default async function AnimalHealthGuidePage({ params }: GuidePageProps) 
     const product = res.ok ? await res.json() : null
 
     if (!product) {
-        return (
-            <div className="min-h-screen bg-background flex items-center justify-center px-4 pb-4">
-                <div className="text-center max-w-md">
-                    <div className="mb-6">
-                        <div className="mx-auto w-20 h-20 bg-muted rounded-full" />
-                    </div>
-                    <h2 className="text-2xl font-semibold mb-2">Guide Not Found</h2>
-                    <p className="text-muted-foreground mb-6">
-                        We couldn&apos;t find the animal health product guide you&apos;re looking for. It may have been removed or the link might be incorrect.
-                    </p>
-                    <div className="flex flex-col sm:flex-row gap-3 justify-center">
-                        <Link href="/animal-health-guides">
-                            <button className="inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">
-                                Browse All Guides
-                            </button>
-                        </Link>
-                        <Link href="/animal-health-guides">
-                            <button className="inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">
-                                Go to Categories
-                            </button>
-                        </Link>
-                    </div>
-                </div>
-            </div>
-        )
+        return <ProductNotFound title="Animal Health Guide Not Found" description="The animal health product guide you're looking for doesn't exist or may have been removed." primary={{ href: "/animal-health-guides", label: "Browse All Guides" }} secondary={{ href: "/animal-health-guides", label: "Go to Categories" }} />
     }
 
     const categorySlug = product?.animal_health_category?.slug || ""
-
-    // Generate JSON-LD structured data
     const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://farmnport.com'
     const url = `${baseUrl}/animal-health-guides/${category}/${slug}`
     const imageUrl = product.images?.[0]?.img?.src || `${baseUrl}/default-chemical.png`
@@ -103,10 +71,6 @@ export default async function AnimalHealthGuidePage({ params }: GuidePageProps) 
         ? `${product.name} is a ${product.animal_health_category.name} for poultry and livestock health. View active ingredients, dosage rates, and withdrawal periods.`
         : `Professional animal health product guide for ${product.name}. Complete information on active ingredients, dosage rates, and withdrawal periods.`
 
-    const usageInfo = product.dosage_rates?.length > 0
-        ? `Dosage rates available for ${product.dosage_rates.map((r: any) => r.animal).join(', ')}`
-        : undefined
-
     const breadcrumbJsonLd = {
         "@context": "https://schema.org",
         "@type": "BreadcrumbList",
@@ -114,7 +78,7 @@ export default async function AnimalHealthGuidePage({ params }: GuidePageProps) 
             { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://farmnport.com" },
             { "@type": "ListItem", "position": 2, "name": "Animal Health Guides", "item": "https://farmnport.com/animal-health-guides" },
             { "@type": "ListItem", "position": 3, "name": product.animal_health_category?.name || category, "item": `https://farmnport.com/animal-health-guides/${category}` },
-            { "@type": "ListItem", "position": 4, "name": product.name, "item": `https://farmnport.com/animal-health-guides/${category}/${slug}` },
+            { "@type": "ListItem", "position": 4, "name": product.name, "item": url },
         ],
     }
 
@@ -139,13 +103,11 @@ export default async function AnimalHealthGuidePage({ params }: GuidePageProps) 
             })) || [])
         ],
         "applicationCategory": "Veterinary Product",
-        "usageInfo": usageInfo
     }
 
-    // Pre-process dosage rates grouping for the table
+    // Pre-process dosage rates
     const grouped = new Map<string, any[]>()
     const ungrouped: any[] = []
-
     if (product.dosage_rates) {
         product.dosage_rates.forEach((rate: any) => {
             if (rate.animal_group_id) {
@@ -157,8 +119,6 @@ export default async function AnimalHealthGuidePage({ params }: GuidePageProps) 
             }
         })
     }
-
-    // Pre-process ungrouped target grouping
     const targetGrouped = new Map<string, any[]>()
     const targetOrder: string[] = []
     ungrouped.forEach((rate: any) => {
@@ -194,23 +154,15 @@ export default async function AnimalHealthGuidePage({ params }: GuidePageProps) 
         const lastIdx = entries.length - 1
         return entries.map((entry: any, entryIdx: number) => (
             <tr key={`${rateKey}-${entryIdx}`} className={`hover:bg-muted/30 transition-colors ${entryIdx === 0 ? "border-t border-border" : ""} ${entryIdx === lastIdx ? "border-b border-border" : ""}`}>
+                <td className="p-3 align-top">{entryIdx === 0 ? animalCell : null}</td>
+                <td className="p-3 align-top">{entryIdx === 0 ? targetCell : null}</td>
                 <td className="p-3 align-top">
-                    {entryIdx === 0 ? animalCell : null}
-                </td>
-                <td className="p-3 align-top">
-                    {entryIdx === 0 ? targetCell : null}
-                </td>
-                <td className="p-3 align-top">
-                    <div className="font-bold text-blue-600 dark:text-blue-400 text-base">
-                        {entry.dosage.value} {formatUnit(entry.dosage.unit)}
-                    </div>
+                    <div className="font-bold text-blue-600 dark:text-blue-400 text-base">{entry.dosage.value} {formatUnit(entry.dosage.unit)}</div>
                     <div className="text-xs text-muted-foreground">per {entry.dosage.per}</div>
                 </td>
                 <td className="p-3 align-top">
                     <div className="font-semibold text-orange-700 dark:text-orange-300">{entry.max_applications.max > 0 ? entry.max_applications.max : "—"}</div>
-                    {entry.max_applications.note && entry.max_applications.note.trim() !== '' && (
-                        <div className="text-xs text-muted-foreground mt-1">{entry.max_applications.note}</div>
-                    )}
+                    {entry.max_applications.note?.trim() && <div className="text-xs text-muted-foreground mt-1">{entry.max_applications.note}</div>}
                 </td>
                 <td className="p-3 align-top">
                     <div className="font-semibold text-teal-700 dark:text-teal-300 text-sm">{entry.application_interval}</div>
@@ -225,12 +177,10 @@ export default async function AnimalHealthGuidePage({ params }: GuidePageProps) 
                                 </li>
                             ))}
                         </ul>
-                    ) : (
-                        <span className="text-xs text-muted-foreground">&mdash;</span>
-                    )}
+                    ) : <span className="text-xs text-muted-foreground">&mdash;</span>}
                 </td>
                 <td className="p-3 align-top">
-                    {entry.remarks && entry.remarks.length > 0 ? (
+                    {entry.remarks?.length > 0 ? (
                         <ul className="space-y-1">
                             {entry.remarks.map((remark: string, remarkIdx: number) => (
                                 <li key={remarkIdx} className="text-xs text-foreground flex items-start gap-1.5">
@@ -239,316 +189,112 @@ export default async function AnimalHealthGuidePage({ params }: GuidePageProps) 
                                 </li>
                             ))}
                         </ul>
-                    ) : (
-                        <span className="text-xs text-muted-foreground">&mdash;</span>
-                    )}
+                    ) : <span className="text-xs text-muted-foreground">&mdash;</span>}
                 </td>
             </tr>
         ))
     }
 
-    return (
-        <div className="min-h-screen bg-background">
-            {/* JSON-LD Structured Data */}
-            <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
-            <script
-                type="application/ld+json"
-                dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
-            />
-
-            {/* Breadcrumb */}
-            <div className="border-b">
-                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
-                    <nav className="flex text-sm text-muted-foreground">
-                        <Link href="/" className="hover:text-foreground">Home</Link>
-                        <span className="mx-2">/</span>
-                        <Link href="/animal-health-guides" className="hover:text-foreground">Animal Health Guides</Link>
-                        <span className="mx-2">/</span>
-                        <Link href={`/animal-health-guides/${category}`} className="hover:text-foreground capitalize">{product.animal_health_category?.name || category}</Link>
-                        <span className="mx-2">/</span>
-                        <span className="text-foreground capitalize">{product.name}</span>
-                    </nav>
-                </div>
-            </div>
-
-            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-                {/* Header Section */}
-                <div className="grid lg:grid-cols-[450px,1fr] gap-12 mb-16">
-                    {/* Left - Image */}
-                    <div className="flex flex-col gap-4">
-                        <div className="relative aspect-square bg-muted/30 dark:bg-white rounded-xl border overflow-hidden shadow-sm">
-                            {product.images && product.images[0] && product.images[0].img?.src ? (
-                                <Image
-                                    src={product.images[0].img.src}
-                                    alt={product.name}
-                                    fill
-                                    sizes="(max-width: 1024px) 100vw, 450px"
-                                    className="object-contain p-8"
-                                    priority
-                                />
-                            ) : (
-                                <div className="absolute inset-0 bg-muted/30" />
-                            )}
-                        </div>
-
-                        {/* Thumbnail Gallery */}
-                        {product.images && product.images.length > 1 && (
-                            <div className="grid grid-cols-4 gap-3">
-                                {product.images.slice(0, 4).map((img: any, idx: number) => (
-                                    <button
-                                        key={idx}
-                                        className="relative aspect-square bg-muted/30 dark:bg-white rounded-lg border hover:border-primary transition-colors"
-                                    >
-                                        {img.img?.src && (
-                                            <Image
-                                                src={img.img.src}
-                                                alt={`${product.name} ${idx + 1}`}
-                                                fill
-                                                sizes="(max-width: 1024px) 25vw, 100px"
-                                                className="object-contain p-2"
-                                            />
-                                        )}
-                                    </button>
-                                ))}
-                            </div>
-                        )}
-
-                        {/* Want to Buy CTA */}
-                        <WantToBuyCTA available_for_sale={product.available_for_sale} name={product.name} brand={product.brand?.name} href={`/buy-animal-health/${slug}`} interestHref={`/interest/animal-health/${slug}`} />
-
-                        {/* Precautions */}
-                        {product.precautions && product.precautions.length > 0 && (
-                            <div className="rounded-lg border border-red-200 dark:border-red-900 bg-red-50/50 dark:bg-red-950/30 px-3 py-2">
-                                <h2 className="text-xs font-semibold uppercase tracking-wide text-red-700 dark:text-red-400 mb-1.5 flex items-center gap-1.5">
-                                    <AlertTriangle className="w-3.5 h-3.5" />
-                                    Precautions
-                                </h2>
-                                <ul className="space-y-0.5">
-                                    {product.precautions.map((precaution: string, idx: number) => (
-                                        <li key={idx} className="flex items-start gap-1.5 text-xs text-red-800 dark:text-red-300">
-                                            <span className="h-1 w-1 rounded-full bg-red-500 dark:bg-red-400 flex-shrink-0 mt-1.5" />
-                                            <span>{precaution}</span>
-                                        </li>
-                                    ))}
-                                </ul>
-                            </div>
-                        )}
-
-                        {/* Promo - fills remaining sidebar space */}
-                        <div className="flex-1">
-                            <SidebarPromo />
-                        </div>
-                    </div>
-
-                    {/* Right - Product Info */}
-                    <div className="space-y-6">
-                        {/* Product Name */}
-                        <GuideProductTitle name={product.name} brand={product.brand?.name} />
-                        <div className="mt-3"><ShareBar name={product.name} /></div>
-
-                        {/* Category Badge */}
-                        <div className="flex items-center gap-3 flex-wrap">
-                            {product.animal_health_category && (
-                                <div className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300">
-                                    {product.animal_health_category.name}
-                                </div>
-                            )}
-                        </div>
-
-                        {/* Divider */}
-                        <div className="h-px bg-border" />
-
-                        {/* Overview */}
-                        <div>
-                            <h2 className="text-lg font-semibold mb-3 text-foreground">Overview</h2>
-                            <p className="text-muted-foreground leading-relaxed text-sm">
-                                {categorySlug ? (
-                                    <><span className="font-medium text-foreground">{capitalizeFirstLetter(product.name)}</span> is {overviewDesc[categorySlug] || `a ${product.animal_health_category?.name?.toLowerCase() || 'veterinary'} product for effective animal health management. It supports animal health when used according to recommended guidelines.`}</>
-                                ) : (
-                                    <><span className="font-medium text-foreground">{product.name}</span> is a professional animal health product for poultry and livestock management.</>
-                                )}
-                            </p>
-                        </div>
-
-                        {/* Active Ingredients Section */}
-                        <div>
-                            <h2 className="text-lg font-semibold mb-1 text-foreground">Active Ingredients</h2>
-                            <ActiveIngredientsList activeIngredients={product.active_ingredients || []} />
-                        </div>
-
-                        {/* AdSense Ad */}
-                        <AdSenseInFeed />
-
-                        {/* Used On & Targets Grid */}
-                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                            {/* Used On Section */}
-                            {product.dosage_rates && product.dosage_rates.length > 0 && (
-                                <div className="rounded-xl border bg-card p-4">
-                                    <h2 className="text-sm font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-400 mb-3">
-                                        Used On
-                                    </h2>
-                                    <ul className="space-y-1.5">
-                                        {Array.from(new Set(product.dosage_rates.map((rate: any) => rate.animal))).map((animal: any, idx: number) => (
-                                            <li key={idx} className="flex items-center gap-2 text-sm text-foreground">
-                                                <span className="h-1.5 w-1.5 rounded-full bg-amber-500 dark:bg-amber-400 flex-shrink-0" />
-                                                <span className="capitalize">{animal}</span>
-                                            </li>
-                                        ))}
-                                    </ul>
-                                </div>
-                            )}
-
-                            {/* Target Diseases Section */}
-                            <div className="rounded-xl border bg-card p-4">
-                                <h2 className="text-sm font-semibold uppercase tracking-wide text-green-700 dark:text-green-400 mb-3">
-                                    Target Diseases & Conditions
-                                </h2>
-                                {product.targets && product.targets.length > 0 ? (
-                                    <ul className="space-y-1.5">
-                                        {product.targets.map((target: any, idx: number) => (
-                                            <li key={idx} className="flex items-start gap-2 text-sm text-foreground">
-                                                <span className="h-1.5 w-1.5 rounded-full bg-green-500 dark:bg-green-400 flex-shrink-0 mt-1.5" />
-                                                <span>
-                                                    <span className="capitalize">{target.name}</span>
-                                                    {target.scientific_name && (
-                                                        <span className="text-xs text-muted-foreground italic ml-1">({target.scientific_name})</span>
-                                                    )}
-                                                </span>
-                                            </li>
-                                        ))}
-                                    </ul>
-                                ) : (
-                                    <p className="text-sm text-muted-foreground">No target disease information available.</p>
-                                )}
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                {/* Dosage Rates & Application Guide Section */}
-                {product.dosage_rates && product.dosage_rates.length > 0 && (
-                    <div className="mb-12">
-                        <h2 className="sticky top-16 z-10 text-2xl font-bold py-4 text-foreground bg-background">Dosage Rates & Application Guide</h2>
-                        <div className="overflow-x-auto">
-                            <table className="w-full border-collapse">
-                                <thead>
-                                    <tr className="bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-950/50 dark:to-indigo-950/50 border-b-2 border-blue-200 dark:border-blue-800">
-                                        <th className="text-left p-3 text-sm font-semibold text-blue-900 dark:text-blue-100 min-w-[120px]">Animal</th>
-                                        <th className="text-left p-3 text-sm font-semibold text-blue-900 dark:text-blue-100 min-w-[180px]">Target</th>
-                                        <th className="text-left p-3 text-sm font-semibold text-blue-900 dark:text-blue-100 min-w-[140px]">Dosage</th>
-                                        <th className="text-left p-3 text-sm font-semibold text-orange-700 dark:text-orange-300 min-w-[120px] whitespace-nowrap">Max Applications</th>
-                                        <th className="text-left p-3 text-sm font-semibold text-teal-700 dark:text-teal-300 min-w-[130px] whitespace-nowrap">Application Interval</th>
-                                        <th className="text-left p-3 text-sm font-semibold text-rose-700 dark:text-rose-300 min-w-[120px] whitespace-nowrap">Withdrawal Period</th>
-                                        <th className="text-left p-3 text-sm font-semibold text-blue-900 dark:text-blue-100 min-w-[180px]">Remarks</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    {/* Grouped rates */}
-                                    {Array.from(grouped.entries()).map(([groupId, rates]) => {
-                                        const firstRate = rates[0]
-                                        const animalCell = (
-                                            <div>
-                                                <div className="font-semibold text-sm text-blue-700 dark:text-blue-300">
-                                                    {firstRate.animal_group}
-                                                </div>
-                                                <div className="mt-1 space-y-0.5">
-                                                    {rates.map((r: any, idx: number) => (
-                                                        <div key={idx} className="text-xs text-muted-foreground capitalize flex items-start gap-1">
-                                                            <span className="h-1 w-1 mt-1.5 rounded-full bg-blue-400 flex-shrink-0" />
-                                                            <span className="flex-1">{r.animal}</span>
-                                                        </div>
-                                                    ))}
-                                                </div>
+    const dosageTable = product.dosage_rates?.length > 0 ? (
+        <div className="mb-12">
+            <h2 className="sticky top-16 z-10 text-2xl font-bold py-4 text-foreground bg-background">Dosage Rates & Application Guide</h2>
+            <div className="overflow-x-auto">
+                <table className="w-full border-collapse">
+                    <thead>
+                        <tr className="bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-950/50 dark:to-indigo-950/50 border-b-2 border-blue-200 dark:border-blue-800">
+                            <th className="text-left p-3 text-sm font-semibold text-blue-900 dark:text-blue-100 min-w-[120px]">Animal</th>
+                            <th className="text-left p-3 text-sm font-semibold text-blue-900 dark:text-blue-100 min-w-[180px]">Target</th>
+                            <th className="text-left p-3 text-sm font-semibold text-blue-900 dark:text-blue-100 min-w-[140px]">Dosage</th>
+                            <th className="text-left p-3 text-sm font-semibold text-orange-700 dark:text-orange-300 min-w-[120px] whitespace-nowrap">Max Applications</th>
+                            <th className="text-left p-3 text-sm font-semibold text-teal-700 dark:text-teal-300 min-w-[130px] whitespace-nowrap">Application Interval</th>
+                            <th className="text-left p-3 text-sm font-semibold text-rose-700 dark:text-rose-300 min-w-[120px] whitespace-nowrap">Withdrawal Period</th>
+                            <th className="text-left p-3 text-sm font-semibold text-blue-900 dark:text-blue-100 min-w-[180px]">Remarks</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {Array.from(grouped.entries()).map(([groupId, rates]) => {
+                            const firstRate = rates[0]
+                            const animalCell = (
+                                <div>
+                                    <div className="font-semibold text-sm text-blue-700 dark:text-blue-300">{firstRate.animal_group}</div>
+                                    <div className="mt-1 space-y-0.5">
+                                        {rates.map((r: any, idx: number) => (
+                                            <div key={idx} className="text-xs text-muted-foreground capitalize flex items-start gap-1">
+                                                <span className="h-1 w-1 mt-1.5 rounded-full bg-blue-400 flex-shrink-0" />
+                                                <span className="flex-1">{r.animal}</span>
                                             </div>
-                                        )
-                                        const targetCell = renderTargetGrid(firstRate.targets || [])
-                                        return renderEntryRows(firstRate, `group-${groupId}`, animalCell, targetCell)
-                                    })}
-
-                                    {/* Ungrouped rates */}
-                                    {targetOrder.map((targetKey, tgIdx) => {
-                                        const rates = targetGrouped.get(targetKey)!
-                                        if (rates.length === 1) {
-                                            const rate = rates[0]
-                                            const animalCell = (
-                                                <div>
-                                                    <div className="font-semibold capitalize text-sm text-foreground">{rate.animal}</div>
-                                                </div>
-                                            )
-                                            const targetCell = renderTargetGrid(rate.targets || [])
-                                            return renderEntryRows(rate, `tg-${tgIdx}`, animalCell, targetCell)
-                                        }
-                                        return rates.map((rate: any, rateIdx: number) => {
-                                            const animalCell = (
-                                                <div>
-                                                    <div className="font-semibold capitalize text-sm text-foreground">{rate.animal}</div>
-                                                </div>
-                                            )
-                                            const targetCell = rateIdx === 0 ? renderTargetGrid(rate.targets || []) : null
-                                            return renderEntryRows(rate, `tg-${tgIdx}-${rateIdx}`, animalCell, targetCell)
-                                        })
-                                    })}
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
-                )}
-
-                {/* Product Labels Section */}
-                {(product.front_label?.img?.src || product.back_label?.img?.src) && (
-                    <div className="mb-12">
-                        <h2 className="text-2xl font-bold mb-6">Product Labels</h2>
-                        <div className="grid md:grid-cols-2 gap-6">
-                            {product.front_label?.img?.src && (
-                                <div className="space-y-3">
-                                    <h3 className="text-lg font-semibold">Front Label</h3>
-                                    <div className="relative aspect-[3/4] bg-white rounded-lg border overflow-hidden">
-                                        <Image
-                                            src={product.front_label.img.src}
-                                            alt={`${product.name} - Front Label`}
-                                            fill
-                                            sizes="(max-width: 768px) 100vw, 50vw"
-                                            className="object-contain p-4"
-                                        />
+                                        ))}
                                     </div>
                                 </div>
-                            )}
-
-                            {product.back_label?.img?.src && (
-                                <div className="space-y-3">
-                                    <h3 className="text-lg font-semibold">Back Label</h3>
-                                    <div className="relative aspect-[3/4] bg-white rounded-lg border overflow-hidden">
-                                        <Image
-                                            src={product.back_label.img.src}
-                                            alt={`${product.name} - Back Label`}
-                                            fill
-                                            sizes="(max-width: 768px) 100vw, 50vw"
-                                            className="object-contain p-4"
-                                        />
-                                    </div>
-                                </div>
-                            )}
-                        </div>
-                    </div>
-                )}
-
-                {/* Safety Warning */}
-                <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-lg p-6">
-                    <div className="flex items-start gap-3">
-                        <AlertTriangle className="w-6 h-6 text-yellow-600 dark:text-yellow-500 flex-shrink-0" />
-                        <div>
-                            <h3 className="font-semibold mb-2 text-yellow-900 dark:text-yellow-100">Safety Information</h3>
-                            <p className="text-sm text-yellow-800 dark:text-yellow-200">
-                                Always read and follow label directions. Consult a veterinarian before administering animal health products.
-                                Observe withdrawal periods before slaughter or sale of animal products. Store in original containers in a cool, dry place away from children.
-                            </p>
-                            <p className="text-xs text-black dark:text-white mt-2">
-                                Disclaimer: The information provided on this page, including active ingredients, dosage rates, application methods, and safety guidelines, has been compiled from publicly available product labels, manufacturer datasheets, and other third-party sources. Farmnport does not manufacture, formulate, or independently verify the accuracy, completeness, or currency of this information. Product formulations, registrations, and label directions may change without notice. Always refer to the official product label accompanying the purchased product for the most up-to-date and legally binding instructions. Farmnport accepts no liability for any loss, damage, crop injury, or adverse outcome arising from the use of, or reliance on, the information presented here. Use of any product is entirely at the user&#39;s own risk.
-                            </p>
-                        </div>
-                    </div>
-                </div>
+                            )
+                            return renderEntryRows(firstRate, `group-${groupId}`, animalCell, renderTargetGrid(firstRate.targets || []))
+                        })}
+                        {targetOrder.map((targetKey, tgIdx) => {
+                            const rates = targetGrouped.get(targetKey)!
+                            if (rates.length === 1) {
+                                const rate = rates[0]
+                                return renderEntryRows(rate, `tg-${tgIdx}`, <div className="font-semibold capitalize text-sm text-foreground">{rate.animal}</div>, renderTargetGrid(rate.targets || []))
+                            }
+                            return rates.map((rate: any, rateIdx: number) => renderEntryRows(rate, `tg-${tgIdx}-${rateIdx}`, <div className="font-semibold capitalize text-sm text-foreground">{rate.animal}</div>, rateIdx === 0 ? renderTargetGrid(rate.targets || []) : null))
+                        })}
+                    </tbody>
+                </table>
             </div>
         </div>
+    ) : null
+
+    return (
+        <GuideDetailLayout
+            product={product}
+            breadcrumbs={[
+                { label: "Animal Health Guides", href: "/animal-health-guides" },
+                { label: product.animal_health_category?.name || category, href: `/animal-health-guides/${category}` },
+                { label: product.name, href: url },
+            ]}
+            categoryBadge={product.animal_health_category ? { label: product.animal_health_category.name } : undefined}
+            buyHref={`/buy-animal-health/${slug}`}
+            interestHref={`/interest/animal-health/${slug}`}
+            safetyText="Always read and follow label directions. Consult a veterinarian before administering animal health products. Observe withdrawal periods before slaughter or sale of animal products. Store in original containers in a cool, dry place away from children."
+            disclaimerText={DISCLAIMER}
+            structuredData={structuredData}
+            breadcrumbJsonLd={breadcrumbJsonLd}
+            bottomContent={dosageTable}
+        >
+            {/* Overview */}
+            <div>
+                <h2 className="text-lg font-semibold mb-3 text-foreground">Overview</h2>
+                <p className="text-muted-foreground leading-relaxed text-sm">
+                    {categorySlug ? (
+                        <><span className="font-medium text-foreground">{capitalizeFirstLetter(product.name)}</span> is {overviewDesc[categorySlug] || `a ${product.animal_health_category?.name?.toLowerCase() || 'veterinary'} product for effective animal health management. It supports animal health when used according to recommended guidelines.`}</>
+                    ) : (
+                        <><span className="font-medium text-foreground">{product.name}</span> is a professional animal health product for poultry and livestock management.</>
+                    )}
+                </p>
+            </div>
+
+            {/* Active Ingredients */}
+            <div>
+                <h2 className="text-lg font-semibold mb-1 text-foreground">Active Ingredients</h2>
+                <ActiveIngredientsList activeIngredients={product.active_ingredients || []} />
+            </div>
+
+            {/* Used On & Targets Grid */}
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                {product.dosage_rates && product.dosage_rates.length > 0 && (
+                    <div className="rounded-xl border bg-card p-4">
+                        <h2 className="text-sm font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-400 mb-3">Used On</h2>
+                        <ul className="space-y-1.5">
+                            {Array.from(new Set(product.dosage_rates.map((rate: any) => rate.animal))).map((animal: any, idx: number) => (
+                                <li key={idx} className="flex items-center gap-2 text-sm text-foreground">
+                                    <span className="h-1.5 w-1.5 rounded-full bg-amber-500 dark:bg-amber-400 flex-shrink-0" />
+                                    <span className="capitalize">{animal}</span>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                )}
+                <ProductTargets title="Target Diseases & Conditions" targets={product.targets || []} emptyMessage="No target disease information available." />
+            </div>
+        </GuideDetailLayout>
     )
 }

--- a/apps/client-fnp/app/(landing)/equipment-guides/[category]/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/equipment-guides/[category]/[slug]/page.tsx
@@ -1,16 +1,10 @@
 import type { Metadata } from 'next'
-import Image from "next/image"
-import Link from "next/link"
 import { BaseURL } from "@/lib/schemas"
 import { buildGuideMetadata } from "@/lib/utilities"
-import { GuideProductTitle } from "@/components/shared/GuideProductTitle"
-import { WantToBuyCTA } from "@/components/shared/WantToBuyCTA"
-import { ShareBar } from "@/components/shared/ShareBar"
-import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
 import { guardTestItem } from "@/lib/guardTestItem"
 import { ProductNotFound } from "@/components/shared/ProductNotFound"
-import { SidebarPromo } from "@/components/ads/SidebarPromo"
-
+import { GuideDetailLayout } from "@/components/shared/GuideDetailLayout"
+import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
 
 type Props = { params: Promise<{ category: string; slug: string }> }
 
@@ -29,14 +23,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return buildGuideMetadata(product, categoryName, 'Specifications & Guide', description, `/equipment-guides/${category}/${slug}`, product.images?.[0]?.img?.src)
 }
 
-interface GuidePageProps {
-    params: Promise<{
-        category: string
-        slug: string
-    }>
-}
-
 const fetchOptions: RequestInit = { cache: "no-store" }
+
+interface GuidePageProps {
+    params: Promise<{ category: string; slug: string }>
+}
 
 export default async function EquipmentGuidePage({ params }: GuidePageProps) {
     const { category, slug } = await params
@@ -66,171 +57,87 @@ export default async function EquipmentGuidePage({ params }: GuidePageProps) {
         "category": product.equipment_category?.name || "Farm Equipment",
         "url": url,
         "brand": product.brand?.name ? { "@type": "Brand", "name": product.brand.name } : undefined,
-        "additionalProperty": [
-            ...(product.specifications?.map((spec: any) => ({
-                "@type": "PropertyValue",
-                "name": spec.name,
-                "value": spec.value
-            })) || [])
-        ],
+        "additionalProperty": product.specifications?.map((spec: any) => ({
+            "@type": "PropertyValue",
+            "name": spec.name,
+            "value": spec.value
+        })) || [],
     }
 
     return (
-        <div className="min-h-screen bg-background">
-            <script
-                type="application/ld+json"
-                dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
-            />
-
-            <div className="border-b">
-                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
-                    <nav className="flex flex-wrap text-sm text-muted-foreground">
-                        <Link href="/" className="hover:text-foreground">Home</Link>
-                        <span className="mx-2">/</span>
-                        <Link href="/equipment-guides" className="hover:text-foreground">Equipment Guides</Link>
-                        <span className="mx-2">/</span>
-                        <Link href={`/equipment-guides/${category}`} className="hover:text-foreground capitalize">{product.equipment_category?.name || category}</Link>
-                        <span className="mx-2">/</span>
-                        <span className="text-foreground capitalize truncate max-w-[200px] sm:max-w-none">{product.name}</span>
-                    </nav>
+        <GuideDetailLayout
+            product={product}
+            breadcrumbs={[
+                { label: "Equipment Guides", href: "/equipment-guides" },
+                { label: product.equipment_category?.name || category, href: `/equipment-guides/${category}` },
+                { label: product.name, href: url },
+            ]}
+            categoryBadge={product.equipment_category ? { label: product.equipment_category.name } : undefined}
+            buyHref={`/buy-equipment/${slug}`}
+            interestHref={`/interest/equipment/${slug}`}
+            safetyText="Always follow manufacturer guidelines when operating farm equipment. Wear appropriate protective gear and ensure proper training before use."
+            structuredData={structuredData}
+        >
+            {/* Overview */}
+            {product.description && (
+                <div>
+                    <h2 className="text-lg font-semibold mb-3 text-foreground">Overview</h2>
+                    <p className="text-muted-foreground leading-relaxed text-sm">{product.description}</p>
                 </div>
-            </div>
+            )}
 
-            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-                <div className="grid lg:grid-cols-[450px,1fr] gap-6 lg:gap-12 mb-16">
-                    {/* Left - Image */}
-                    <div className="flex flex-col gap-4">
-                        <div className="relative aspect-square bg-muted/30 dark:bg-white rounded-xl border overflow-hidden shadow-sm">
-                            {product.images && product.images[0] && product.images[0].img?.src ? (
-                                <Image
-                                    src={product.images[0].img.src}
-                                    alt={product.name}
-                                    fill
-                                    sizes="(max-width: 1024px) 100vw, 450px"
-                                    className="object-contain p-8"
-                                    priority
-                                />
-                            ) : (
-                                <div className="absolute inset-0 bg-muted/30" />
-                            )}
-                        </div>
+            <AdSenseInFeed />
 
-                        {product.images && product.images.length > 1 && (
-                            <div className="grid grid-cols-4 gap-3">
-                                {product.images.slice(0, 4).map((img: any, idx: number) => (
-                                    <button
-                                        key={idx}
-                                        className="relative aspect-square bg-muted/30 dark:bg-white rounded-lg border hover:border-primary transition-colors"
-                                    >
-                                        {img.img?.src ? (
-                                            <Image
-                                                src={img.img.src}
-                                                alt={`${product.name} ${idx + 1}`}
-                                                fill
-                                                sizes="(max-width: 1024px) 25vw, 100px"
-                                                className="object-contain p-2"
-                                            />
-                                        ) : (
-                                            <div className="absolute inset-0 bg-muted/30 rounded-lg" />
-                                        )}
-                                    </button>
-                                ))}
+            {/* Grouped specs */}
+            {product.spec_groups && product.spec_groups.length > 0 && (
+                <div className="border overflow-hidden">
+                    {product.spec_groups.map((group: any, gIdx: number) => (
+                        <div key={gIdx}>
+                            <div className="bg-muted px-4 py-2 text-xs font-bold uppercase tracking-wider border-b">
+                                {group.name}
                             </div>
-                        )}
-
-                        <div className="hidden lg:block">
-                            <WantToBuyCTA available_for_sale={product.available_for_sale} name={product.name} brand={product.brand?.name} href={`/buy-equipment/${slug}`} interestHref={`/interest/equipment/${slug}`} />
-                        </div>
-
-                        <div className="hidden lg:block flex-1">
-                            <SidebarPromo />
-                        </div>
-                    </div>
-
-                    {/* Right - Product Info */}
-                    <div className="space-y-4 lg:space-y-6">
-                        <div>
-                            <GuideProductTitle name={product.name} brand={product.brand?.name} />
-                            <div className="flex items-center gap-2 mt-2">
-                                {product.equipment_category && (
-                                    <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300">
-                                        {product.equipment_category.name}
-                                    </span>
-                                )}
-                                <ShareBar name={product.name} />
-                            </div>
-                        </div>
-
-                        <div className="lg:hidden space-y-4">
-                            <WantToBuyCTA available_for_sale={product.available_for_sale} name={product.name} brand={product.brand?.name} href={`/buy-equipment/${slug}`} interestHref={`/interest/equipment/${slug}`} />
-                            <SidebarPromo />
-                        </div>
-
-                        <div className="h-px bg-border" />
-
-                        {product.description && (
-                            <div>
-                                <h2 className="text-lg font-semibold mb-3 text-foreground">Overview</h2>
-                                <p className="text-muted-foreground leading-relaxed text-sm">{product.description}</p>
-                            </div>
-                        )}
-
-
-                        <AdSenseInFeed />
-
-                        {/* Grouped specs */}
-                        {product.spec_groups && product.spec_groups.length > 0 && (
-                            <div className="border overflow-hidden">
-                                {product.spec_groups.map((group: any, gIdx: number) => (
-                                    <div key={gIdx}>
-                                        <div className="bg-muted px-4 py-2 text-xs font-bold uppercase tracking-wider border-b">
-                                            {group.name}
-                                        </div>
-                                        <dl className="divide-y divide-border">
-                                            {group.specs.map((spec: any, sIdx: number) => (
-                                                <div key={sIdx} className="flex justify-between gap-4 px-4 py-2 text-sm">
-                                                    <dt className="text-muted-foreground">{spec.name}</dt>
-                                                    <dd className="font-medium text-foreground text-right">{spec.value}</dd>
-                                                </div>
-                                            ))}
-                                        </dl>
+                            <dl className="divide-y divide-border">
+                                {group.specs.map((spec: any, sIdx: number) => (
+                                    <div key={sIdx} className="flex justify-between gap-4 px-4 py-2 text-sm">
+                                        <dt className="text-muted-foreground">{spec.name}</dt>
+                                        <dd className="font-medium text-foreground text-right">{spec.value}</dd>
                                     </div>
                                 ))}
-                            </div>
-                        )}
-
-                        {/* Fallback: flat specs for backward compat */}
-                        {(!product.spec_groups || product.spec_groups.length === 0) && product.specifications && product.specifications.length > 0 && (
-                            <div className="rounded-xl border bg-card p-4">
-                                <h2 className="text-sm font-semibold uppercase tracking-wide text-green-700 dark:text-green-400 mb-3">Specifications</h2>
-                                <dl className="space-y-2">
-                                    {product.specifications.map((spec: any, idx: number) => (
-                                        <div key={idx} className="flex justify-between gap-4 text-sm">
-                                            <dt className="text-muted-foreground flex-shrink-0">{typeof spec === "string" ? spec : spec.name}</dt>
-                                            <dd className="font-medium text-foreground text-right">{typeof spec === "string" ? "" : spec.value}</dd>
-                                        </div>
-                                    ))}
-                                </dl>
-                            </div>
-                        )}
-
-                        {product.features && product.features.length > 0 && (
-                            <div className="rounded-xl border bg-card p-4">
-                                <h2 className="text-sm font-semibold uppercase tracking-wide text-blue-700 dark:text-blue-400 mb-3">Features</h2>
-                                <ul className="space-y-1.5">
-                                    {product.features.map((feature: string, idx: number) => (
-                                        <li key={idx} className="flex items-start gap-2 text-sm text-foreground">
-                                            <span className="h-1.5 w-1.5 rounded-full bg-blue-500 dark:bg-blue-400 flex-shrink-0 mt-1.5" />
-                                            <span>{feature}</span>
-                                        </li>
-                                    ))}
-                                </ul>
-                            </div>
-                        )}
-
-                    </div>
+                            </dl>
+                        </div>
+                    ))}
                 </div>
-            </div>
-        </div>
+            )}
+
+            {/* Fallback: flat specs */}
+            {(!product.spec_groups || product.spec_groups.length === 0) && product.specifications && product.specifications.length > 0 && (
+                <div className="rounded-xl border bg-card p-4">
+                    <h2 className="text-sm font-semibold uppercase tracking-wide text-green-700 dark:text-green-400 mb-3">Specifications</h2>
+                    <dl className="space-y-2">
+                        {product.specifications.map((spec: any, idx: number) => (
+                            <div key={idx} className="flex justify-between gap-4 text-sm">
+                                <dt className="text-muted-foreground flex-shrink-0">{typeof spec === "string" ? spec : spec.name}</dt>
+                                <dd className="font-medium text-foreground text-right">{typeof spec === "string" ? "" : spec.value}</dd>
+                            </div>
+                        ))}
+                    </dl>
+                </div>
+            )}
+
+            {/* Features */}
+            {product.features && product.features.length > 0 && (
+                <div className="rounded-xl border bg-card p-4">
+                    <h2 className="text-sm font-semibold uppercase tracking-wide text-blue-700 dark:text-blue-400 mb-3">Features</h2>
+                    <ul className="space-y-1.5">
+                        {product.features.map((feature: string, idx: number) => (
+                            <li key={idx} className="flex items-start gap-2 text-sm text-foreground">
+                                <span className="h-1.5 w-1.5 rounded-full bg-blue-500 dark:bg-blue-400 flex-shrink-0 mt-1.5" />
+                                <span>{feature}</span>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+        </GuideDetailLayout>
     )
 }

--- a/apps/client-fnp/app/(landing)/feed-guides/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/feed-guides/[slug]/page.tsx
@@ -1,16 +1,11 @@
 import type { Metadata } from "next"
-import Image from "next/image"
-import { AlertTriangle } from "lucide-react"
-import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
 import { BaseURL } from "@/lib/schemas"
 import { guardTestItem } from "@/lib/guardTestItem"
 import { ProductNotFound } from "@/components/shared/ProductNotFound"
-import { FeedBreadcrumb } from "./FeedBreadcrumb"
-import { WantToBuyCTA } from "@/components/shared/WantToBuyCTA"
-import { GuideProductTitle } from "@/components/shared/GuideProductTitle"
-import { ShareBar } from "@/components/shared/ShareBar"
-import { SidebarPromo } from "@/components/ads/SidebarPromo"
+import { GuideDetailLayout } from "@/components/shared/GuideDetailLayout"
+import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
 import { capitalizeFirstLetter } from "@/lib/utilities"
+import { FeedBreadcrumb } from "./FeedBreadcrumb"
 
 interface FeedDetailPageProps {
     params: Promise<{ slug: string }>
@@ -71,7 +66,7 @@ export default async function FeedDetailPage({ params }: FeedDetailPageProps) {
     await guardTestItem(!!product.is_test)
 
     const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://farmnport.com'
-    const url = `${baseUrl}/feeds/${slug}`
+    const url = `${baseUrl}/feed-guides/${slug}`
     const imageUrl = product.images?.[0]?.img?.src || `${baseUrl}/default-feed.png`
 
     const breadcrumbJsonLd = {
@@ -80,7 +75,7 @@ export default async function FeedDetailPage({ params }: FeedDetailPageProps) {
         "itemListElement": [
             { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://farmnport.com" },
             { "@type": "ListItem", "position": 2, "name": "Feed Guides", "item": "https://farmnport.com/feed-guides" },
-            { "@type": "ListItem", "position": 3, "name": product.name, "item": `https://farmnport.com/feed-guides/${slug}` },
+            { "@type": "ListItem", "position": 3, "name": product.name, "item": url },
         ],
     }
 
@@ -101,332 +96,223 @@ export default async function FeedDetailPage({ params }: FeedDetailPageProps) {
     }
 
     return (
-        <div className="min-h-screen bg-background">
-            <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
-            <script
-                type="application/ld+json"
-                dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
-            />
-
-            {/* Breadcrumb */}
-            <div className="border-b">
-                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
-                    <FeedBreadcrumb productName={product.name} />
-                </div>
-            </div>
-
-            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-                <div className="grid lg:grid-cols-[450px,1fr] gap-12 mb-16">
-
-                    {/* Left - Image */}
-                    <div className="flex flex-col gap-4">
-                        <div className="relative aspect-square bg-muted/30 dark:bg-white rounded-xl border overflow-hidden shadow-sm">
-                            {product.images?.[0]?.img?.src ? (
-                                <Image
-                                    src={product.images[0].img.src}
-                                    alt={product.name}
-                                    fill
-                                    sizes="(max-width: 1024px) 100vw, 450px"
-                                    className="object-contain p-8"
-                                    priority
-                                />
-                            ) : (
-                                <div className="absolute inset-0 bg-muted/20" />
-                            )}
-                        </div>
-
-                        {product.images && product.images.length > 1 && (
-                            <div className="grid grid-cols-4 gap-3">
-                                {product.images.slice(0, 4).map((img: any, idx: number) => (
-                                    <div key={idx} className="relative aspect-square bg-muted/30 dark:bg-white rounded-lg border hover:border-primary transition-colors">
-                                        {img.img?.src && (
-                                            <Image
-                                                src={img.img.src}
-                                                alt={`${product.name} ${idx + 1}`}
-                                                fill
-                                                sizes="(max-width: 1024px) 25vw, 100px"
-                                                className="object-contain p-2"
-                                            />
-                                        )}
-                                    </div>
-                                ))}
-                            </div>
-                        )}
-
-                        {/* Want to Buy CTA */}
-                        <WantToBuyCTA available_for_sale={product.available_for_sale} name={product.name} brand={product.brand?.name} href={`/buy-feeds/${slug}`} interestHref={`/interest/feed/${slug}`} />
-
-                        {/* Safety Warnings */}
-                        {product.safety_warnings && (
-                            <div className="rounded-lg border border-red-200 dark:border-red-900 bg-red-50/50 dark:bg-red-950/30 px-3 py-2">
-                                <h2 className="text-xs font-semibold uppercase tracking-wide text-red-700 dark:text-red-400 mb-1.5 flex items-center gap-1.5">
-                                    <AlertTriangle className="w-3.5 h-3.5" />
-                                    Safety Warning
-                                </h2>
-                                <p className="text-xs text-red-800 dark:text-red-300 whitespace-pre-line">{product.safety_warnings}</p>
-                            </div>
-                        )}
-
-                        {/* Promo - fills remaining sidebar space */}
-                        <div className="flex-1">
-                            <SidebarPromo />
-                        </div>
-                    </div>
-
-                    {/* Right - Product Info */}
-                    <div className="space-y-6">
-                        <GuideProductTitle name={product.name} brand={product.brand?.name} />
-                        <div className="mt-3"><ShareBar name={product.name} /></div>
-
-                        <div className="flex items-center gap-3 flex-wrap">
-                            {product.feed_category && (
-                                <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300">
-                                    {product.feed_category.name}
-                                </span>
-                            )}
-                        </div>
-
-                        <div className="h-px bg-border" />
-
-                        {/* Tags */}
-                        <div className="flex flex-wrap gap-2">
-                            {product.animal && (
-                                <span className="inline-flex items-center px-3 py-1.5 rounded-lg text-xs font-medium bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-600/10 dark:bg-amber-950/30 dark:text-amber-400">
-                                    {product.animal}
-                                </span>
-                            )}
-                            {product.phase && (
-                                <span className="inline-flex items-center px-3 py-1.5 rounded-lg text-xs font-medium bg-blue-50 text-blue-700 ring-1 ring-inset ring-blue-600/10 dark:bg-blue-950/30 dark:text-blue-400">
-                                    {product.phase}
-                                </span>
-                            )}
-                            {product.form && (
-                                <span className="inline-flex items-center px-3 py-1.5 rounded-lg text-xs font-medium bg-green-50 text-green-700 ring-1 ring-inset ring-green-600/10 dark:bg-green-950/30 dark:text-green-400">
-                                    {product.form}
-                                </span>
-                            )}
-                            {product.sub_type && (
-                                <span className="inline-flex items-center px-3 py-1.5 rounded-lg text-xs font-medium bg-violet-50 text-violet-700 ring-1 ring-inset ring-violet-600/10 dark:bg-violet-950/30 dark:text-violet-400">
-                                    {product.sub_type}
-                                </span>
-                            )}
-                        </div>
-
-                        {/* Description */}
-                        {product.description && (
-                            <div>
-                                <h2 className="text-lg font-semibold mb-3 text-foreground">Overview</h2>
-                                <p className="text-muted-foreground leading-relaxed text-sm">{product.description}</p>
-                            </div>
-                        )}
-
-
-                        {/* Breed Recommendations */}
-                        {product.breed_recommendations && (
-                            <div>
-                                <h2 className="text-lg font-semibold mb-2 text-foreground">Breed Recommendations</h2>
-                                <p className="text-muted-foreground text-sm whitespace-pre-line">{product.breed_recommendations}</p>
-                            </div>
-                        )}
-
-                        {/* Feeding Instructions */}
-                        {product.feeding_instructions && product.feeding_instructions.length > 0 && (
-                            <div>
-                                <h2 className="text-lg font-semibold mb-3 text-foreground">Feeding Instructions</h2>
-                                <div className="overflow-x-auto">
-                                    <table className="w-full text-sm">
-                                        <thead>
-                                            <tr className="border-b border-border">
-                                                <th className="text-left py-2 pr-4 font-medium text-foreground">Period</th>
-                                                <th className="text-left py-2 pr-4 font-medium text-foreground">Amount</th>
-                                                <th className="text-left py-2 font-medium text-foreground">Notes</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            {product.feeding_instructions.map((row: any, idx: number) => (
-                                                <tr key={idx} className="border-b border-border/50">
-                                                    <td className="py-2 pr-4 text-muted-foreground">{row.period}</td>
-                                                    <td className="py-2 pr-4 text-muted-foreground">{row.amount}</td>
-                                                    <td className="py-2 text-muted-foreground">{row.notes}</td>
-                                                </tr>
-                                            ))}
-                                        </tbody>
-                                    </table>
-                                </div>
-                            </div>
-                        )}
-
-                        {/* Management Tips */}
-                        {product.management_tips && (
-                            <div>
-                                <h2 className="text-lg font-semibold mb-2 text-foreground">Management Tips</h2>
-                                <p className="text-muted-foreground text-sm whitespace-pre-line">{product.management_tips}</p>
-                            </div>
-                        )}
-
-                        {/* Active Ingredients */}
-                        {product.active_ingredients && product.active_ingredients.length > 0 && (
-                            <div>
-                                <h2 className="text-lg font-semibold mb-3 text-foreground">Active Ingredients</h2>
-                                <div className="space-y-2">
-                                    {product.active_ingredients.map((ai: any, idx: number) => (
-                                        <div key={idx} className="flex items-center justify-between p-3 bg-gradient-to-r from-purple-50/50 to-transparent dark:from-purple-950/30 rounded-lg border border-purple-100 dark:border-purple-900">
-                                            <span className="font-medium capitalize text-sm text-foreground">{ai.name}</span>
-                                            {ai.concentration && (
-                                                <span className="font-bold text-purple-600 dark:text-purple-400">{ai.concentration}</span>
-                                            )}
-                                        </div>
-                                    ))}
-                                </div>
-                            </div>
-                        )}
-
-                        <AdSenseInFeed />
-
-                        {/* Nutritional Specifications */}
-                        {product.nutritional_specs && product.nutritional_specs.length > 0 && (
-                            <div>
-                                <h2 className="text-lg font-semibold mb-3 text-foreground">Nutritional Specifications</h2>
-                                <div className="rounded-lg border overflow-hidden">
-                                    <table className="w-full text-sm">
-                                        <thead>
-                                            <tr className="bg-muted/50">
-                                                <th className="text-left px-4 py-2.5 font-medium text-muted-foreground">Nutrient</th>
-                                                <th className="text-left px-4 py-2.5 font-medium text-muted-foreground">Qualifier</th>
-                                                <th className="text-right px-4 py-2.5 font-medium text-muted-foreground">Value</th>
-                                                <th className="text-right px-4 py-2.5 font-medium text-muted-foreground">Unit</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody className="divide-y">
-                                            {product.nutritional_specs.map((spec: any, idx: number) => (
-                                                <tr key={idx} className="hover:bg-muted/30 transition-colors">
-                                                    <td className="px-4 py-2.5 font-medium text-foreground capitalize">{spec.name}</td>
-                                                    <td className="px-4 py-2.5 text-muted-foreground capitalize">{spec.qualifier || "-"}</td>
-                                                    <td className="px-4 py-2.5 text-right font-semibold text-foreground">{spec.value}</td>
-                                                    <td className="px-4 py-2.5 text-right text-muted-foreground">{spec.unit}</td>
-                                                </tr>
-                                            ))}
-                                        </tbody>
-                                    </table>
-                                </div>
-                            </div>
-                        )}
-
-                        {/* Mixing Recommendations */}
-                        {product.mixing_recommendations && product.mixing_recommendations.length > 0 && (
-                            <div>
-                                <h2 className="text-lg font-semibold mb-3 text-foreground">Mixing Recommendations</h2>
-                                <div className="space-y-4">
-                                    {product.mixing_recommendations.map((mix: any, idx: number) => (
-                                        <div key={idx} className="rounded-lg border p-4">
-                                            <div className="flex items-center justify-between mb-3">
-                                                <h3 className="font-medium text-foreground">{mix.name || `Formulation ${idx + 1}`}</h3>
-                                                {mix.resulting_protein && (
-                                                    <span className="text-xs font-medium px-2 py-1 rounded-full bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300">
-                                                        {mix.resulting_protein} Protein
-                                                    </span>
-                                                )}
-                                            </div>
-                                            {mix.batch_size && (
-                                                <p className="text-xs text-muted-foreground mb-3">Batch size: {mix.batch_size}</p>
-                                            )}
-                                            {mix.ingredients && mix.ingredients.length > 0 && (
-                                                <div className="rounded-md border overflow-hidden">
-                                                    <table className="w-full text-sm">
-                                                        <thead>
-                                                            <tr className="bg-muted/50">
-                                                                <th className="text-left px-3 py-2 font-medium text-muted-foreground text-xs">Ingredient</th>
-                                                                <th className="text-right px-3 py-2 font-medium text-muted-foreground text-xs">Quantity</th>
-                                                            </tr>
-                                                        </thead>
-                                                        <tbody className="divide-y">
-                                                            {mix.ingredients.map((ing: any, ingIdx: number) => (
-                                                                <tr key={ingIdx}>
-                                                                    <td className="px-3 py-2 text-foreground">{ing.name}</td>
-                                                                    <td className="px-3 py-2 text-right text-muted-foreground">{ing.quantity} {ing.unit}</td>
-                                                                </tr>
-                                                            ))}
-                                                        </tbody>
-                                                    </table>
-                                                </div>
-                                            )}
-                                            {mix.notes && (
-                                                <p className="mt-3 text-xs text-muted-foreground italic">{mix.notes}</p>
-                                            )}
-                                        </div>
-                                    ))}
-                                </div>
-                            </div>
-                        )}
-
-                        {/* Adaptation Schedule */}
-                        {product.adaptation_schedule && product.adaptation_schedule.length > 0 && (
-                            <div>
-                                <h2 className="text-lg font-semibold mb-3 text-foreground">Adaptation Schedule</h2>
-                                <div className="rounded-lg border overflow-hidden">
-                                    <table className="w-full text-sm">
-                                        <thead>
-                                            <tr className="bg-muted/50">
-                                                <th className="text-left px-4 py-2.5 font-medium text-muted-foreground">Day</th>
-                                                <th className="text-left px-4 py-2.5 font-medium text-muted-foreground">Amount</th>
-                                                <th className="text-left px-4 py-2.5 font-medium text-muted-foreground">Notes</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody className="divide-y">
-                                            {product.adaptation_schedule.map((step: any, idx: number) => (
-                                                <tr key={idx} className="hover:bg-muted/30 transition-colors">
-                                                    <td className="px-4 py-2.5 font-medium text-foreground">{step.day}</td>
-                                                    <td className="px-4 py-2.5 text-foreground">{step.amount}</td>
-                                                    <td className="px-4 py-2.5 text-muted-foreground">{step.notes || "-"}</td>
-                                                </tr>
-                                            ))}
-                                        </tbody>
-                                    </table>
-                                </div>
-                            </div>
-                        )}
+        <GuideDetailLayout
+            product={product}
+            breadcrumbs={[
+                { label: "Feed Guides", href: "/feed-guides" },
+                { label: product.name, href: url },
+            ]}
+            categoryBadge={product.feed_category ? { label: product.feed_category.name } : undefined}
+            buyHref={`/buy-feeds/${slug}`}
+            interestHref={`/interest/feed/${slug}`}
+            safetyText="Always follow the manufacturer's feeding guidelines and recommended dosage rates. Consult a veterinarian or animal nutritionist for advice specific to your livestock. Store feed products in a cool, dry place away from direct sunlight."
+            structuredData={structuredData}
+            breadcrumbJsonLd={breadcrumbJsonLd}
+            safetyWarnings={product.safety_warnings}
+            customBreadcrumb={
+                <div className="border-b">
+                    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+                        <FeedBreadcrumb productName={product.name} />
                     </div>
                 </div>
-
-                {/* Product Labels */}
-                {(product.front_label?.img?.src || product.back_label?.img?.src) && (
-                    <div className="mb-12">
-                        <h2 className="text-2xl font-bold mb-6">Product Labels</h2>
-                        <div className="grid md:grid-cols-2 gap-6">
-                            {product.front_label?.img?.src && (
-                                <div className="space-y-3">
-                                    <h3 className="text-lg font-semibold">Front Label</h3>
-                                    <div className="relative aspect-[3/4] bg-white rounded-lg border overflow-hidden">
-                                        <Image src={product.front_label.img.src} alt={`${product.name} - Front Label`} fill sizes="(max-width: 768px) 100vw, 50vw" className="object-contain p-4" />
-                                    </div>
-                                </div>
-                            )}
-                            {product.back_label?.img?.src && (
-                                <div className="space-y-3">
-                                    <h3 className="text-lg font-semibold">Back Label</h3>
-                                    <div className="relative aspect-[3/4] bg-white rounded-lg border overflow-hidden">
-                                        <Image src={product.back_label.img.src} alt={`${product.name} - Back Label`} fill sizes="(max-width: 768px) 100vw, 50vw" className="object-contain p-4" />
-                                    </div>
-                                </div>
-                            )}
-                        </div>
-                    </div>
+            }
+        >
+            {/* Tags */}
+            <div className="flex flex-wrap gap-2">
+                {product.animal && (
+                    <span className="inline-flex items-center px-3 py-1.5 rounded-lg text-xs font-medium bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-600/10 dark:bg-amber-950/30 dark:text-amber-400">
+                        {product.animal}
+                    </span>
                 )}
+                {product.phase && (
+                    <span className="inline-flex items-center px-3 py-1.5 rounded-lg text-xs font-medium bg-blue-50 text-blue-700 ring-1 ring-inset ring-blue-600/10 dark:bg-blue-950/30 dark:text-blue-400">
+                        {product.phase}
+                    </span>
+                )}
+                {product.form && (
+                    <span className="inline-flex items-center px-3 py-1.5 rounded-lg text-xs font-medium bg-green-50 text-green-700 ring-1 ring-inset ring-green-600/10 dark:bg-green-950/30 dark:text-green-400">
+                        {product.form}
+                    </span>
+                )}
+                {product.sub_type && (
+                    <span className="inline-flex items-center px-3 py-1.5 rounded-lg text-xs font-medium bg-violet-50 text-violet-700 ring-1 ring-inset ring-violet-600/10 dark:bg-violet-950/30 dark:text-violet-400">
+                        {product.sub_type}
+                    </span>
+                )}
+            </div>
 
-                {/* Safety / Disclaimer */}
-                <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-lg p-6">
-                    <div className="flex items-start gap-3">
-                        <AlertTriangle className="w-6 h-6 text-yellow-600 dark:text-yellow-500 flex-shrink-0" />
-                        <div>
-                            <h3 className="font-semibold mb-2 text-yellow-900 dark:text-yellow-100">Important Notice</h3>
-                            <p className="text-sm text-yellow-800 dark:text-yellow-200">
-                                Always follow the manufacturer&apos;s feeding guidelines and recommended dosage rates. Consult a veterinarian or animal nutritionist for advice specific to your livestock. Store feed products in a cool, dry place away from direct sunlight.
-                            </p>
-                        </div>
+            {/* Description */}
+            {product.description && (
+                <div>
+                    <h2 className="text-lg font-semibold mb-3 text-foreground">Overview</h2>
+                    <p className="text-muted-foreground leading-relaxed text-sm">{product.description}</p>
+                </div>
+            )}
+
+            {/* Breed Recommendations */}
+            {product.breed_recommendations && (
+                <div>
+                    <h2 className="text-lg font-semibold mb-2 text-foreground">Breed Recommendations</h2>
+                    <p className="text-muted-foreground text-sm whitespace-pre-line">{product.breed_recommendations}</p>
+                </div>
+            )}
+
+            {/* Feeding Instructions */}
+            {product.feeding_instructions && product.feeding_instructions.length > 0 && (
+                <div>
+                    <h2 className="text-lg font-semibold mb-3 text-foreground">Feeding Instructions</h2>
+                    <div className="overflow-x-auto">
+                        <table className="w-full text-sm">
+                            <thead>
+                                <tr className="border-b border-border">
+                                    <th className="text-left py-2 pr-4 font-medium text-foreground">Period</th>
+                                    <th className="text-left py-2 pr-4 font-medium text-foreground">Amount</th>
+                                    <th className="text-left py-2 font-medium text-foreground">Notes</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {product.feeding_instructions.map((row: any, idx: number) => (
+                                    <tr key={idx} className="border-b border-border/50">
+                                        <td className="py-2 pr-4 text-muted-foreground">{row.period}</td>
+                                        <td className="py-2 pr-4 text-muted-foreground">{row.amount}</td>
+                                        <td className="py-2 text-muted-foreground">{row.notes}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
                     </div>
                 </div>
+            )}
 
-            </div>
-        </div>
+            {/* Management Tips */}
+            {product.management_tips && (
+                <div>
+                    <h2 className="text-lg font-semibold mb-2 text-foreground">Management Tips</h2>
+                    <p className="text-muted-foreground text-sm whitespace-pre-line">{product.management_tips}</p>
+                </div>
+            )}
+
+            {/* Active Ingredients */}
+            {product.active_ingredients && product.active_ingredients.length > 0 && (
+                <div>
+                    <h2 className="text-lg font-semibold mb-3 text-foreground">Active Ingredients</h2>
+                    <div className="space-y-2">
+                        {product.active_ingredients.map((ai: any, idx: number) => (
+                            <div key={idx} className="flex items-center justify-between p-3 bg-gradient-to-r from-purple-50/50 to-transparent dark:from-purple-950/30 rounded-lg border border-purple-100 dark:border-purple-900">
+                                <span className="font-medium capitalize text-sm text-foreground">{ai.name}</span>
+                                {ai.concentration && (
+                                    <span className="font-bold text-purple-600 dark:text-purple-400">{ai.concentration}</span>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            )}
+
+            <AdSenseInFeed />
+
+            {/* Nutritional Specifications */}
+            {product.nutritional_specs && product.nutritional_specs.length > 0 && (
+                <div>
+                    <h2 className="text-lg font-semibold mb-3 text-foreground">Nutritional Specifications</h2>
+                    <div className="rounded-lg border overflow-hidden">
+                        <table className="w-full text-sm">
+                            <thead>
+                                <tr className="bg-muted/50">
+                                    <th className="text-left px-4 py-2.5 font-medium text-muted-foreground">Nutrient</th>
+                                    <th className="text-left px-4 py-2.5 font-medium text-muted-foreground">Qualifier</th>
+                                    <th className="text-right px-4 py-2.5 font-medium text-muted-foreground">Value</th>
+                                    <th className="text-right px-4 py-2.5 font-medium text-muted-foreground">Unit</th>
+                                </tr>
+                            </thead>
+                            <tbody className="divide-y">
+                                {product.nutritional_specs.map((spec: any, idx: number) => (
+                                    <tr key={idx} className="hover:bg-muted/30 transition-colors">
+                                        <td className="px-4 py-2.5 font-medium text-foreground capitalize">{spec.name}</td>
+                                        <td className="px-4 py-2.5 text-muted-foreground capitalize">{spec.qualifier || "-"}</td>
+                                        <td className="px-4 py-2.5 text-right font-semibold text-foreground">{spec.value}</td>
+                                        <td className="px-4 py-2.5 text-right text-muted-foreground">{spec.unit}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            )}
+
+            {/* Mixing Recommendations */}
+            {product.mixing_recommendations && product.mixing_recommendations.length > 0 && (
+                <div>
+                    <h2 className="text-lg font-semibold mb-3 text-foreground">Mixing Recommendations</h2>
+                    <div className="space-y-4">
+                        {product.mixing_recommendations.map((mix: any, idx: number) => (
+                            <div key={idx} className="rounded-lg border p-4">
+                                <div className="flex items-center justify-between mb-3">
+                                    <h3 className="font-medium text-foreground">{mix.name || `Formulation ${idx + 1}`}</h3>
+                                    {mix.resulting_protein && (
+                                        <span className="text-xs font-medium px-2 py-1 rounded-full bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300">
+                                            {mix.resulting_protein} Protein
+                                        </span>
+                                    )}
+                                </div>
+                                {mix.batch_size && (
+                                    <p className="text-xs text-muted-foreground mb-3">Batch size: {mix.batch_size}</p>
+                                )}
+                                {mix.ingredients && mix.ingredients.length > 0 && (
+                                    <div className="rounded-md border overflow-hidden">
+                                        <table className="w-full text-sm">
+                                            <thead>
+                                                <tr className="bg-muted/50">
+                                                    <th className="text-left px-3 py-2 font-medium text-muted-foreground text-xs">Ingredient</th>
+                                                    <th className="text-right px-3 py-2 font-medium text-muted-foreground text-xs">Quantity</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody className="divide-y">
+                                                {mix.ingredients.map((ing: any, ingIdx: number) => (
+                                                    <tr key={ingIdx}>
+                                                        <td className="px-3 py-2 text-foreground">{ing.name}</td>
+                                                        <td className="px-3 py-2 text-right text-muted-foreground">{ing.quantity} {ing.unit}</td>
+                                                    </tr>
+                                                ))}
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                )}
+                                {mix.notes && (
+                                    <p className="mt-3 text-xs text-muted-foreground italic">{mix.notes}</p>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            )}
+
+            {/* Adaptation Schedule */}
+            {product.adaptation_schedule && product.adaptation_schedule.length > 0 && (
+                <div>
+                    <h2 className="text-lg font-semibold mb-3 text-foreground">Adaptation Schedule</h2>
+                    <div className="rounded-lg border overflow-hidden">
+                        <table className="w-full text-sm">
+                            <thead>
+                                <tr className="bg-muted/50">
+                                    <th className="text-left px-4 py-2.5 font-medium text-muted-foreground">Day</th>
+                                    <th className="text-left px-4 py-2.5 font-medium text-muted-foreground">Amount</th>
+                                    <th className="text-left px-4 py-2.5 font-medium text-muted-foreground">Notes</th>
+                                </tr>
+                            </thead>
+                            <tbody className="divide-y">
+                                {product.adaptation_schedule.map((step: any, idx: number) => (
+                                    <tr key={idx} className="hover:bg-muted/30 transition-colors">
+                                        <td className="px-4 py-2.5 font-medium text-foreground">{step.day}</td>
+                                        <td className="px-4 py-2.5 text-foreground">{step.amount}</td>
+                                        <td className="px-4 py-2.5 text-muted-foreground">{step.notes || "-"}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            )}
+        </GuideDetailLayout>
     )
 }

--- a/apps/client-fnp/app/(landing)/plant-nutrition-guides/[category]/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/plant-nutrition-guides/[category]/[slug]/page.tsx
@@ -1,17 +1,11 @@
 import type { Metadata } from 'next'
-import Image from "next/image"
-import { Beaker, AlertTriangle } from "lucide-react"
-import Link from "next/link"
-import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
+import { ActiveIngredientsList } from "@/components/shared/ActiveIngredientUnitsKey"
 import { capitalizeFirstLetter, buildGuideMetadata } from "@/lib/utilities"
 import { BaseURL } from "@/lib/schemas"
 import { FertilizerApplicationRates } from "@/components/agrochemical/FertilizerApplicationRates"
 import { AgrochemicalDosageTable } from "@/components/agrochemical/AgrochemicalDosageTable"
-import { ActiveIngredientsList } from "@/components/shared/ActiveIngredientUnitsKey"
-import { WantToBuyCTA } from "@/components/shared/WantToBuyCTA"
-import { GuideProductTitle } from "@/components/shared/GuideProductTitle"
-import { ShareBar } from "@/components/shared/ShareBar"
-import { SidebarPromo } from "@/components/ads/SidebarPromo"
+import { GuideDetailLayout } from "@/components/shared/GuideDetailLayout"
+import { ProductNotFound } from "@/components/shared/ProductNotFound"
 
 type Props = { params: Promise<{ category: string; slug: string }> }
 
@@ -44,14 +38,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return buildGuideMetadata(product, categorySingularTitle, 'Application Rates & Guide', description, `/plant-nutrition-guides/${category}/${slug}`, product.images?.[0]?.img?.src, keywords)
 }
 
-interface GuidePageProps {
-    params: Promise<{
-        category: string
-        slug: string
-    }>
-}
+const DISCLAIMER = "Disclaimer: The information provided on this page, including active ingredients, dosage rates, application methods, and safety guidelines, has been compiled from publicly available product labels, manufacturer datasheets, and other third-party sources. Farmnport does not manufacture, formulate, or independently verify the accuracy, completeness, or currency of this information. Product formulations, registrations, and label directions may change without notice. Always refer to the official product label accompanying the purchased product for the most up-to-date and legally binding instructions. Farmnport accepts no liability for any loss, damage, crop injury, or adverse outcome arising from the use of, or reliance on, the information presented here. Use of any product is entirely at the user's own risk."
 
 const fetchOptions: RequestInit = { cache: "no-store" }
+
+interface GuidePageProps {
+    params: Promise<{ category: string; slug: string }>
+}
 
 export default async function PlantNutritionGuidePage({ params }: GuidePageProps) {
     const { category, slug } = await params
@@ -59,44 +52,16 @@ export default async function PlantNutritionGuidePage({ params }: GuidePageProps
     const product = res.ok ? await res.json() : null
 
     if (!product) {
-        return (
-            <div className="min-h-screen bg-background flex items-center justify-center px-4 pb-4">
-                <div className="text-center max-w-md">
-                    <div className="mb-6">
-                        <div className="mx-auto w-20 h-20 bg-muted rounded-full flex items-center justify-center">
-                            <Beaker className="w-10 h-10 text-muted-foreground" />
-                        </div>
-                    </div>
-                    <h2 className="text-2xl font-semibold mb-2">Guide Not Found</h2>
-                    <p className="text-muted-foreground mb-6">
-                        We couldn&apos;t find the plant nutrition guide you&apos;re looking for. It may have been removed or the link might be incorrect.
-                    </p>
-                    <div className="flex flex-col sm:flex-row gap-3 justify-center">
-                        <Link href="/plant-nutrition-guides">
-                            <button className="inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2">
-                                Browse All Guides
-                            </button>
-                        </Link>
-                        <Link href="/plant-nutrition-guides">
-                            <button className="inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2">
-                                Go to Categories
-                            </button>
-                        </Link>
-                    </div>
-                </div>
-            </div>
-        )
+        return <ProductNotFound title="Plant Nutrition Guide Not Found" description="The plant nutrition guide you're looking for doesn't exist or may have been removed." primary={{ href: "/plant-nutrition-guides", label: "Browse All Guides" }} secondary={{ href: "/plant-nutrition-guides", label: "Go to Categories" }} />
     }
-
-    const categorySlug = product?.plant_nutrition_category?.slug || category
 
     const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://farmnport.com'
     const url = `${baseUrl}/plant-nutrition-guides/${category}/${slug}`
     const imageUrl = product.images?.[0]?.img?.src || `${baseUrl}/default-chemical.png`
 
     const description = product.plant_nutrition_category?.name
-        ? `${product.name} is a ${product.plant_nutrition_category.name}. View active ingredients and application rates.`
-        : `Plant nutrition guide for ${product.name}. Complete information on active ingredients and application rates.`
+        ? `${product.name} is a ${product.plant_nutrition_category.name}. View composition and application rates.`
+        : `Plant nutrition guide for ${product.name}. Complete information on composition and application rates.`
 
     const breadcrumbJsonLd = {
         "@context": "https://schema.org",
@@ -104,8 +69,8 @@ export default async function PlantNutritionGuidePage({ params }: GuidePageProps
         "itemListElement": [
             { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://farmnport.com" },
             { "@type": "ListItem", "position": 2, "name": "Plant Nutrition Guides", "item": "https://farmnport.com/plant-nutrition-guides" },
-            { "@type": "ListItem", "position": 3, "name": product.plant_nutrition_category?.name || category, "item": `https://farmnport.com/plant-nutrition-guides/${categorySlug}` },
-            { "@type": "ListItem", "position": 4, "name": product.name, "item": `https://farmnport.com/plant-nutrition-guides/${category}/${slug}` },
+            { "@type": "ListItem", "position": 3, "name": product.plant_nutrition_category?.name || category, "item": `https://farmnport.com/plant-nutrition-guides/${product.plant_nutrition_category?.slug || category}` },
+            { "@type": "ListItem", "position": 4, "name": product.name, "item": url },
         ],
     }
 
@@ -119,217 +84,69 @@ export default async function PlantNutritionGuidePage({ params }: GuidePageProps
         "url": url,
         "additionalProperty": product.active_ingredients?.map((ai: any) => ({
             "@type": "PropertyValue",
-            "name": "Active Ingredient",
+            "name": "Composition",
             "value": `${ai.name} (${ai.dosage_value} ${ai.dosage_unit})`
         })) || [],
         "brand": product.brand ? { "@type": "Brand", "name": product.brand.name } : undefined,
     }
 
+    const dosageTable = product.dosage_rates?.length > 0 ? (
+        product.dosage_rates.every((r: any) => !r.crop_group_id && r.crop_group)
+            ? <FertilizerApplicationRates dosageRates={product.dosage_rates} />
+            : <AgrochemicalDosageTable dosageRates={product.dosage_rates} />
+    ) : null
+
     return (
-        <div className="min-h-screen bg-background">
-            <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
-            <script
-                type="application/ld+json"
-                dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
-            />
-
-            {/* Breadcrumb */}
-            <div className="border-b">
-                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
-                    <nav className="flex text-sm text-muted-foreground">
-                        <Link href="/" className="hover:text-foreground">Home</Link>
-                        <span className="mx-2">/</span>
-                        <Link href="/plant-nutrition-guides" className="hover:text-foreground">Plant Nutrition Guides</Link>
-                        <span className="mx-2">/</span>
-                        <Link href={`/plant-nutrition-guides/${categorySlug}`} className="hover:text-foreground capitalize">{product.plant_nutrition_category?.name || category}</Link>
-                        <span className="mx-2">/</span>
-                        <span className="text-foreground capitalize">{product.name}</span>
-                    </nav>
-                </div>
+        <GuideDetailLayout
+            product={product}
+            breadcrumbs={[
+                { label: "Plant Nutrition Guides", href: "/plant-nutrition-guides" },
+                { label: product.plant_nutrition_category?.name || category, href: `/plant-nutrition-guides/${product.plant_nutrition_category?.slug || category}` },
+                { label: product.name, href: url },
+            ]}
+            categoryBadge={product.plant_nutrition_category ? { label: product.plant_nutrition_category.name, color: "green" } : undefined}
+            buyHref={`/buy-plant-nutrition/${slug}`}
+            interestHref={`/interest/plant-nutrition/${slug}`}
+            safetyText="Always read and follow label directions. Wear appropriate personal protective equipment (PPE) when handling plant nutrition products. Store in original containers in a secure location away from children and animals. Dispose of containers properly according to local regulations."
+            disclaimerText={DISCLAIMER}
+            structuredData={structuredData}
+            breadcrumbJsonLd={breadcrumbJsonLd}
+            bottomContent={dosageTable}
+        >
+            {/* Overview */}
+            <div>
+                <h2 className="text-lg font-semibold mb-3 text-foreground">Overview</h2>
+                <p className="text-muted-foreground leading-relaxed text-sm">
+                    {product.description ? (
+                        product.description
+                    ) : (
+                        <><span className="font-medium text-foreground">{capitalizeFirstLetter(product.name)}</span> is a {product.plant_nutrition_category?.name?.toLowerCase() || 'plant nutrition product'} designed to support crop health and productivity.</>
+                    )}
+                </p>
             </div>
 
-            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-                {/* Header Section */}
-                <div className="grid lg:grid-cols-[450px,1fr] gap-12 mb-16">
-                    {/* Left - Image + Precautions */}
-                    <div className="flex flex-col gap-4">
-                        <div className="relative aspect-square bg-muted/30 dark:bg-white rounded-xl border overflow-hidden shadow-sm">
-                            {product.images && product.images[0] && product.images[0].img?.src ? (
-                                <Image
-                                    src={product.images[0].img.src}
-                                    alt={product.name}
-                                    fill
-                                    sizes="(max-width: 1024px) 100vw, 450px"
-                                    className="object-contain p-8"
-                                    priority
-                                />
-                            ) : (
-                                <div className="absolute inset-0 bg-muted/30" />
-                            )}
-                        </div>
-
-                        {/* Thumbnail Gallery */}
-                        {product.images && product.images.length > 1 && (
-                            <div className="grid grid-cols-4 gap-3">
-                                {product.images.slice(0, 4).map((img: any, idx: number) => (
-                                    <div key={idx} className="relative aspect-square bg-muted/30 dark:bg-white rounded-lg border hover:border-primary transition-colors">
-                                        {img.img?.src && (
-                                            <Image
-                                                src={img.img.src}
-                                                alt={`${product.name} ${idx + 1}`}
-                                                fill
-                                                sizes="(max-width: 1024px) 25vw, 100px"
-                                                className="object-contain p-2"
-                                            />
-                                        )}
-                                    </div>
-                                ))}
-                            </div>
-                        )}
-
-                        {/* Want to Buy CTA */}
-                        <WantToBuyCTA available_for_sale={product.available_for_sale} name={product.name} brand={product.brand?.name} href={`/buy-plant-nutrition/${slug}`} interestHref={`/interest/plant-nutrition/${slug}`} />
-
-                        {/* Precautions */}
-                        {product.precautions && product.precautions.length > 0 && (
-                            <div className="rounded-lg border border-red-200 dark:border-red-900 bg-red-50/50 dark:bg-red-950/30 px-3 py-2">
-                                <h2 className="text-xs font-semibold uppercase tracking-wide text-red-700 dark:text-red-400 mb-1.5 flex items-center gap-1.5">
-                                    <AlertTriangle className="w-3.5 h-3.5" />
-                                    Precautions
-                                </h2>
-                                <ul className="space-y-0.5">
-                                    {product.precautions.map((precaution: string, idx: number) => (
-                                        <li key={idx} className="flex items-start gap-1.5 text-xs text-red-800 dark:text-red-300">
-                                            <span className="h-1 w-1 rounded-full bg-red-500 dark:bg-red-400 flex-shrink-0 mt-1.5" />
-                                            <span>{precaution}</span>
-                                        </li>
-                                    ))}
-                                </ul>
-                            </div>
-                        )}
-
-                        {/* Promo - fills remaining sidebar space */}
-                        <div className="flex-1">
-                            <SidebarPromo />
-                        </div>
-                    </div>
-
-                    {/* Right - Product Info */}
-                    <div className="space-y-6">
-                        <GuideProductTitle name={product.name} brand={product.brand?.name} />
-                        <div className="mt-3"><ShareBar name={product.name} /></div>
-
-                        {/* Category Badge */}
-                        <div className="flex items-center gap-3 flex-wrap">
-                            {product.plant_nutrition_category && (
-                                <div className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300">
-                                    {product.plant_nutrition_category.name}
-                                </div>
-                            )}
-                        </div>
-
-                        <div className="h-px bg-border" />
-
-                        {/* Overview */}
-                        <div>
-                            <h2 className="text-lg font-semibold mb-3 text-foreground">Overview</h2>
-                            <p className="text-muted-foreground leading-relaxed text-sm">
-                                {product.description ? (
-                                    product.description
-                                ) : (
-                                    <><span className="font-medium text-foreground">{capitalizeFirstLetter(product.name)}</span> is a {product.plant_nutrition_category?.name?.toLowerCase() || 'plant nutrition product'} designed to support crop health and productivity.</>
-                                )}
-                            </p>
-                        </div>
-
-                        {/* Active Ingredients */}
-                        <div>
-                            <h2 className="text-lg font-semibold mb-1 text-foreground">Active Ingredients</h2>
-                            <ActiveIngredientsList activeIngredients={product.active_ingredients || []} />
-                        </div>
-
-                        <AdSenseInFeed />
-
-                        {/* Used On */}
-                        {product.dosage_rates && product.dosage_rates.length > 0 && (
-                            <div className="rounded-xl border bg-card p-4">
-                                <h2 className="text-sm font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-400 mb-3">
-                                    Used On
-                                </h2>
-                                <ul className="space-y-1.5">
-                                    {Array.from(new Set(product.dosage_rates.map((rate: any) => rate.crop_group))).map((crop: any, idx: number) => (
-                                        <li key={idx} className="flex items-center gap-2 text-sm text-foreground">
-                                            <span className="h-1.5 w-1.5 rounded-full bg-amber-500 dark:bg-amber-400 flex-shrink-0" />
-                                            <span className="capitalize">{crop}</span>
-                                        </li>
-                                    ))}
-                                </ul>
-                            </div>
-                        )}
-                    </div>
-                </div>
-
-                {/* Application Rates */}
-                {product.dosage_rates && product.dosage_rates.length > 0 && (
-                    product.dosage_rates.every((r: any) => !r.crop_group_id && r.crop_group)
-                        ? <FertilizerApplicationRates dosageRates={product.dosage_rates} />
-                        : <AgrochemicalDosageTable dosageRates={product.dosage_rates} />
-                )}
-
-                {/* Product Labels */}
-                {(product.front_label?.img?.src || product.back_label?.img?.src) && (
-                    <div className="mb-12">
-                        <h2 className="text-2xl font-bold mb-6">Product Labels</h2>
-                        <div className="grid md:grid-cols-2 gap-6">
-                            {product.front_label?.img?.src && (
-                                <div className="space-y-3">
-                                    <h3 className="text-lg font-semibold">Front Label</h3>
-                                    <div className="relative aspect-[3/4] bg-white rounded-lg border overflow-hidden">
-                                        <Image
-                                            src={product.front_label.img.src}
-                                            alt={`${product.name} - Front Label`}
-                                            fill
-                                            sizes="(max-width: 768px) 100vw, 50vw"
-                                            className="object-contain p-4"
-                                        />
-                                    </div>
-                                </div>
-                            )}
-                            {product.back_label?.img?.src && (
-                                <div className="space-y-3">
-                                    <h3 className="text-lg font-semibold">Back Label</h3>
-                                    <div className="relative aspect-[3/4] bg-white rounded-lg border overflow-hidden">
-                                        <Image
-                                            src={product.back_label.img.src}
-                                            alt={`${product.name} - Back Label`}
-                                            fill
-                                            sizes="(max-width: 768px) 100vw, 50vw"
-                                            className="object-contain p-4"
-                                        />
-                                    </div>
-                                </div>
-                            )}
-                        </div>
-                    </div>
-                )}
-
-                {/* Safety Warning */}
-                <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-lg p-6">
-                    <div className="flex items-start gap-3">
-                        <AlertTriangle className="w-6 h-6 text-yellow-600 dark:text-yellow-500 flex-shrink-0" />
-                        <div>
-                            <h3 className="font-semibold mb-2 text-yellow-900 dark:text-yellow-100">Safety Information</h3>
-                            <p className="text-sm text-yellow-800 dark:text-yellow-200">
-                                Always read and follow label directions. Wear appropriate personal protective equipment (PPE) when handling plant nutrition products.
-                                Store in original containers in a secure location away from children and animals. Dispose of containers properly according to local regulations.
-                            </p>
-                            <p className="text-xs text-black dark:text-white mt-2">
-                                Disclaimer: The information provided on this page, including active ingredients, dosage rates, application methods, and safety guidelines, has been compiled from publicly available product labels, manufacturer datasheets, and other third-party sources. Farmnport does not manufacture, formulate, or independently verify the accuracy, completeness, or currency of this information. Product formulations, registrations, and label directions may change without notice. Always refer to the official product label accompanying the purchased product for the most up-to-date and legally binding instructions. Farmnport accepts no liability for any loss, damage, crop injury, or adverse outcome arising from the use of, or reliance on, the information presented here. Use of any product is entirely at the user&#39;s own risk.
-                            </p>
-                        </div>
-                    </div>
-                </div>
+            {/* Composition (not "Active Ingredients" for plant nutrition) */}
+            <div>
+                <h2 className="text-lg font-semibold mb-1 text-foreground">Composition</h2>
+                <ActiveIngredientsList activeIngredients={product.active_ingredients || []} />
             </div>
-        </div>
+
+            {/* Used On */}
+            {product.dosage_rates && product.dosage_rates.length > 0 && (
+                <div className="rounded-xl border bg-card p-4">
+                    <h2 className="text-sm font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-400 mb-3">
+                        Used On
+                    </h2>
+                    <ul className="space-y-1.5">
+                        {Array.from(new Set(product.dosage_rates.map((rate: any) => rate.crop_group))).map((crop: any, idx: number) => (
+                            <li key={idx} className="flex items-center gap-2 text-sm text-foreground">
+                                <span className="h-1.5 w-1.5 rounded-full bg-amber-500 dark:bg-amber-400 flex-shrink-0" />
+                                <span className="capitalize">{crop}</span>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            )}
+        </GuideDetailLayout>
     )
 }

--- a/apps/client-fnp/app/(landing)/seed-guides/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/seed-guides/[slug]/page.tsx
@@ -1,13 +1,8 @@
 import { serverFetch } from "@/lib/serverFetch"
-import Image from "next/image"
-import Link from "next/link"
-import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
-import { SidebarPromo } from "@/components/ads/SidebarPromo"
-import { WantToBuyCTA } from "@/components/shared/WantToBuyCTA"
-import { GuideProductTitle } from "@/components/shared/GuideProductTitle"
-import { ShareBar } from "@/components/shared/ShareBar"
 import { formatProductName } from "@/lib/utilities"
 import { ProductNotFound } from "@/components/shared/ProductNotFound"
+import { GuideDetailLayout } from "@/components/shared/GuideDetailLayout"
+import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
 
 interface Props {
     params: Promise<{ slug: string }>
@@ -50,184 +45,93 @@ export default async function SeedGuidePage({ params }: Props) {
         "brand": { "@type": "Brand", "name": product.brand?.name || "farmnport" },
     }
 
-    const hasPlantingGuide = product.planting_guide?.length > 0
     const categoryLabel = [product.variety, product.type?.replace("_", " ")].filter(Boolean).join(" · ")
+    const hasPlantingGuide = product.planting_guide?.length > 0
+
+    const plantingGuide = hasPlantingGuide ? (
+        <div className="mb-12">
+            <h2 className="text-2xl font-bold mb-6">Planting Guide</h2>
+            <ol className="space-y-4">
+                {product.planting_guide.map((step: any, i: number) => (
+                    <li key={i} className="flex gap-4">
+                        <span className="flex-shrink-0 w-8 h-8 rounded-full bg-primary/10 text-primary flex items-center justify-center text-sm font-semibold">{i + 1}</span>
+                        <div className="pt-1">
+                            <p className="font-medium text-foreground text-sm">{step.step}</p>
+                            {step.notes && <p className="text-muted-foreground text-sm mt-0.5">{step.notes}</p>}
+                        </div>
+                    </li>
+                ))}
+            </ol>
+        </div>
+    ) : null
 
     return (
-        <div className="min-h-screen bg-background">
-            <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }} />
-
-            {/* Breadcrumb */}
-            <div className="border-b">
-                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
-                    <nav className="flex text-sm text-muted-foreground">
-                        <Link href="/" className="hover:text-foreground">Home</Link>
-                        <span className="mx-2">/</span>
-                        <Link href="/seed-guides" className="hover:text-foreground">Seed Guides</Link>
-                        <span className="mx-2">/</span>
-                        <Link href="/seed-guides" className="hover:text-foreground">Seed Guides</Link>
-                        <span className="mx-2">/</span>
-                        <span className="text-foreground capitalize">{product.name}</span>
-                    </nav>
+        <GuideDetailLayout
+            product={product}
+            breadcrumbs={[
+                { label: "Seed Guides", href: "/seed-guides" },
+                { label: product.name, href: `/seed-guides/${slug}` },
+            ]}
+            categoryBadge={categoryLabel ? { label: categoryLabel, color: "green" } : undefined}
+            buyHref={`/buy-seed-products/${slug}`}
+            interestHref={`/interest/seed/${slug}`}
+            safetyText="Always follow recommended planting guidelines and seed treatment instructions. Store seeds in a cool, dry place away from direct sunlight."
+            structuredData={structuredData}
+            bottomContent={plantingGuide}
+        >
+            {/* Overview */}
+            {product.description && (
+                <div>
+                    <h2 className="text-lg font-semibold mb-3 text-foreground">Overview</h2>
+                    <p className="text-muted-foreground leading-relaxed text-sm">{product.description}</p>
                 </div>
-            </div>
+            )}
 
-            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-                {/* Header Section */}
-                <div className="grid lg:grid-cols-[450px,1fr] gap-12 mb-16">
-                    {/* Left - Image */}
-                    <div className="flex flex-col gap-4">
-                        <div className="relative aspect-square bg-muted/30 dark:bg-white rounded-xl border overflow-hidden shadow-sm">
-                            {product.images?.[0]?.img?.src ? (
-                                <Image
-                                    src={product.images[0].img.src}
-                                    alt={product.name}
-                                    fill
-                                    sizes="(max-width: 1024px) 100vw, 450px"
-                                    className="object-contain p-8"
-                                    priority
-                                />
-                            ) : (
-                                <div className="absolute inset-0 bg-muted/30" />
-                            )}
-                        </div>
+            <AdSenseInFeed />
 
-                        {/* Thumbnail Gallery */}
-                        {product.images && product.images.length > 1 && (
-                            <div className="grid grid-cols-4 gap-3">
-                                {product.images.slice(0, 4).map((img: any, idx: number) => (
-                                    <div key={idx} className="relative aspect-square bg-muted/30 dark:bg-white rounded-lg border hover:border-primary transition-colors">
-                                        {img.img?.src && (
-                                            <Image
-                                                src={img.img.src}
-                                                alt={`${product.name} ${idx + 1}`}
-                                                fill
-                                                sizes="(max-width: 1024px) 25vw, 100px"
-                                                className="object-contain p-2"
-                                            />
-                                        )}
-                                    </div>
-                                ))}
-                            </div>
-                        )}
-
-                        <WantToBuyCTA available_for_sale={product.available_for_sale} name={product.name} brand={product.brand?.name} href={`/buy-seed-products/${slug}`} interestHref={`/interest/seed/${slug}`} />
-
-                        {/* Precautions */}
-                        {product.precautions?.length > 0 && (
-                            <div className="rounded-lg border border-orange-200 dark:border-orange-900 bg-orange-50/50 dark:bg-orange-950/30 px-3 py-2">
-                                <h2 className="text-xs font-semibold uppercase tracking-wide text-orange-700 dark:text-orange-400 mb-1.5">
-                                    Precautions
-                                </h2>
-                                <ul className="space-y-0.5">
-                                    {product.precautions.map((precaution: string, idx: number) => (
-                                        <li key={idx} className="flex items-start gap-1.5 text-xs text-orange-800 dark:text-orange-300">
-                                            <span className="h-1 w-1 rounded-full bg-orange-500 dark:bg-orange-400 flex-shrink-0 mt-1.5" />
-                                            <span>{precaution}</span>
-                                        </li>
-                                    ))}
-                                </ul>
-                            </div>
-                        )}
-
-                        {/* Promo - fills remaining sidebar space */}
-                        <div className="flex-1">
-                            <SidebarPromo />
-                        </div>
+            {/* Key Stats Grid */}
+            <div className="grid grid-cols-2 gap-4">
+                {product.planting_season && (
+                    <div className="rounded-xl border bg-card p-4">
+                        <p className="text-xs font-semibold uppercase tracking-wide text-green-700 dark:text-green-400 mb-1">Planting Season</p>
+                        <p className="text-sm text-foreground">{product.planting_season}</p>
                     </div>
-
-                    {/* Right - Product Info */}
-                    <div className="space-y-6">
-                        {/* Product Name */}
-                        <GuideProductTitle name={product.name} brand={product.brand?.name} />
-                        <div className="mt-3"><ShareBar name={product.name} /></div>
-
-                        {/* Category Badge */}
-                        {categoryLabel && (
-                            <div className="flex items-center gap-3 flex-wrap">
-                                <div className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300 capitalize">
-                                    {categoryLabel}
-                                </div>
-                            </div>
-                        )}
-
-                        <div className="h-px bg-border" />
-
-                        {/* Description / Overview */}
-                        {product.description && (
-                            <div>
-                                <h2 className="text-lg font-semibold mb-3 text-foreground">Overview</h2>
-                                <p className="text-muted-foreground leading-relaxed text-sm">{product.description}</p>
-                            </div>
-                        )}
-
-                        {/* AdSense Ad */}
-                        <AdSenseInFeed />
-
-                        {/* Key Stats Grid */}
-                        <div className="grid grid-cols-2 gap-4">
-                            {product.planting_season && (
-                                <div className="rounded-xl border bg-card p-4">
-                                    <p className="text-xs font-semibold uppercase tracking-wide text-green-700 dark:text-green-400 mb-1">Planting Season</p>
-                                    <p className="text-sm text-foreground">{product.planting_season}</p>
-                                </div>
-                            )}
-                            {product.days_to_maturity && (
-                                <div className="rounded-xl border bg-card p-4">
-                                    <p className="text-xs font-semibold uppercase tracking-wide text-green-700 dark:text-green-400 mb-1">Days to Maturity</p>
-                                    <p className="text-sm text-foreground">{product.days_to_maturity}</p>
-                                </div>
-                            )}
-                            {product.yield_potential && (
-                                <div className="rounded-xl border bg-card p-4">
-                                    <p className="text-xs font-semibold uppercase tracking-wide text-green-700 dark:text-green-400 mb-1">Yield Potential</p>
-                                    <p className="text-sm text-foreground">{product.yield_potential}</p>
-                                </div>
-                            )}
-                            {product.seed_treatment && (
-                                <div className="rounded-xl border bg-card p-4">
-                                    <p className="text-xs font-semibold uppercase tracking-wide text-green-700 dark:text-green-400 mb-1">Seed Treatment</p>
-                                    <p className="text-sm text-foreground">{product.seed_treatment}</p>
-                                </div>
-                            )}
-                        </div>
-
-                        {/* Soil Requirements */}
-                        {product.soil_requirements && (
-                            <div>
-                                <h2 className="text-lg font-semibold mb-2 text-foreground">Soil Requirements</h2>
-                                <p className="text-sm text-muted-foreground leading-relaxed">{product.soil_requirements}</p>
-                            </div>
-                        )}
-
-                        {/* Management Tips */}
-                        {product.management_tips && (
-                            <div>
-                                <h2 className="text-lg font-semibold mb-2 text-foreground">Management Tips</h2>
-                                <p className="text-sm text-muted-foreground leading-relaxed">{product.management_tips}</p>
-                            </div>
-                        )}
+                )}
+                {product.days_to_maturity && (
+                    <div className="rounded-xl border bg-card p-4">
+                        <p className="text-xs font-semibold uppercase tracking-wide text-green-700 dark:text-green-400 mb-1">Days to Maturity</p>
+                        <p className="text-sm text-foreground">{product.days_to_maturity}</p>
                     </div>
-                </div>
-
-                {/* Planting Guide */}
-                {hasPlantingGuide && (
-                    <div className="mb-12">
-                        <h2 className="text-2xl font-bold mb-6">Planting Guide</h2>
-                        <ol className="space-y-4">
-                            {product.planting_guide.map((step: any, i: number) => (
-                                <li key={i} className="flex gap-4">
-                                    <span className="flex-shrink-0 w-8 h-8 rounded-full bg-primary/10 text-primary flex items-center justify-center text-sm font-semibold">{i + 1}</span>
-                                    <div className="pt-1">
-                                        <p className="font-medium text-foreground text-sm">{step.step}</p>
-                                        {step.notes && <p className="text-muted-foreground text-sm mt-0.5">{step.notes}</p>}
-                                    </div>
-                                </li>
-                            ))}
-                        </ol>
+                )}
+                {product.yield_potential && (
+                    <div className="rounded-xl border bg-card p-4">
+                        <p className="text-xs font-semibold uppercase tracking-wide text-green-700 dark:text-green-400 mb-1">Yield Potential</p>
+                        <p className="text-sm text-foreground">{product.yield_potential}</p>
+                    </div>
+                )}
+                {product.seed_treatment && (
+                    <div className="rounded-xl border bg-card p-4">
+                        <p className="text-xs font-semibold uppercase tracking-wide text-green-700 dark:text-green-400 mb-1">Seed Treatment</p>
+                        <p className="text-sm text-foreground">{product.seed_treatment}</p>
                     </div>
                 )}
             </div>
-        </div>
+
+            {/* Soil Requirements */}
+            {product.soil_requirements && (
+                <div>
+                    <h2 className="text-lg font-semibold mb-2 text-foreground">Soil Requirements</h2>
+                    <p className="text-sm text-muted-foreground leading-relaxed">{product.soil_requirements}</p>
+                </div>
+            )}
+
+            {/* Management Tips */}
+            {product.management_tips && (
+                <div>
+                    <h2 className="text-lg font-semibold mb-2 text-foreground">Management Tips</h2>
+                    <p className="text-sm text-muted-foreground leading-relaxed">{product.management_tips}</p>
+                </div>
+            )}
+        </GuideDetailLayout>
     )
 }

--- a/apps/client-fnp/components/shared/GuideDetailLayout.tsx
+++ b/apps/client-fnp/components/shared/GuideDetailLayout.tsx
@@ -1,0 +1,254 @@
+import Image from "next/image"
+import Link from "next/link"
+import { AlertTriangle } from "lucide-react"
+import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
+import { SidebarPromo } from "@/components/ads/SidebarPromo"
+import { WantToBuyCTA } from "@/components/shared/WantToBuyCTA"
+import { GuideProductTitle } from "@/components/shared/GuideProductTitle"
+import { ShareBar } from "@/components/shared/ShareBar"
+
+interface BreadcrumbItem {
+    label: string
+    href: string
+}
+
+interface GuideDetailLayoutProps {
+    product: any
+    breadcrumbs: BreadcrumbItem[]
+    categoryBadge?: { label: string; color?: "blue" | "green" }
+    buyHref: string
+    interestHref: string
+    safetyText: string
+    disclaimerText?: string
+    structuredData?: object
+    breadcrumbJsonLd?: object
+    /** Precautions array — defaults to product.precautions */
+    precautions?: string[]
+    /** Safety warnings as a single string (feeds use this instead of precautions array) */
+    safetyWarnings?: string
+    /** Content for the right column (overview, AI, targets, specs, etc.) */
+    children: React.ReactNode
+    /** Content below the 2-column grid (dosage tables, planting guides, etc.) */
+    bottomContent?: React.ReactNode
+    /** Extra content before the breadcrumb (e.g. SprayProgramBackLink) */
+    topContent?: React.ReactNode
+    /** Replace the default breadcrumb with a custom one (e.g. FeedBreadcrumb) */
+    customBreadcrumb?: React.ReactNode
+}
+
+export function GuideDetailLayout({
+    product,
+    breadcrumbs,
+    categoryBadge,
+    buyHref,
+    interestHref,
+    safetyText,
+    disclaimerText,
+    structuredData,
+    breadcrumbJsonLd,
+    precautions,
+    safetyWarnings,
+    children,
+    bottomContent,
+    topContent,
+    customBreadcrumb,
+}: GuideDetailLayoutProps) {
+    const resolvedPrecautions = precautions ?? product.precautions
+
+    return (
+        <div className="min-h-screen bg-background">
+            {breadcrumbJsonLd && (
+                <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }} />
+            )}
+            {structuredData && (
+                <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }} />
+            )}
+
+            {topContent}
+
+            {/* Breadcrumb */}
+            {customBreadcrumb || (
+                <div className="border-b">
+                    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
+                        <nav className="flex flex-wrap text-sm text-muted-foreground">
+                            <Link href="/" className="hover:text-foreground">Home</Link>
+                            {breadcrumbs.map((crumb, idx) => (
+                                <span key={idx} className="contents">
+                                    <span className="mx-2">/</span>
+                                    {idx === breadcrumbs.length - 1 ? (
+                                        <span className="text-foreground capitalize truncate max-w-[200px] sm:max-w-none">{crumb.label}</span>
+                                    ) : (
+                                        <Link href={crumb.href} className="hover:text-foreground capitalize">{crumb.label}</Link>
+                                    )}
+                                </span>
+                            ))}
+                        </nav>
+                    </div>
+                </div>
+            )}
+
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+                {/* Header Section — 2 column grid */}
+                <div className="grid lg:grid-cols-[450px,1fr] gap-6 lg:gap-12 mb-16">
+                    {/* Left — Image + CTA + Precautions + Promo */}
+                    <div className="flex flex-col gap-4">
+                        <div className="relative aspect-square bg-muted/30 dark:bg-white rounded-xl border overflow-hidden shadow-sm">
+                            {product.images?.[0]?.img?.src ? (
+                                <Image
+                                    src={product.images[0].img.src}
+                                    alt={product.name}
+                                    fill
+                                    sizes="(max-width: 1024px) 100vw, 450px"
+                                    className="object-contain p-8"
+                                    priority
+                                />
+                            ) : (
+                                <div className="absolute inset-0 bg-muted/30" />
+                            )}
+                        </div>
+
+                        {/* Thumbnail Gallery */}
+                        {product.images && product.images.length > 1 && (
+                            <div className="grid grid-cols-4 gap-3">
+                                {product.images.slice(0, 4).map((img: any, idx: number) => (
+                                    <div key={idx} className="relative aspect-square bg-muted/30 dark:bg-white rounded-lg border hover:border-primary transition-colors">
+                                        {img.img?.src && (
+                                            <Image
+                                                src={img.img.src}
+                                                alt={`${product.name} ${idx + 1}`}
+                                                fill
+                                                sizes="(max-width: 1024px) 25vw, 100px"
+                                                className="object-contain p-2"
+                                            />
+                                        )}
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+
+                        {/* Want to Buy CTA */}
+                        <WantToBuyCTA
+                            available_for_sale={product.available_for_sale}
+                            name={product.name}
+                            brand={product.brand?.name}
+                            href={buyHref}
+                            interestHref={interestHref}
+                        />
+
+                        {/* Precautions (array) */}
+                        {resolvedPrecautions && resolvedPrecautions.length > 0 && (
+                            <div className="rounded-lg border border-red-200 dark:border-red-900 bg-red-50/50 dark:bg-red-950/30 px-3 py-2">
+                                <h2 className="text-xs font-semibold uppercase tracking-wide text-red-700 dark:text-red-400 mb-1.5 flex items-center gap-1.5">
+                                    <AlertTriangle className="w-3.5 h-3.5" />
+                                    Precautions
+                                </h2>
+                                <ul className="space-y-0.5">
+                                    {resolvedPrecautions.map((precaution: string, idx: number) => (
+                                        <li key={idx} className="flex items-start gap-1.5 text-xs text-red-800 dark:text-red-300">
+                                            <span className="h-1 w-1 rounded-full bg-red-500 dark:bg-red-400 flex-shrink-0 mt-1.5" />
+                                            <span>{precaution}</span>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                        )}
+
+                        {/* Safety warnings (string — used by feeds) */}
+                        {safetyWarnings && (
+                            <div className="rounded-lg border border-red-200 dark:border-red-900 bg-red-50/50 dark:bg-red-950/30 px-3 py-2">
+                                <h2 className="text-xs font-semibold uppercase tracking-wide text-red-700 dark:text-red-400 mb-1.5 flex items-center gap-1.5">
+                                    <AlertTriangle className="w-3.5 h-3.5" />
+                                    Safety Warning
+                                </h2>
+                                <p className="text-xs text-red-800 dark:text-red-300 whitespace-pre-line">{safetyWarnings}</p>
+                            </div>
+                        )}
+
+                        {/* Promo */}
+                        <div className="flex-1">
+                            <SidebarPromo />
+                        </div>
+                    </div>
+
+                    {/* Right — Product Info */}
+                    <div className="space-y-6">
+                        <GuideProductTitle name={product.name} brand={product.brand?.name} />
+                        <div className="mt-3 flex items-center flex-wrap gap-3">
+                            {categoryBadge && (
+                                <span className={`inline-flex items-center px-3 py-1 rounded-md text-sm font-medium ${
+                                    categoryBadge.color === "green"
+                                        ? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-300"
+                                        : "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300"
+                                }`}>
+                                    {categoryBadge.label}
+                                </span>
+                            )}
+                            <ShareBar name={product.name} />
+                        </div>
+
+                        <div className="h-px bg-border" />
+
+                        {/* Page-specific content */}
+                        {children}
+
+                        <AdSenseInFeed />
+                    </div>
+                </div>
+
+                {/* Below the grid — dosage tables, planting guides, etc. */}
+                {bottomContent}
+
+                {/* Product Labels */}
+                {(product.front_label?.img?.src || product.back_label?.img?.src) && (
+                    <div className="mb-12">
+                        <h2 className="text-2xl font-bold mb-6">Product Labels</h2>
+                        <div className="grid md:grid-cols-2 gap-6">
+                            {product.front_label?.img?.src && (
+                                <div className="space-y-3">
+                                    <h3 className="text-lg font-semibold">Front Label</h3>
+                                    <div className="relative aspect-[3/4] bg-white rounded-lg border overflow-hidden">
+                                        <Image
+                                            src={product.front_label.img.src}
+                                            alt={`${product.name} - Front Label`}
+                                            fill
+                                            sizes="(max-width: 768px) 100vw, 50vw"
+                                            className="object-contain p-4"
+                                        />
+                                    </div>
+                                </div>
+                            )}
+                            {product.back_label?.img?.src && (
+                                <div className="space-y-3">
+                                    <h3 className="text-lg font-semibold">Back Label</h3>
+                                    <div className="relative aspect-[3/4] bg-white rounded-lg border overflow-hidden">
+                                        <Image
+                                            src={product.back_label.img.src}
+                                            alt={`${product.name} - Back Label`}
+                                            fill
+                                            sizes="(max-width: 768px) 100vw, 50vw"
+                                            className="object-contain p-4"
+                                        />
+                                    </div>
+                                </div>
+                            )}
+                        </div>
+                    </div>
+                )}
+
+                {/* Safety Warning / Disclaimer */}
+                <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-lg p-6">
+                    <div className="flex items-start gap-3">
+                        <AlertTriangle className="w-6 h-6 text-yellow-600 dark:text-yellow-500 flex-shrink-0" />
+                        <div>
+                            <h3 className="font-semibold mb-2 text-yellow-900 dark:text-yellow-100">Safety Information</h3>
+                            <p className="text-sm text-yellow-800 dark:text-yellow-200">{safetyText}</p>
+                            {disclaimerText && (
+                                <p className="text-xs text-black dark:text-white mt-2">{disclaimerText}</p>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "6.6.3",
+  "version": "6.6.5",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- Extract `GuideDetailLayout` shared component used by all 6 guide detail pages (agrochemical, plant-nutrition, animal-health, equipment, seed, feed)
- Eliminates ~660 lines of duplicated breadcrumb, sidebar, image gallery, precautions, product labels, and safety warning code
- Plant nutrition pages now show "Composition" instead of "Active Ingredients"

## Test plan
- [ ] Verify agrochemical guide page renders correctly
- [ ] Verify plant-nutrition guide page shows "Composition" heading
- [ ] Verify animal-health guide page with custom dosage table
- [ ] Verify equipment guide page with specs
- [ ] Verify seed guide page with planting guide
- [ ] Verify feed guide page with FeedBreadcrumb back-link