### PR TITLE
fix: add seller booking alert email

### DIFF
--- a/apps/client-fnp/app/api/emails/send/route.ts
+++ b/apps/client-fnp/app/api/emails/send/route.ts
@@ -18,6 +18,7 @@ import {
   OrderDocumentConfirmationEmail,
   PreorderRequestReceivedEmail,
   PreorderRequestAdminEmail,
+  PreorderRequestSellerEmail,
   PreorderConfirmedEmail,
   PreorderRejectedEmail,
   PreorderDepositPaidEmail,
@@ -164,6 +165,11 @@ export async function POST(req: NextRequest) {
     case "preorder-request-admin":
       subject = `New Pre-Order Request — ${(props as { bookingRef?: string }).bookingRef ?? ""}`
       html = await render(PreorderRequestAdminEmail(props as Parameters<typeof PreorderRequestAdminEmail>[0]))
+      break
+
+    case "preorder-request-seller":
+      subject = `New Booking on Your Listing — ${(props as { bookingRef?: string }).bookingRef ?? ""}`
+      html = await render(PreorderRequestSellerEmail(props as Parameters<typeof PreorderRequestSellerEmail>[0]))
       break
 
     case "preorder-confirmed":

--- a/apps/client-fnp/emails/index.ts
+++ b/apps/client-fnp/emails/index.ts
@@ -32,6 +32,7 @@ export { default as LotBidRejectedEmail } from "./templates/lots/lot-bid-rejecte
 // Pre-order templates
 export { default as PreorderRequestReceivedEmail } from "./templates/bookings/preorder-request-received"
 export { default as PreorderRequestAdminEmail } from "./templates/bookings/preorder-request-admin"
+export { default as PreorderRequestSellerEmail } from "./templates/bookings/preorder-request-seller"
 export { default as PreorderConfirmedEmail } from "./templates/bookings/preorder-confirmed"
 export { default as PreorderRejectedEmail } from "./templates/bookings/preorder-rejected"
 export { default as PreorderDepositPaidEmail } from "./templates/bookings/preorder-deposit-paid"

--- a/apps/client-fnp/emails/templates/blast.tsx
+++ b/apps/client-fnp/emails/templates/blast.tsx
@@ -6,11 +6,13 @@ interface BlastEmailProps {
   subject?: string
   link?: string
   linkLabel?: string
+  link2?: string
+  linkLabel2?: string
 }
 
 const UTM = "?utm_source=blast&utm_medium=email&utm_campaign=custom_blast"
 
-export default function BlastEmail({ name = "Okandas", message = "", link, linkLabel }: BlastEmailProps) {
+export default function BlastEmail({ name = "Okandas", message = "", link, linkLabel, link2, linkLabel2 }: BlastEmailProps) {
   return (
     <Html lang="en">
       <Head />
@@ -28,7 +30,10 @@ export default function BlastEmail({ name = "Okandas", message = "", link, linkL
             <Text style={greeting}>Hi {name},</Text>
             <Text style={paragraph}>{message}</Text>
             {link && (
-              <Link href={link} style={inlineLink}>{linkLabel || link}</Link>
+              <Text style={{ margin: "0 0 8px" }}><Link href={link} style={inlineLink}>{linkLabel || link}</Link></Text>
+            )}
+            {link2 && (
+              <Text style={{ margin: "0 0 8px" }}><Link href={link2} style={inlineLink}>{linkLabel2 || link2}</Link></Text>
             )}
           </Section>
 

--- a/apps/client-fnp/emails/templates/bookings/preorder-request-seller.tsx
+++ b/apps/client-fnp/emails/templates/bookings/preorder-request-seller.tsx
@@ -1,0 +1,77 @@
+import { Body, Container, Head, Hr, Html, Link, Preview, Section, Text } from "@react-email/components"
+
+interface Props { bookingRef?: string; sellerName?: string; customerName?: string; productName?: string; quantity?: number; unit?: string; offerPrice?: number; buyerNotes?: string }
+
+export default function PreorderRequestSellerEmail({
+  bookingRef = "FNP-BK-PO-0001",
+  sellerName = "Okandas",
+  customerName = "Jane Doe",
+  productName = "Fivet Cobb 500 Day-Old Chicks",
+  quantity = 0,
+  unit = "",
+  offerPrice = 0,
+  buyerNotes = "",
+}: Props) {
+  const orderDetails = [
+    `Produce   ${productName}`,
+    `Quantity  ${quantity} ${unit || "units"}`,
+    offerPrice > 0 ? `Offer     $${(offerPrice / 100).toFixed(2)} per ${unit || "unit"}` : "",
+    buyerNotes ? `Notes     ${buyerNotes}` : "",
+  ].filter(Boolean).join("\n")
+
+  return (
+    <Html lang="en">
+      <Head />
+      <Preview>New booking from {customerName} — {String(quantity)} {unit} of {productName}</Preview>
+      <Body style={body}>
+        <Container style={container}>
+
+          {/* Header */}
+          <Section style={header}>
+            <Text style={brand}>farmnport</Text>
+          </Section>
+
+          {/* Content */}
+          <Section style={content}>
+            <Text style={greeting}>Hi {sellerName},</Text>
+            <Text style={paragraph}>You have a new booking request on farmnport.</Text>
+            <Text style={paragraph}>Booking reference: <strong>{bookingRef}</strong></Text>
+            <Text style={paragraph}>Customer: <strong>{customerName}</strong></Text>
+            <Text style={paragraph}>{orderDetails}</Text>
+            <Text style={paragraph}>Our team will review this request and coordinate with you shortly.</Text>
+          </Section>
+
+          <Hr style={divider} />
+
+          <Section style={content}>
+            <Text style={signoff}>farmnport notifications</Text>
+          </Section>
+
+          {/* Footer */}
+          <Section style={footer}>
+            <Text style={footerText}>
+              farmnport &nbsp;&middot;&nbsp; 13 Grace Rd, Winston Park, Marondera, Zimbabwe
+            </Text>
+            <Text style={footerText}>
+              &copy; {new Date().getFullYear()} <Link href="https://farmnport.com" style={footerLink}>farmnport.com</Link>. All rights reserved.
+            </Text>
+          </Section>
+
+        </Container>
+      </Body>
+    </Html>
+  )
+}
+
+const body: React.CSSProperties = { backgroundColor: "#f8fafc", fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif", margin: 0, padding: "40px 0" }
+const container: React.CSSProperties = { backgroundColor: "#ffffff", margin: "0 auto", maxWidth: "580px", borderRadius: "8px", overflow: "hidden" }
+const header: React.CSSProperties = { padding: "32px 40px 0" }
+const brand: React.CSSProperties = { fontSize: "22px", fontWeight: "700", color: "#0f172a", margin: 0 }
+const content: React.CSSProperties = { padding: "16px 40px" }
+const greeting: React.CSSProperties = { fontSize: "18px", fontWeight: "600", color: "#0f172a", margin: "0 0 12px" }
+const paragraph: React.CSSProperties = { fontSize: "15px", lineHeight: "1.7", color: "#475569", margin: "0 0 16px", whiteSpace: "pre-wrap" }
+const divider: React.CSSProperties = { borderColor: "#e2e8f0", margin: "8px 40px" }
+const signoff: React.CSSProperties = { fontSize: "14px", color: "#64748b", lineHeight: "1.6", whiteSpace: "pre-wrap" }
+const footer: React.CSSProperties = { padding: "16px 40px 32px" }
+const footerText: React.CSSProperties = { fontSize: "12px", color: "#94a3b8", margin: "0 0 4px", textAlign: "center" }
+const footerLink: React.CSSProperties = { color: "#94a3b8", textDecoration: "underline" }

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "7.4.0",
+  "version": "7.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- New `preorder-request-seller` email template for notifying sellers of new bookings
- Blast email template now supports a second link (link2/linkLabel2)

## Test plan
- [ ] Verify seller receives "New Booking on Your Listing" email when booking is placed
- [ ] Verify blast emails render second link correctly