### PR TITLE
Add nav to auth pages, Login|Sign Up header, cleanup signup

### DIFF
--- a/apps/client-fnp/app/(auth)/layout.tsx
+++ b/apps/client-fnp/app/(auth)/layout.tsx
@@ -1,4 +1,5 @@
-import { auth } from "@/auth"
+import { SiteHeader } from "@/components/layouts/site-header"
+import { SiteFooter } from "@/components/layouts/site-footer"
 
 interface AuthLayoutProps {
     children: React.ReactNode
@@ -8,7 +9,9 @@ export default async function AuthLayout({ children }: AuthLayoutProps) {
 
     return (
         <main>
+            <SiteHeader />
             {children}
+            <SiteFooter />
         </main>
     )
 }

--- a/apps/client-fnp/components/forms/signup.tsx
+++ b/apps/client-fnp/components/forms/signup.tsx
@@ -199,33 +199,6 @@ export function SignUpAuthForm({ className, ...props }: AuthFormProps) {
 
     return (
         <div className={cn("", className)} {...props}>
-            {/* Social login buttons */}
-            <div className="grid gap-3 mb-6">
-                <button
-                    type="button"
-                    onClick={() => signIn("google", { callbackUrl: "/" })}
-                    className="flex w-full items-center justify-center gap-3 rounded-md bg-white px-3 py-2.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 transition-colors"
-                >
-                    <svg className="h-5 w-5" aria-hidden="true" viewBox="0 0 24 24">
-                        <path d="M12.0003 4.75C13.7703 4.75 15.3553 5.36002 16.6053 6.54998L20.0303 3.125C17.9502 1.19 15.2353 0 12.0003 0C7.31028 0 3.25527 2.69 1.28027 6.60998L5.27028 9.70498C6.21525 6.86002 8.87028 4.75 12.0003 4.75Z" fill="#EA4335" />
-                        <path d="M23.49 12.275C23.49 11.49 23.415 10.73 23.3 10H12V14.51H18.47C18.18 15.99 17.34 17.25 16.08 18.1L19.945 21.1C22.2 19.01 23.49 15.92 23.49 12.275Z" fill="#4285F4" />
-                        <path d="M5.26498 14.2949C5.02498 13.5699 4.88501 12.7999 4.88501 11.9999C4.88501 11.1999 5.01998 10.4299 5.26498 9.7049L1.275 6.60986C0.46 8.22986 0 10.0599 0 11.9999C0 13.9399 0.46 15.7699 1.28 17.3899L5.26498 14.2949Z" fill="#FBBC05" />
-                        <path d="M12.0004 24.0001C15.2404 24.0001 17.9654 22.935 19.9454 21.095L16.0804 18.095C15.0054 18.82 13.6204 19.245 12.0004 19.245C8.8704 19.245 6.21537 17.135 5.2654 14.29L1.27539 17.385C3.25539 21.31 7.3104 24.0001 12.0004 24.0001Z" fill="#34A853" />
-                    </svg>
-                    <span>Continue with Google</span>
-                </button>
-
-            </div>
-
-            <div className="relative mb-6">
-                <div className="absolute inset-0 flex items-center" aria-hidden="true">
-                    <div className="w-full border-t border-border" />
-                </div>
-                <div className="relative flex justify-center text-sm">
-                    <span className="bg-card px-4 text-muted-foreground">or register with email</span>
-                </div>
-            </div>
-
             <form onSubmit={handleSubmit((data) => submitSignUpForm(data))}>
                 <div className="space-y-12">
                     {/* Business Information Section */}

--- a/apps/client-fnp/components/layouts/site-header.tsx
+++ b/apps/client-fnp/components/layouts/site-header.tsx
@@ -359,6 +359,23 @@ export function SiteHeader() {
 
         {/* Right side actions */}
         <div className="hidden lg:flex items-center gap-2">
+          {!user && (
+            <>
+              <Link
+                href="/login"
+                className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+              >
+                Login
+              </Link>
+              <span className="text-muted-foreground/40">|</span>
+              <Link
+                href="/signup"
+                className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+              >
+                Sign Up
+              </Link>
+            </>
+          )}
           <Link
             href="/prices"
             onClick={() => sendGTMEvent({ event: 'nav_click', link_name: 'prices' })}

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "7.2.0",
+  "version": "7.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- Auth layout now includes SiteHeader + SiteFooter on login/signup/reset pages
- Desktop header shows Login | Sign Up links for logged-out users
- Removed Google OAuth button from farmer/buyer signup page (only on login + checkout modal)
- Version bump to 7.3.0