### PR TITLE
Campaigns page, analytics redesign, dashboard cleanup

### DIFF
--- a/apps/admin-fnp/app/dashboard/farmnport/analytics/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/analytics/page.tsx
@@ -1,101 +1,216 @@
 "use client"
 
-import { useState } from "react"
 import { useQuery } from "@tanstack/react-query"
-import { PaginationState, ColumnDef, createColumnHelper } from "@tanstack/react-table"
 import Link from "next/link"
+import { Eye, Users, UserCheck, TrendingUp, Phone, Mail, MessageCircle } from "lucide-react"
 
-import { queryRecentViewedContacts } from "@/lib/query"
+import { queryContactViewsStats, queryRecentViewedContacts } from "@/lib/query"
 import { formatDate } from "@/lib/utilities"
-import { DataTable } from "@/components/structures/data-table"
-import { DashboardHeader } from "@/components/state/dashboardHeader"
-import { DashboardShell } from "@/components/state/dashboardShell"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import { Skeleton } from "@/components/ui/skeleton"
 
-type ViewedContact = {
-  viewed_id: string
-  name: string
-  type: string
-  city: string
-  primary_category: string
-  main_produce: string
-  last_date: string
+function StatCard({ title, value, icon: Icon, subtitle }: { title: string; value: string | number; icon: any; subtitle?: string }) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium">{title}</CardTitle>
+        <Icon className="h-4 w-4 text-muted-foreground" />
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-bold">{value}</div>
+        {subtitle && <p className="text-xs text-muted-foreground">{subtitle}</p>}
+      </CardContent>
+    </Card>
+  )
 }
 
-const columnHelper = createColumnHelper<ViewedContact>()
+const TYPE_BADGE: Record<string, string> = {
+  farmer: "bg-green-100 text-green-800",
+  buyer: "bg-blue-100 text-blue-800",
+}
 
-const columns = [
-  columnHelper.accessor("name", {
-    header: "Contact",
-    cell: ({ row }) => (
-      <Link
-        href={`/dashboard/farmnport/contact-views/contact/${row.original.viewed_id}`}
-        className="font-medium capitalize hover:text-primary transition-colors"
-      >
-        {row.getValue("name")}
-      </Link>
-    ),
-  }),
-  columnHelper.accessor("type", {
-    header: "Type",
-    cell: ({ row }) => {
-      const t = row.getValue("type") as string
-      return (
-        <span className={`text-xs px-2 py-0.5 rounded-full font-medium capitalize ${
-          t === "farmer" ? "bg-green-100 text-green-800"
-          : t === "buyer" ? "bg-blue-100 text-blue-800"
-          : "bg-muted text-muted-foreground"
-        }`}>
-          {t || "—"}
-        </span>
-      )
-    },
-  }),
-  columnHelper.accessor("city", {
-    header: "City",
-    cell: ({ row }) => <span className="capitalize">{row.getValue("city") || "—"}</span>,
-  }),
-  columnHelper.accessor("primary_category", {
-    header: "Category",
-    cell: ({ row }) => <span className="capitalize">{row.getValue("primary_category") || "—"}</span>,
-  }),
-  columnHelper.accessor("main_produce", {
-    header: "Main Produce",
-    cell: ({ row }) => <span className="capitalize">{row.getValue("main_produce") || "—"}</span>,
-  }),
-  columnHelper.accessor("last_date", {
-    header: () => <div className="text-right">Last Viewed</div>,
-    cell: ({ row }) => (
-      <div className="text-right text-muted-foreground">{formatDate(row.getValue("last_date")) || "—"}</div>
-    ),
-  }),
-] as ColumnDef<ViewedContact>[]
-
-const PAGE_SIZE = 20
+const ACTION_ICON: Record<string, any> = {
+  phone: Phone,
+  email: Mail,
+  whatsapp: MessageCircle,
+}
 
 export default function AnalyticsPage() {
-  const [search, setSearch] = useState("")
-  const [pagination, setPagination] = useState<PaginationState>({ pageIndex: 0, pageSize: PAGE_SIZE })
-
-  const { data } = useQuery({
-    queryKey: ["recent-viewed-contacts", pagination.pageIndex + 1],
-    queryFn: () => queryRecentViewedContacts(pagination.pageIndex + 1, PAGE_SIZE),
+  const { data: statsData, isLoading: statsLoading } = useQuery({
+    queryKey: ["contact-views-stats"],
+    queryFn: () => queryContactViewsStats(),
     refetchOnWindowFocus: false,
   })
 
+  const { data: recentData } = useQuery({
+    queryKey: ["recent-viewed-contacts", 1],
+    queryFn: () => queryRecentViewedContacts(1, 10),
+    refetchOnWindowFocus: false,
+  })
+
+  const stats = statsData?.data
+  const recentContacts = recentData?.data?.contacts ?? []
+
+  if (statsLoading) {
+    return (
+      <div className="flex flex-col gap-6">
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Card key={i}>
+              <CardHeader className="pb-2"><Skeleton className="h-4 w-24" /></CardHeader>
+              <CardContent><Skeleton className="h-7 w-16" /></CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  const summary = stats?.summary
+  const topViewed = stats?.top_viewed ?? []
+  const topViewers = stats?.top_viewers ?? []
+  const viewsByType = stats?.views_by_type ?? []
+
   return (
-    <DashboardShell>
-      <DashboardHeader heading="Recent View Activity" text="Contacts sorted by most recently viewed." />
-      <DataTable
-        columns={columns}
-        data={data?.data?.contacts || []}
-        tableName="Contact"
-        total={data?.data?.total || 0}
-        pagination={pagination}
-        setPagination={setPagination}
-        search={search}
-        setSearch={setSearch}
-        searchPlaceholder="Search contacts..."
-      />
-    </DashboardShell>
+    <div className="flex flex-col gap-6">
+      <div>
+        <h2 className="text-3xl font-bold tracking-tight">Analytics</h2>
+        <p className="text-muted-foreground">Platform activity and engagement overview</p>
+      </div>
+
+      {/* Key Numbers */}
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <StatCard title="Total Contact Views" value={summary?.total_views ?? 0} icon={Eye} subtitle="All-time contact reveals" />
+        <StatCard title="Unique Viewers" value={summary?.unique_viewers ?? 0} icon={Users} subtitle="People who viewed contacts" />
+        <StatCard title="Profiles Viewed" value={summary?.unique_viewed ?? 0} icon={UserCheck} subtitle="Unique contacts viewed" />
+        <StatCard title="Avg Views Per Profile" value={summary?.avg_views_per_profile?.toFixed(1) ?? "0"} icon={TrendingUp} subtitle="Average views per contact" />
+      </div>
+
+      {/* Views by Type */}
+      {viewsByType.length > 0 && (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {viewsByType.map((vt: any) => {
+            const total = viewsByType.reduce((sum: number, v: any) => sum + v.count, 0)
+            const pct = total > 0 ? ((vt.count / total) * 100).toFixed(0) : "0"
+            return (
+              <div key={vt.type} className="flex items-center justify-between rounded-lg border p-3">
+                <div>
+                  <p className="text-sm font-medium capitalize">{vt.type}</p>
+                  <p className="text-xs text-muted-foreground">{pct}% of views</p>
+                </div>
+                <span className="text-lg font-bold">{vt.count}</span>
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        {/* Most Viewed — Who's being looked at */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Most Viewed — Buyers Getting Attention</CardTitle>
+            <p className="text-xs text-muted-foreground">Profiles whose contact info was viewed most often</p>
+          </CardHeader>
+          <CardContent>
+            {topViewed.length === 0 ? (
+              <p className="text-sm text-muted-foreground py-4 text-center">No data yet</p>
+            ) : (
+              <div className="space-y-2">
+                <div className="grid grid-cols-[2rem_1fr_5rem_5rem_3.5rem] gap-2 text-xs font-medium text-muted-foreground pb-1 border-b">
+                  <span>#</span>
+                  <span>Name</span>
+                  <span>Type</span>
+                  <span>Last</span>
+                  <span className="text-right">Views</span>
+                </div>
+                {topViewed.slice(0, 10).map((contact: any, i: number) => (
+                  <Link
+                    key={contact.viewed_id || i}
+                    href={`/dashboard/farmnport/contact-views/contact/${contact.viewed_id}`}
+                    className="grid grid-cols-[2rem_1fr_5rem_5rem_3.5rem] gap-2 items-center rounded-lg p-2 text-sm hover:bg-muted/50 transition-colors"
+                  >
+                    <span className="text-muted-foreground text-xs">{i + 1}</span>
+                    <span className="font-medium truncate capitalize">{contact.name}</span>
+                    <Badge variant="secondary" className="text-xs w-fit capitalize">{contact.type}</Badge>
+                    <span className="text-muted-foreground text-xs">{formatDate(contact.last_date) || "—"}</span>
+                    <span className="text-right font-semibold">{contact.view_count}</span>
+                  </Link>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Most Active Viewers — Who's looking */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Most Active — Farmers Looking for Buyers</CardTitle>
+            <p className="text-xs text-muted-foreground">Users who have viewed the most contact profiles</p>
+          </CardHeader>
+          <CardContent>
+            {topViewers.length === 0 ? (
+              <p className="text-sm text-muted-foreground py-4 text-center">No data yet</p>
+            ) : (
+              <div className="space-y-2">
+                <div className="grid grid-cols-[2rem_1fr_5rem_5rem_4rem] gap-2 text-xs font-medium text-muted-foreground pb-1 border-b">
+                  <span>#</span>
+                  <span>Name</span>
+                  <span>Type</span>
+                  <span>Last</span>
+                  <span className="text-right">Viewed</span>
+                </div>
+                {topViewers.slice(0, 10).map((viewer: any, i: number) => (
+                  <Link
+                    key={viewer.user_id || i}
+                    href={`/dashboard/farmnport/contact-views/viewer/${viewer.user_id}`}
+                    className="grid grid-cols-[2rem_1fr_5rem_5rem_4rem] gap-2 items-center rounded-lg p-2 text-sm hover:bg-muted/50 transition-colors"
+                  >
+                    <span className="text-muted-foreground text-xs">{i + 1}</span>
+                    <span className="font-medium truncate capitalize">{viewer.name}</span>
+                    <Badge variant="secondary" className="text-xs w-fit capitalize">{viewer.type}</Badge>
+                    <span className="text-muted-foreground text-xs">{formatDate(viewer.last_date) || "—"}</span>
+                    <span className="text-right font-semibold">{viewer.contacts_viewed}</span>
+                  </Link>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Recent Activity */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Recent Contact Views</CardTitle>
+          <p className="text-xs text-muted-foreground">Latest contact reveal activity</p>
+        </CardHeader>
+        <CardContent>
+          {recentContacts.length === 0 ? (
+            <p className="text-sm text-muted-foreground py-4 text-center">No recent activity</p>
+          ) : (
+            <div className="space-y-2">
+              <div className="grid grid-cols-[1fr_5rem_5rem_5rem_6rem] gap-2 text-xs font-medium text-muted-foreground pb-1 border-b">
+                <span>Contact</span>
+                <span>Type</span>
+                <span>Category</span>
+                <span>Produce</span>
+                <span className="text-right">Last Viewed</span>
+              </div>
+              {recentContacts.slice(0, 10).map((c: any, i: number) => (
+                <div key={i} className="grid grid-cols-[1fr_5rem_5rem_5rem_6rem] gap-2 items-center p-2 text-sm rounded-lg hover:bg-muted/50">
+                  <span className="font-medium capitalize truncate">{c.name}</span>
+                  <span className={`text-xs px-2 py-0.5 rounded-full font-medium capitalize w-fit ${TYPE_BADGE[c.type] ?? "bg-muted text-muted-foreground"}`}>{c.type || "—"}</span>
+                  <span className="text-xs text-muted-foreground capitalize truncate">{c.primary_category || "—"}</span>
+                  <span className="text-xs text-muted-foreground capitalize truncate">{c.main_produce || "—"}</span>
+                  <span className="text-xs text-muted-foreground text-right">{formatDate(c.last_date) || "—"}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
   )
 }

--- a/apps/admin-fnp/app/dashboard/farmnport/campaigns/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/campaigns/page.tsx
@@ -1,0 +1,14 @@
+import { DashboardHeader } from "@/components/state/dashboardHeader"
+import { DashboardShell } from "@/components/state/dashboardShell"
+import { CampaignsView } from "@/components/structures/views/campaigns-view"
+
+export const metadata = { title: "Campaigns — Farmnport Admin" }
+
+export default function CampaignsPage() {
+  return (
+    <DashboardShell>
+      <DashboardHeader heading="Campaigns" text="Track and manage email, SMS and WhatsApp campaigns." />
+      <CampaignsView />
+    </DashboardShell>
+  )
+}

--- a/apps/admin-fnp/app/dashboard/farmnport/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/page.tsx
@@ -32,13 +32,7 @@ function SectionHeader({ title, href }: { title: string; href: string }) {
   )
 }
 
-function ClickableCard({
-  href,
-  children,
-}: {
-  href: string
-  children: React.ReactNode
-}) {
+function ClickableCard({ href, children }: { href: string; children: React.ReactNode }) {
   return (
     <Link href={href} className="rounded-xl border bg-card p-5 hover:border-foreground/20 hover:shadow-sm transition-all block">
       {children}
@@ -46,25 +40,12 @@ function ClickableCard({
   )
 }
 
-function QuickLink({
-  href,
-  label,
-  count,
-}: {
-  href: string
-  label: string
-  count?: number | string
-}) {
+function QuickLink({ href, label, count }: { href: string; label: string; count?: number | string }) {
   return (
-    <Link
-      href={href}
-      className="flex items-center justify-between rounded-lg border bg-card px-4 py-3 hover:border-foreground/20 hover:shadow-sm transition-all"
-    >
+    <Link href={href} className="flex items-center justify-between rounded-lg border bg-card px-4 py-3 hover:border-foreground/20 hover:shadow-sm transition-all">
       <span className="text-sm font-medium">{label}</span>
       <div className="flex items-center gap-2">
-        {count != null && (
-          <span className="text-xs text-muted-foreground">{count}</span>
-        )}
+        {count != null && <span className="text-xs text-muted-foreground">{count}</span>}
         <ChevronRight className="h-4 w-4 text-muted-foreground" />
       </div>
     </Link>
@@ -99,7 +80,7 @@ export default function DashboardPage() {
       <div className="flex flex-col gap-6">
         <Skeleton className="h-8 w-48" />
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-          {Array.from({ length: 8 }).map((_, i) => (
+          {Array.from({ length: 4 }).map((_, i) => (
             <Skeleton key={i} className="h-28 rounded-xl" />
           ))}
         </div>
@@ -115,13 +96,12 @@ export default function DashboardPage() {
   return (
     <div className="flex flex-col gap-8">
 
-      {/* Header */}
       <div>
         <h2 className="text-2xl font-bold tracking-tight">Dashboard</h2>
         <p className="text-sm text-muted-foreground mt-0.5">Platform overview</p>
       </div>
 
-      {/* ── Users & Engagement ── */}
+      {/* ── Users & Contact Views ── */}
       <div>
         <SectionHeader title="Users & Engagement" href="/dashboard/farmnport/users" />
         <div className="grid gap-4 md:grid-cols-3">
@@ -162,25 +142,28 @@ export default function DashboardPage() {
             </div>
           </ClickableCard>
 
-          <ClickableCard href="/dashboard/farmnport/brands">
-            <span className="text-sm font-medium text-muted-foreground">Brands</span>
-            <div className="text-3xl font-bold mt-1">{stats.brands}</div>
-            <p className="text-xs text-muted-foreground mt-1">Registered brands</p>
+          <ClickableCard href="/dashboard/farmnport/campaigns">
+            <span className="text-sm font-medium text-muted-foreground">Campaigns</span>
+            <div className="text-3xl font-bold mt-1">—</div>
+            <div className="mt-3 grid grid-cols-2 gap-2">
+              <div className="rounded-lg bg-muted/50 px-2.5 py-2">
+                <p className="text-[11px] text-muted-foreground">Blasts</p>
+                <p className="text-sm font-semibold">—</p>
+              </div>
+              <div className="rounded-lg bg-muted/50 px-2.5 py-2">
+                <p className="text-[11px] text-muted-foreground">SMS</p>
+                <p className="text-sm font-semibold">—</p>
+              </div>
+            </div>
           </ClickableCard>
 
         </div>
       </div>
 
-      {/* ── Sales & Orders ── */}
+      {/* ── Revenue Channels ── */}
       <div>
-        <SectionHeader title="Sales & Orders" href="/dashboard/farmnport/orders/sales" />
+        <SectionHeader title="Revenue Channels" href="/dashboard/farmnport/sales" />
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-
-          <ClickableCard href="/dashboard/farmnport/orders/sales">
-            <span className="text-sm font-medium text-muted-foreground">Total Orders</span>
-            <div className="text-3xl font-bold mt-1">{salesStats?.orders?.total ?? "—"}</div>
-            <p className="text-xs text-muted-foreground mt-1">Excluding cancelled</p>
-          </ClickableCard>
 
           <ClickableCard href="/dashboard/farmnport/sales">
             <span className="text-sm font-medium text-muted-foreground">Revenue</span>
@@ -212,12 +195,8 @@ export default function DashboardPage() {
           </ClickableCard>
 
           <ClickableCard href="/dashboard/farmnport/orders/sales">
-            <span className="text-sm font-medium text-muted-foreground">Needs Attention</span>
-            <div className="text-3xl font-bold mt-1">
-              {salesStats?.orders != null
-                ? (salesStats.orders.pending ?? 0) + (salesStats.orders.paid ?? 0)
-                : "—"}
-            </div>
+            <span className="text-sm font-medium text-muted-foreground">Orders</span>
+            <div className="text-3xl font-bold mt-1">{salesStats?.orders?.total ?? "—"}</div>
             <div className="mt-3 space-y-1.5">
               <div className="flex items-center justify-between text-xs">
                 <span className="text-muted-foreground">Pending</span>
@@ -230,97 +209,25 @@ export default function DashboardPage() {
             </div>
           </ClickableCard>
 
-          <ClickableCard href="/dashboard/farmnport/orders/sales">
-            <span className="text-sm font-medium text-muted-foreground">Fulfilled</span>
-            <div className="text-3xl font-bold mt-1">
-              {salesStats?.orders != null
-                ? (salesStats.orders.delivered ?? 0) + (salesStats.orders.collected ?? 0)
-                : "—"}
-            </div>
-            <div className="mt-3 space-y-1.5">
-              <div className="flex items-center justify-between text-xs">
-                <span className="text-muted-foreground">Delivered</span>
-                <span className="font-medium">{salesStats?.orders?.delivered ?? "—"}</span>
-              </div>
-              <div className="flex items-center justify-between text-xs">
-                <span className="text-muted-foreground">Collected</span>
-                <span className="font-medium">{salesStats?.orders?.collected ?? "—"}</span>
-              </div>
-            </div>
+          <ClickableCard href="/dashboard/farmnport/orders/bookings">
+            <span className="text-sm font-medium text-muted-foreground">Bookings</span>
+            <div className="text-3xl font-bold mt-1">—</div>
+            <p className="text-xs text-muted-foreground mt-1">Active bookings</p>
+          </ClickableCard>
+
+          <ClickableCard href="/dashboard/farmnport/lots">
+            <span className="text-sm font-medium text-muted-foreground">Lots</span>
+            <div className="text-3xl font-bold mt-1">—</div>
+            <p className="text-xs text-muted-foreground mt-1">Active lots</p>
           </ClickableCard>
 
         </div>
 
-        {/* Sales quick links */}
         <div className="grid gap-2 md:grid-cols-4 mt-3">
-          <QuickLink href="/dashboard/farmnport/orders/bookings" label="Bookings" />
           <QuickLink href="/dashboard/farmnport/orders/booking-preorders" label="Pre-Orders" />
-          <QuickLink href="/dashboard/farmnport/lots" label="Lots" />
           <QuickLink href="/dashboard/farmnport/documents" label="Documents" />
-        </div>
-      </div>
-
-      {/* ── Products ── */}
-      <div>
-        <SectionHeader title="Products" href="/dashboard/farmnport/agrochemicals" />
-        <div className="grid gap-4 md:grid-cols-3">
-
-          <ClickableCard href="/dashboard/farmnport/agrochemicals">
-            <span className="text-sm font-medium text-muted-foreground">AgroChemicals</span>
-            <div className="text-3xl font-bold mt-1">{stats.products.agro_chemicals}</div>
-            <p className="text-xs text-muted-foreground mt-1">Products</p>
-          </ClickableCard>
-
-          <ClickableCard href="/dashboard/farmnport/animal-health-products">
-            <span className="text-sm font-medium text-muted-foreground">Animal Health</span>
-            <div className="text-3xl font-bold mt-1">{stats.products.animal_health}</div>
-            <p className="text-xs text-muted-foreground mt-1">Products</p>
-          </ClickableCard>
-
-          <ClickableCard href="/dashboard/farmnport/feed-products">
-            <span className="text-sm font-medium text-muted-foreground">Feed</span>
-            <div className="text-3xl font-bold mt-1">{stats.products.feed}</div>
-            <p className="text-xs text-muted-foreground mt-1">Products</p>
-          </ClickableCard>
-
-        </div>
-
-        {/* Product quick links */}
-        <div className="grid gap-2 md:grid-cols-4 mt-3">
-          <QuickLink href="/dashboard/farmnport/agrochemical-categories" label="Agro Categories" />
-          <QuickLink href="/dashboard/farmnport/agrochemical-active-ingredients" label="Agro Ingredients" />
-          <QuickLink href="/dashboard/farmnport/agrochemical-targets" label="Agro Targets" />
-          <QuickLink href="/dashboard/farmnport/animal-health-categories" label="Animal Categories" />
-          <QuickLink href="/dashboard/farmnport/feed-categories" label="Feed Categories" />
-          <QuickLink href="/dashboard/farmnport/feed-active-ingredients" label="Feed Ingredients" />
-          <QuickLink href="/dashboard/farmnport/feed-nutritional-specs" label="Nutritional Specs" />
-          <QuickLink href="/dashboard/farmnport/equipment" label="Equipment" />
-        </div>
-      </div>
-
-      {/* ── Farm Produce & Programs ── */}
-      <div>
-        <SectionHeader title="Farm Produce & Programs" href="/dashboard/farmnport/farmproduce" />
-        <div className="grid gap-2 md:grid-cols-4">
-          <QuickLink href="/dashboard/farmnport/farmproduce" label="Produce" />
-          <QuickLink href="/dashboard/farmnport/farmproducecategories" label="Produce Categories" />
-          <QuickLink href="/dashboard/farmnport/seed-products" label="Seed Products" />
-          <QuickLink href="/dashboard/farmnport/breeds" label="Breeds" />
-          <QuickLink href="/dashboard/farmnport/crop-groups" label="Crop Groups" />
-          <QuickLink href="/dashboard/farmnport/weed-groups" label="Weed Groups" />
-          <QuickLink href="/dashboard/farmnport/spray-programs" label="Spray Programs" count={stats.guides.spray_programs} />
-          <QuickLink href="/dashboard/farmnport/feeding-programs" label="Feeding Programs" count={stats.guides.feeding_programs} />
-        </div>
-      </div>
-
-      {/* ── Communications ── */}
-      <div>
-        <SectionHeader title="Communications" href="/dashboard/farmnport/blast" />
-        <div className="grid gap-2 md:grid-cols-4">
-          <QuickLink href="/dashboard/farmnport/blast" label="New Blast" />
-          <QuickLink href="/dashboard/farmnport/blast/sent" label="Sent Blasts" />
-          <QuickLink href="/dashboard/farmnport/buyer-contacts" label="Buyer Contacts" />
           <QuickLink href="/dashboard/farmnport/prices/series" label="Price Series" />
+          <QuickLink href="/dashboard/farmnport/buyer-contacts" label="Buyer Contacts" />
         </div>
       </div>
 

--- a/apps/admin-fnp/components/structures/forms/buyer-contact-form.tsx
+++ b/apps/admin-fnp/components/structures/forms/buyer-contact-form.tsx
@@ -110,7 +110,7 @@ export function BuyerContactForm() {
             <FormItem>
               <FormLabel>Contact Name</FormLabel>
               <FormControl>
-                <Input placeholder="John Doe" {...field} />
+                <Input placeholder="Full name" {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>
@@ -156,7 +156,7 @@ export function BuyerContactForm() {
               <FormItem>
                 <FormLabel>Email</FormLabel>
                 <FormControl>
-                  <Input type="email" placeholder="john@example.com" {...field} />
+                  <Input type="email" placeholder="you@example.com" {...field} />
                 </FormControl>
                 <FormDescription>Optional</FormDescription>
                 <FormMessage />

--- a/apps/admin-fnp/components/structures/views/campaigns-view.tsx
+++ b/apps/admin-fnp/components/structures/views/campaigns-view.tsx
@@ -1,0 +1,316 @@
+"use client"
+
+import { useState } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { Icons } from "@/components/icons/lucide"
+import { authorizedHTTPClient } from "@/lib/axios"
+
+interface CampaignStats {
+  total: number
+  queued: number
+  sent: number
+  delivered: number
+  bounced: number
+  suppressed: number
+  failed: number
+  opened: number
+  converted: number
+}
+
+interface Campaign {
+  id: string
+  name: string
+  channel: string
+  template: string
+  subject: string
+  message: string
+  audience: {
+    source: string
+    type: string
+    province: string
+    category: string
+    produce: string
+    verified: string
+    uploaded: boolean
+  }
+  stats: CampaignStats
+  status: string
+  sent_by: string
+  created: string
+  sent_at: string | null
+}
+
+interface CampaignRecipient {
+  id: string
+  campaign_id: string
+  client_id: string
+  name: string
+  to: string
+  status: string
+  error: string
+  queued_at: string
+  sent_at: string | null
+  delivered_at: string | null
+  updated_at: string
+}
+
+const CHANNEL_BADGE: Record<string, string> = {
+  sms: "bg-blue-50 text-blue-700 border-blue-200",
+  whatsapp: "bg-green-50 text-green-700 border-green-200",
+  email: "bg-orange-50 text-orange-600 border-orange-200",
+}
+
+const STATUS_BADGE: Record<string, string> = {
+  draft: "bg-muted text-muted-foreground",
+  sending: "bg-amber-50 text-amber-700 border-amber-200",
+  sent: "bg-green-50 text-green-700 border-green-200",
+  failed: "bg-red-50 text-red-600 border-red-200",
+}
+
+const RECIPIENT_STATUS: Record<string, { color: string; label: string }> = {
+  queued: { color: "text-muted-foreground", label: "Queued" },
+  sent: { color: "text-amber-600", label: "Sent" },
+  delivered: { color: "text-green-600", label: "Delivered" },
+  bounced: { color: "text-red-500", label: "Bounced" },
+  suppressed: { color: "text-red-400", label: "Suppressed" },
+  failed: { color: "text-red-500", label: "Failed" },
+  opened: { color: "text-blue-600", label: "Opened" },
+  converted: { color: "text-emerald-600", label: "Converted" },
+}
+
+function formatDate(d: string) {
+  return new Date(d).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric", hour: "2-digit", minute: "2-digit" })
+}
+
+function StatBar({ stats }: { stats: CampaignStats }) {
+  const total = stats.total || 1
+  const segments = [
+    { key: "delivered", count: stats.delivered, color: "bg-green-500" },
+    { key: "converted", count: stats.converted, color: "bg-emerald-500" },
+    { key: "sent", count: stats.sent - stats.delivered - stats.converted, color: "bg-amber-400" },
+    { key: "bounced", count: stats.bounced, color: "bg-red-400" },
+    { key: "suppressed", count: stats.suppressed, color: "bg-red-300" },
+    { key: "failed", count: stats.failed, color: "bg-red-200" },
+  ].filter(s => s.count > 0)
+
+  return (
+    <div className="space-y-1.5">
+      <div className="h-2 rounded-full bg-muted overflow-hidden flex">
+        {segments.map(s => (
+          <div key={s.key} className={`${s.color} h-full`} style={{ width: `${(s.count / total) * 100}%` }} />
+        ))}
+      </div>
+      <div className="flex gap-3 text-xs text-muted-foreground flex-wrap">
+        {stats.delivered > 0 && <span className="text-green-600 font-medium">{stats.delivered} delivered</span>}
+        {stats.converted > 0 && <span className="text-emerald-600 font-medium">{stats.converted} converted</span>}
+        {stats.bounced > 0 && <span className="text-red-500">{stats.bounced} bounced</span>}
+        {stats.suppressed > 0 && <span className="text-red-400">{stats.suppressed} suppressed</span>}
+        {stats.failed > 0 && <span className="text-red-500">{stats.failed} failed</span>}
+        <span>{stats.total} total</span>
+      </div>
+    </div>
+  )
+}
+
+function CampaignDetail({ campaignId, onBack }: { campaignId: string; onBack: () => void }) {
+  const [statusFilter, setStatusFilter] = useState("")
+  const [page, setPage] = useState(1)
+
+  const { data: campaign } = useQuery({
+    queryKey: ["campaign", campaignId],
+    queryFn: () => authorizedHTTPClient.get<Campaign>(`/v1/campaigns/${campaignId}`),
+    select: (res) => res.data,
+  })
+
+  const { data: recipientData, isLoading: recipientsLoading } = useQuery({
+    queryKey: ["campaign-recipients", campaignId, statusFilter, page],
+    queryFn: () => authorizedHTTPClient.get<{ data: CampaignRecipient[]; total: number; page: number; limit: number }>(
+      `/v1/campaigns/${campaignId}/recipients?page=${page}&limit=50${statusFilter ? `&status=${statusFilter}` : ""}`
+    ),
+    select: (res) => res.data,
+  })
+
+  const recipients = recipientData?.data ?? []
+  const total = recipientData?.total ?? 0
+
+  if (!campaign) return <div className="py-16 flex justify-center"><Icons.spinner className="w-5 h-5 animate-spin text-muted-foreground" /></div>
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border bg-white shadow-sm overflow-hidden">
+        <div className="flex items-center justify-between px-5 py-3.5 border-b">
+          <div className="flex items-center gap-3">
+            <button onClick={onBack} className="text-xs font-medium text-primary hover:underline flex items-center gap-1">
+              <Icons.chevronLeft className="w-3.5 h-3.5" /> Back
+            </button>
+            <span className="text-sm font-semibold">{campaign.name}</span>
+            <span className={`inline-flex px-2 py-0.5 rounded text-xs font-medium border capitalize ${CHANNEL_BADGE[campaign.channel] ?? "bg-muted"}`}>
+              {campaign.channel}
+            </span>
+            <span className={`inline-flex px-2 py-0.5 rounded text-xs font-medium border capitalize ${STATUS_BADGE[campaign.status] ?? "bg-muted"}`}>
+              {campaign.status}
+            </span>
+          </div>
+          <span className="text-xs text-muted-foreground">{campaign.sent_at ? formatDate(campaign.sent_at) : formatDate(campaign.created)}</span>
+        </div>
+
+        <div className="px-5 py-4">
+          <StatBar stats={campaign.stats} />
+        </div>
+
+        {campaign.message && (
+          <div className="px-5 pb-4">
+            <p className="text-xs text-muted-foreground mb-1">Message</p>
+            <p className="text-sm bg-muted/30 rounded-lg p-3">{campaign.message}</p>
+          </div>
+        )}
+      </div>
+
+      <div className="rounded-lg border bg-white shadow-sm overflow-hidden">
+        <div className="flex items-center justify-between px-5 py-3 border-b">
+          <div className="flex items-center gap-3">
+            <span className="text-sm font-semibold">Recipients</span>
+            <span className="text-xs px-2 py-0.5 rounded bg-muted text-muted-foreground font-medium">{total}</span>
+          </div>
+          <div className="flex gap-1">
+            {["", "delivered", "bounced", "failed", "converted", "sent"].map(s => (
+              <button key={s} onClick={() => { setStatusFilter(s); setPage(1) }}
+                className={`text-xs px-2 py-1 rounded ${statusFilter === s ? "bg-primary text-white" : "text-muted-foreground hover:bg-muted"}`}>
+                {s || "All"}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {recipientsLoading ? (
+          <div className="py-10 flex justify-center"><Icons.spinner className="w-5 h-5 animate-spin text-muted-foreground" /></div>
+        ) : recipients.length === 0 ? (
+          <p className="py-10 text-center text-sm text-muted-foreground">No recipients</p>
+        ) : (
+          <>
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="bg-muted/20 text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                  <th className="px-5 py-2.5 text-left w-10">#</th>
+                  <th className="px-5 py-2.5 text-left">Name</th>
+                  <th className="px-5 py-2.5 text-left">To</th>
+                  <th className="px-5 py-2.5 text-left">Status</th>
+                  <th className="px-5 py-2.5 text-left">Error</th>
+                  <th className="px-5 py-2.5 text-left">Date</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {recipients.map((r, i) => {
+                  const st = RECIPIENT_STATUS[r.status] ?? { color: "text-muted-foreground", label: r.status }
+                  return (
+                    <tr key={r.id} className="hover:bg-muted/50">
+                      <td className="px-5 py-2.5 text-muted-foreground">{(page - 1) * 50 + i + 1}</td>
+                      <td className="px-5 py-2.5 font-medium capitalize">{r.name}</td>
+                      <td className="px-5 py-2.5 text-muted-foreground">{r.to}</td>
+                      <td className="px-5 py-2.5"><span className={`font-medium ${st.color}`}>{st.label}</span></td>
+                      <td className="px-5 py-2.5 text-muted-foreground text-xs">{r.error || "—"}</td>
+                      <td className="px-5 py-2.5 text-muted-foreground text-xs">{r.sent_at ? formatDate(r.sent_at) : "—"}</td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+            {total > 50 && (
+              <div className="flex items-center justify-between px-5 py-3 border-t">
+                <button onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1}
+                  className="text-xs text-primary hover:underline disabled:opacity-40">Previous</button>
+                <span className="text-xs text-muted-foreground">Page {page} of {Math.ceil(total / 50)}</span>
+                <button onClick={() => setPage(p => p + 1)} disabled={page * 50 >= total}
+                  className="text-xs text-primary hover:underline disabled:opacity-40">Next</button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function CampaignsView() {
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["campaigns"],
+    queryFn: () => authorizedHTTPClient.get<{ data: Campaign[]; total: number }>("/v1/campaigns"),
+    select: (res) => (res.data?.data ?? []) as Campaign[],
+  })
+
+  const campaigns = data ?? []
+
+  if (selectedId) {
+    return <CampaignDetail campaignId={selectedId} onBack={() => setSelectedId(null)} />
+  }
+
+  return (
+    <div className="rounded-lg border bg-white shadow-sm overflow-hidden">
+      <div className="flex items-center justify-between px-5 py-3.5 border-b bg-white">
+        <div className="flex items-center gap-3">
+          <Icons.barChart className="w-4 h-4 text-muted-foreground" />
+          <span className="text-sm font-semibold">All Campaigns</span>
+          <span className="text-xs px-2 py-0.5 rounded bg-muted text-muted-foreground font-medium">{campaigns.length}</span>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="py-16 flex justify-center"><Icons.spinner className="w-5 h-5 animate-spin text-muted-foreground" /></div>
+      ) : campaigns.length === 0 ? (
+        <p className="py-16 text-center text-sm text-muted-foreground">No campaigns yet</p>
+      ) : (
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="bg-muted/20 text-xs font-medium text-muted-foreground uppercase tracking-wider">
+              <th className="px-5 py-2.5 text-left w-10">#</th>
+              <th className="px-5 py-2.5 text-left">Campaign</th>
+              <th className="px-5 py-2.5 text-left">Channel</th>
+              <th className="px-5 py-2.5 text-left">Status</th>
+              <th className="px-5 py-2.5 text-right">Sent</th>
+              <th className="px-5 py-2.5 text-right">Delivered</th>
+              <th className="px-5 py-2.5 text-right">Bounced</th>
+              <th className="px-5 py-2.5 text-right">Converted</th>
+              <th className="px-5 py-2.5 text-left">Date</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y">
+            {campaigns.map((c, i) => (
+              <tr key={c.id} className="hover:bg-muted/50 cursor-pointer" onClick={() => setSelectedId(c.id)}>
+                <td className="px-5 py-2.5 text-muted-foreground">{i + 1}</td>
+                <td className="px-5 py-2.5">
+                  <p className="font-medium">{c.name}</p>
+                  {c.subject && <p className="text-xs text-muted-foreground truncate max-w-xs">{c.subject}</p>}
+                </td>
+                <td className="px-5 py-2.5">
+                  <span className={`inline-flex px-2 py-0.5 rounded text-xs font-medium border capitalize ${CHANNEL_BADGE[c.channel] ?? "bg-muted"}`}>
+                    {c.channel}
+                  </span>
+                </td>
+                <td className="px-5 py-2.5">
+                  <span className={`inline-flex px-2 py-0.5 rounded text-xs font-medium border capitalize ${STATUS_BADGE[c.status] ?? "bg-muted"}`}>
+                    {c.status}
+                  </span>
+                </td>
+                <td className="px-5 py-2.5 text-right">
+                  <span className="text-amber-600 font-semibold">{c.stats.sent}</span>
+                </td>
+                <td className="px-5 py-2.5 text-right">
+                  <span className="text-green-600 font-semibold">{c.stats.delivered}</span>
+                </td>
+                <td className="px-5 py-2.5 text-right">
+                  {c.stats.bounced > 0 ? <span className="text-red-500 font-semibold">{c.stats.bounced}</span> : <span className="text-muted-foreground">0</span>}
+                </td>
+                <td className="px-5 py-2.5 text-right">
+                  {c.stats.converted > 0 ? <span className="text-emerald-600 font-semibold">{c.stats.converted}</span> : <span className="text-muted-foreground">0</span>}
+                </td>
+                <td className="px-5 py-2.5 text-muted-foreground whitespace-nowrap">{formatDate(c.sent_at || c.created)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}

--- a/apps/admin-fnp/config/dashboard.ts
+++ b/apps/admin-fnp/config/dashboard.ts
@@ -41,6 +41,7 @@ export const dashboardConfig: DashboardConfig = {
     },
     {
       label: "Analytics",
+      alwaysOpen: true,
       items: [
         {
           title: "Analytics",
@@ -69,9 +70,9 @@ export const dashboardConfig: DashboardConfig = {
           icon: "send",
         },
         {
-          title: "Sent Blasts",
-          href: "/dashboard/farmnport/blast/sent",
-          icon: "messageSquare",
+          title: "Campaigns",
+          href: "/dashboard/farmnport/campaigns",
+          icon: "barChart",
         },
       ],
     },

--- a/apps/client-fnp/app/(landing)/checkout/page.tsx
+++ b/apps/client-fnp/app/(landing)/checkout/page.tsx
@@ -17,6 +17,10 @@ import { centsToDollars } from "@/lib/utilities"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { getGuestCartItems, clearGuestCart } from "@/hooks/use-guest-cart"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { QuickSignupForm } from "@/components/forms/quick-signup"
+import { AuthForm } from "@/components/forms/login"
 
 const PAYMENT_METHODS = [
   { value: "ecocash", label: "EcoCash",          description: "Mobile money prompt to your phone",  icon: Smartphone },
@@ -488,20 +492,25 @@ function onSubmit(data: CheckoutForm) {
 
   if (!session) {
     return (
-      <div className="min-h-[75vh] flex items-center justify-center">
-        <div className="text-center space-y-4">
-          <ShoppingCart className="w-12 h-12 mx-auto text-muted-foreground/40" />
-          <p className="font-semibold">Sign in to checkout</p>
-          <div className="flex flex-col sm:flex-row gap-3 justify-center">
-            <Link href="/login?next=/checkout" className="inline-flex items-center justify-center rounded-full bg-primary text-primary-foreground text-sm font-semibold px-6 py-2.5 hover:bg-primary/90 transition-colors">
-              Sign In
-            </Link>
-            <Link href="/signup/quick?next=/checkout" className="inline-flex items-center justify-center rounded-full border border-primary text-primary text-sm font-semibold px-6 py-2.5 hover:bg-primary/10 transition-colors">
-              Create Account
-            </Link>
-          </div>
-        </div>
-      </div>
+      <Dialog open={true} onOpenChange={(open) => { if (!open) router.back() }}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="text-center">Sign in to checkout</DialogTitle>
+          </DialogHeader>
+          <Tabs defaultValue="login" className="mt-2">
+            <TabsList className="grid w-full grid-cols-2">
+              <TabsTrigger value="login">Sign In</TabsTrigger>
+              <TabsTrigger value="signup">Create Account</TabsTrigger>
+            </TabsList>
+            <TabsContent value="login" className="mt-4">
+              <AuthForm />
+            </TabsContent>
+            <TabsContent value="signup" className="mt-4">
+              <QuickSignupForm redirectTo="/checkout" />
+            </TabsContent>
+          </Tabs>
+        </DialogContent>
+      </Dialog>
     )
   }
 

--- a/apps/client-fnp/components/forms/phone-input.tsx
+++ b/apps/client-fnp/components/forms/phone-input.tsx
@@ -1,0 +1,100 @@
+"use client"
+
+import { useState, useRef, useEffect } from "react"
+import { ChevronDown } from "lucide-react"
+
+const COUNTRIES = [
+  { code: "ZW", label: "Zimbabwe", dialCode: "+263", flag: "\u{1F1FF}\u{1F1FC}", placeholder: "077 123 4567" },
+  { code: "ZA", label: "South Africa", dialCode: "+27", flag: "\u{1F1FF}\u{1F1E6}", placeholder: "071 123 4567" },
+  { code: "GB", label: "United Kingdom", dialCode: "+44", flag: "\u{1F1EC}\u{1F1E7}", placeholder: "07911 123456" },
+  { code: "US", label: "United States", dialCode: "+1", flag: "\u{1F1FA}\u{1F1F8}", placeholder: "202 555 0123" },
+]
+
+interface PhoneInputProps {
+  value: string
+  onChange: (digits: string) => void
+  error?: string
+}
+
+export function PhoneInput({ value, onChange, error }: PhoneInputProps) {
+  const [countryCode, setCountryCode] = useState("ZW")
+  const [localNumber, setLocalNumber] = useState(value || "")
+  const [dropdownOpen, setDropdownOpen] = useState(false)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  const country = COUNTRIES.find((c) => c.code === countryCode)!
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setDropdownOpen(false)
+      }
+    }
+    if (dropdownOpen) document.addEventListener("mousedown", handleClickOutside)
+    return () => document.removeEventListener("mousedown", handleClickOutside)
+  }, [dropdownOpen])
+
+  function handleNumberChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const raw = e.target.value.replace(/[^\d\s]/g, "")
+    setLocalNumber(raw)
+
+    // Strip leading zero for international format, prepend dial code digits
+    const digits = raw.replace(/\s/g, "")
+    const stripped = digits.startsWith("0") ? digits.slice(1) : digits
+    const full = country.dialCode.replace("+", "") + stripped
+    onChange(full)
+  }
+
+  function handleCountryChange(code: string) {
+    setCountryCode(code)
+    setLocalNumber("")
+    onChange("")
+    setDropdownOpen(false)
+  }
+
+  return (
+    <div>
+      <div className={`flex rounded-md border overflow-hidden focus-within:ring-2 focus-within:ring-primary focus-within:border-transparent ${error ? "border-red-400" : "border-border"}`}>
+        <div className="relative" ref={dropdownRef}>
+          <button
+            type="button"
+            onClick={() => setDropdownOpen((v) => !v)}
+            className="flex items-center gap-1.5 px-3 h-full border-r border-border bg-muted/50 hover:bg-muted transition-colors text-sm"
+          >
+            <span>{country.flag}</span>
+            <span className="text-muted-foreground font-medium">{country.dialCode}</span>
+            <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+          </button>
+
+          {dropdownOpen && (
+            <div className="absolute left-0 top-full mt-1 w-52 rounded-lg border border-border bg-card shadow-lg z-50 py-1 overflow-hidden">
+              {COUNTRIES.map((c) => (
+                <button
+                  key={c.code}
+                  type="button"
+                  onClick={() => handleCountryChange(c.code)}
+                  className={`w-full flex items-center gap-2.5 px-3 py-2 text-sm hover:bg-muted transition-colors ${c.code === countryCode ? "bg-primary/10 text-primary" : "text-foreground"}`}
+                >
+                  <span className="text-base">{c.flag}</span>
+                  <span className="flex-1 text-left">{c.label}</span>
+                  <span className="text-muted-foreground text-xs">{c.dialCode}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <input
+          type="tel"
+          inputMode="numeric"
+          placeholder={country.placeholder}
+          value={localNumber}
+          onChange={handleNumberChange}
+          className="flex-1 px-3 py-2 text-sm placeholder:text-muted-foreground outline-none bg-transparent"
+        />
+      </div>
+
+      {error && <p className="mt-1 text-xs text-red-500">{error}</p>}
+    </div>
+  )
+}

--- a/apps/client-fnp/components/forms/quick-signup.tsx
+++ b/apps/client-fnp/components/forms/quick-signup.tsx
@@ -7,12 +7,15 @@ import { toast } from "sonner"
 import { captureException } from "@sentry/nextjs"
 import Link from "next/link"
 
+import { useState } from "react"
+import { Eye, EyeOff } from "lucide-react"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { buttonVariants } from "@/components/ui/button"
 import { Icons } from "@/components/icons/lucide"
 import { cn } from "@/lib/utilities"
 import { shopperSignup } from "@/lib/query"
+import { PhoneInput } from "@/components/forms/phone-input"
 
 interface QuickSignupData {
   name: string
@@ -28,7 +31,8 @@ interface QuickSignupFormProps {
 }
 
 export function QuickSignupForm({ redirectTo = "/", className }: QuickSignupFormProps) {
-  const { register, handleSubmit, formState: { errors } } = useForm<QuickSignupData>()
+  const { register, handleSubmit, setValue, formState: { errors } } = useForm<QuickSignupData>()
+  const [showPassword, setShowPassword] = useState(false)
 
   const { mutate, isPending, isSuccess } = useMutation({
     mutationFn: async (data: QuickSignupData) => {
@@ -84,7 +88,7 @@ export function QuickSignupForm({ redirectTo = "/", className }: QuickSignupForm
             <Label htmlFor="qs-name">Full name</Label>
             <Input
               id="qs-name"
-              placeholder="John Doe"
+              placeholder="Full name"
               disabled={isPending}
               {...register("name", { required: "Name is required" })}
             />
@@ -104,41 +108,57 @@ export function QuickSignupForm({ redirectTo = "/", className }: QuickSignupForm
           </div>
 
           <div className="grid gap-1">
-            <Label htmlFor="qs-phone">Phone number</Label>
-            <Input
-              id="qs-phone"
-              type="tel"
-              placeholder="0771234567"
-              disabled={isPending}
-              {...register("phone", { required: "Phone number is required" })}
+            <Label>Phone number</Label>
+            <PhoneInput
+              value=""
+              onChange={(digits) => setValue("phone", digits, { shouldValidate: true })}
+              error={errors.phone?.message}
             />
-            {errors.phone && <p className="text-xs text-red-600">{errors.phone.message}</p>}
+            <input type="hidden" {...register("phone", { required: "Phone number is required" })} />
           </div>
 
           <div className="grid gap-1">
             <Label htmlFor="qs-password">Password</Label>
-            <Input
-              id="qs-password"
-              type="password"
-              placeholder="Min 8 characters"
-              disabled={isPending}
-              {...register("password", {
-                required: "Password is required",
-                minLength: { value: 8, message: "Min 8 characters" },
-              })}
-            />
+            <div className="relative">
+              <Input
+                id="qs-password"
+                type={showPassword ? "text" : "password"}
+                placeholder="Min 8 characters"
+                disabled={isPending}
+                {...register("password", {
+                  required: "Password is required",
+                  minLength: { value: 8, message: "Min 8 characters" },
+                })}
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((v) => !v)}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+              </button>
+            </div>
             {errors.password && <p className="text-xs text-red-600">{errors.password.message}</p>}
           </div>
 
           <div className="grid gap-1">
             <Label htmlFor="qs-confirm">Confirm password</Label>
-            <Input
-              id="qs-confirm"
-              type="password"
-              placeholder="Confirm password"
-              disabled={isPending}
-              {...register("confirm_password", { required: "Please confirm your password" })}
-            />
+            <div className="relative">
+              <Input
+                id="qs-confirm"
+                type={showPassword ? "text" : "password"}
+                placeholder="Confirm password"
+                disabled={isPending}
+                {...register("confirm_password", { required: "Please confirm your password" })}
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((v) => !v)}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+              </button>
+            </div>
             {errors.confirm_password && <p className="text-xs text-red-600">{errors.confirm_password.message}</p>}
           </div>
 

--- a/apps/client-fnp/emails/templates/lots/lot-bid-received.tsx
+++ b/apps/client-fnp/emails/templates/lots/lot-bid-received.tsx
@@ -11,7 +11,7 @@ interface LotBidReceivedEmailProps {
 
 export default function LotBidReceivedEmail({
   name = "Okandas",
-  bidderName = "John",
+  bidderName = "Okandas",
   lotSlug = "chickens-broilers-abc123",
   quantity = "100.00",
   unit = "bird",


### PR DESCRIPTION
## Summary
- New campaigns page with list + detail view + recipient tracking
- Analytics page redesigned with key numbers, top viewed, most active
- Dashboard cleaned up to focus on Users, Sales, Contact Views, Revenue Channels
- Removed Sent Blasts from sidebar (replaced by Campaigns)
- Analytics section always open in sidebar