### PR TITLE
feat: WhatsApp and email opt-in preferences

### DIFF
--- a/apps/client-fnp/app/(landing)/account/(sections)/profile/ProfileClient.tsx
+++ b/apps/client-fnp/app/(landing)/account/(sections)/profile/ProfileClient.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react"
 import { useSession } from "next-auth/react"
 import { useQuery } from "@tanstack/react-query"
 import { toast } from "sonner"
-import { requestPhoneCode, verifyPhoneCode, myBookings, incomingBookings } from "@/lib/query"
+import { requestPhoneCode, verifyPhoneCode, myBookings, incomingBookings, updateNotificationPrefs } from "@/lib/query"
 import { BaseURL } from "@/lib/schemas"
 import axios from "axios"
 import Link from "next/link"
@@ -23,6 +23,8 @@ export default function AccountProfilePage() {
     const [currentEmail, setCurrentEmail] = useState("")
     const [loading, setLoading] = useState(false)
     const [fetching, setFetching] = useState(true)
+    const [whatsappOptIn, setWhatsappOptIn] = useState(true)
+    const [emailOptIn, setEmailOptIn] = useState(true)
 
     useEffect(() => {
         if (!user?.token) return
@@ -31,6 +33,8 @@ export default function AccountProfilePage() {
         }).then(res => {
             setCurrentPhone(res.data?.phone || "")
             setCurrentEmail(res.data?.email || user?.email || "")
+            setWhatsappOptIn(res.data?.whatsapp_opt_in ?? true)
+            setEmailOptIn(res.data?.email_opt_in ?? true)
         }).catch(() => {}).finally(() => setFetching(false))
     }, [user])
 
@@ -181,6 +185,64 @@ export default function AccountProfilePage() {
                             </div>
                         </div>
                     )}
+                </div>
+            </div>
+
+            {/* Notification preferences */}
+            <div className="border rounded-xl">
+                <div className="px-5 py-4">
+                    <h2 className="text-base font-bold">Notification preferences</h2>
+                    <p className="text-xs text-muted-foreground mt-1">Choose how you want to hear from us</p>
+                </div>
+                <div className="divide-y">
+                    <label className="flex items-center justify-between px-5 py-4 cursor-pointer">
+                        <div>
+                            <p className="text-sm font-medium">WhatsApp notifications</p>
+                            <p className="text-xs text-muted-foreground mt-0.5">Order updates, delivery alerts, and price changes</p>
+                        </div>
+                        <button
+                            role="switch"
+                            aria-checked={whatsappOptIn}
+                            onClick={async () => {
+                                const next = !whatsappOptIn
+                                setWhatsappOptIn(next)
+                                try {
+                                    await updateNotificationPrefs({ whatsapp_opt_in: next })
+                                    toast.success(next ? "WhatsApp notifications enabled" : "WhatsApp notifications disabled")
+                                } catch {
+                                    setWhatsappOptIn(!next)
+                                    toast.error("Failed to update preference")
+                                }
+                            }}
+                            className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors ${whatsappOptIn ? "bg-primary" : "bg-muted"}`}
+                        >
+                            <span className={`inline-block h-4 w-4 rounded-full bg-white transition-transform ${whatsappOptIn ? "translate-x-6" : "translate-x-1"}`} />
+                        </button>
+                    </label>
+                    <label className="flex items-center justify-between px-5 py-4 cursor-pointer">
+                        <div>
+                            <p className="text-sm font-medium">Email notifications</p>
+                            <p className="text-xs text-muted-foreground mt-0.5">Platform updates, announcements, and offers</p>
+                        </div>
+                        <button
+                            role="switch"
+                            aria-checked={emailOptIn}
+                            onClick={async () => {
+                                const next = !emailOptIn
+                                setEmailOptIn(next)
+                                try {
+                                    await updateNotificationPrefs({ email_opt_in: next })
+                                    toast.success(next ? "Email notifications enabled" : "Email notifications disabled")
+                                } catch {
+                                    setEmailOptIn(!next)
+                                    toast.error("Failed to update preference")
+                                }
+                            }}
+                            className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors ${emailOptIn ? "bg-primary" : "bg-muted"}`}
+                        >
+                            <span className={`inline-block h-4 w-4 rounded-full bg-white transition-transform ${emailOptIn ? "translate-x-6" : "translate-x-1"}`} />
+                        </button>
+                    </label>
                 </div>
             </div>
 

--- a/apps/client-fnp/app/(landing)/terms/page.tsx
+++ b/apps/client-fnp/app/(landing)/terms/page.tsx
@@ -18,7 +18,8 @@ const sections = [
   { id: 'indemnification', title: '9. Indemnification' },
   { id: 'modifications', title: '10. Modifications to terms' },
   { id: 'governing-law', title: '11. Governing law' },
-  { id: 'contact', title: '12. Contact us' },
+  { id: 'communications', title: '12. Communications and notifications' },
+  { id: 'contact', title: '13. Contact us' },
 ]
 
 export default function TermsOfServicePage() {
@@ -28,7 +29,7 @@ export default function TermsOfServicePage() {
         {/* Header */}
         <div className="mb-12">
           <h1 className="text-4xl font-heading font-bold tracking-tight mb-3">Terms of Service</h1>
-          <p className="text-sm text-muted-foreground">Last updated: March 2026</p>
+          <p className="text-sm text-muted-foreground">Last updated: August 2026</p>
         </div>
 
         {/* Intro */}
@@ -188,8 +189,28 @@ export default function TermsOfServicePage() {
           </section>
 
           {/* 12 */}
+          <section id="communications">
+            <h2 className="text-xl font-semibold mb-4">12. Communications and notifications</h2>
+            <p className="text-sm leading-6 text-muted-foreground mb-3">
+              By creating an account on Farmnport, you consent to receive communications from Farmnport, including but not limited to:
+            </p>
+            <ul className="list-disc pl-5 space-y-1.5 text-sm leading-6 text-muted-foreground mb-4">
+              <li><span className="font-semibold">Email notifications</span> &mdash; order updates, account activity, platform announcements, and promotional content</li>
+              <li><span className="font-semibold">WhatsApp notifications</span> &mdash; order updates, delivery alerts, price changes, and other service-related messages sent to the phone number associated with your account</li>
+            </ul>
+            <p className="text-sm leading-6 text-muted-foreground mb-3">
+              You may opt out of WhatsApp notifications or email communications at any time through your account settings at{' '}
+              <a href="/account/profile" className="underline hover:text-foreground">farmnport.com/account/profile</a>.
+              Opting out of certain transactional notifications (such as order confirmations and security alerts) is not available, as these are essential to the operation of your account.
+            </p>
+            <p className="text-sm leading-6 text-muted-foreground">
+              By providing your phone number during registration, you acknowledge that Farmnport may contact you via WhatsApp for service-related communications. Farmnport will not share your phone number with third parties for marketing purposes.
+            </p>
+          </section>
+
+          {/* 13 */}
           <section id="contact">
-            <h2 className="text-xl font-semibold mb-4">12. Contact us</h2>
+            <h2 className="text-xl font-semibold mb-4">13. Contact us</h2>
             <p className="text-sm leading-6 text-muted-foreground mb-4">
               If you have any questions about these Terms of Service, please contact us:
             </p>

--- a/apps/client-fnp/app/api/emails/send/route.ts
+++ b/apps/client-fnp/app/api/emails/send/route.ts
@@ -27,6 +27,7 @@ import {
   PreorderCollectedEmail,
   PreorderExpiredEmail,
   MarketingLaunchEmail,
+  TermsUpdateEmail,
   LotBidReceivedEmail,
   LotBidAcceptedEmail,
   LotBidRejectedEmail,
@@ -135,6 +136,13 @@ export async function POST(req: NextRequest) {
       const p = props as Parameters<typeof MarketingLaunchEmail>[0]
       subject = "New ways to trade on farmnport — bookings and lots"
       html = await render(MarketingLaunchEmail(p))
+      break
+    }
+
+    case "terms-update": {
+      const p = props as Parameters<typeof TermsUpdateEmail>[0]
+      subject = "We've updated our Terms of Service"
+      html = await render(TermsUpdateEmail(p))
       break
     }
 

--- a/apps/client-fnp/emails/index.ts
+++ b/apps/client-fnp/emails/index.ts
@@ -12,6 +12,7 @@ export { default as MenusReviewsFavouritesEmail } from "./templates/menus-review
 
 // Marketing templates
 export { default as MarketingLaunchEmail } from "./templates/marketing-launch"
+export { default as TermsUpdateEmail } from "./templates/terms-update"
 
 // Order templates
 export { default as OrderConfirmationEmail } from "./templates/orders/order-confirmation"

--- a/apps/client-fnp/emails/templates/terms-update.tsx
+++ b/apps/client-fnp/emails/templates/terms-update.tsx
@@ -1,0 +1,112 @@
+import { Body, Button, Container, Head, Hr, Html, Link, Preview, Section, Text } from "@react-email/components"
+
+interface TermsUpdateEmailProps {
+  name?: string
+}
+
+export default function TermsUpdateEmail({ name = "Member" }: TermsUpdateEmailProps) {
+  return (
+    <Html lang="en">
+      <Head />
+      <Preview>We've updated our Terms of Service — WhatsApp and email notification preferences</Preview>
+      <Body style={body}>
+        <Container style={container}>
+
+          {/* Header */}
+          <Section style={header}>
+            <Text style={brand}>farmnport</Text>
+          </Section>
+
+          {/* Greeting */}
+          <Section style={content}>
+            <Text style={greeting}>Hi {name},</Text>
+            <Text style={paragraph}>
+              We have made some updates to our Terms of Service that we would like you to know about.
+            </Text>
+          </Section>
+
+          <Hr style={divider} />
+
+          {/* What changed */}
+          <Section style={content}>
+            <Text style={sectionLabel}>UPDATED</Text>
+            <Text style={sectionTitle}>Communications and notifications</Text>
+            <Text style={paragraph}>
+              We have added a new section to our Terms of Service covering how we communicate with you. This means you may now receive:
+            </Text>
+
+            <Text style={subheading}>WhatsApp notifications</Text>
+            <Text style={paragraph}>
+              Order updates, delivery alerts, and price changes — sent to the phone number on your account.
+            </Text>
+
+            <Text style={subheading}>Email notifications</Text>
+            <Text style={paragraph}>
+              Platform updates, announcements, and offers.
+            </Text>
+          </Section>
+
+          <Hr style={divider} />
+
+          {/* Your control */}
+          <Section style={content}>
+            <Text style={sectionTitle}>You are in control</Text>
+            <Text style={paragraph}>
+              You can turn off WhatsApp notifications, email notifications, or both at any time from your account settings.
+            </Text>
+            <Section style={buttonWrapper}>
+              <Button href="https://farmnport.com/account/profile?utm_source=blast&utm_medium=email&utm_campaign=terms_update&utm_content=cta_settings" style={buttonPrimary}>Manage Notification Settings</Button>
+            </Section>
+          </Section>
+
+          <Hr style={divider} />
+
+          {/* Full terms */}
+          <Section style={content}>
+            <Text style={paragraph}>
+              You can read the full updated Terms of Service here:
+            </Text>
+            <Text style={linkList}>
+              <Link href="https://farmnport.com/terms?utm_source=blast&utm_medium=email&utm_campaign=terms_update&utm_content=read_terms" style={inlineLink}>Read Terms of Service</Link>
+            </Text>
+            <Text style={paragraph}>
+              By continuing to use farmnport, you agree to the updated terms. If you have any questions, reply to this email or contact us at sales@farmnport.com.
+            </Text>
+            <Text style={signoff}>Thank you,{"\n"}the farmnport team</Text>
+          </Section>
+
+          {/* Footer */}
+          <Section style={footer}>
+            <Text style={footerText}>
+              farmnport &nbsp;&middot;&nbsp; 13 Grace Rd, Winston Park, Marondera, Zimbabwe
+            </Text>
+            <Text style={footerText}>
+              &copy; {new Date().getFullYear()} <Link href="https://farmnport.com" style={footerLink}>farmnport.com</Link>. All rights reserved.
+            </Text>
+          </Section>
+
+        </Container>
+      </Body>
+    </Html>
+  )
+}
+
+const body: React.CSSProperties = { backgroundColor: "#f8fafc", fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif", margin: 0, padding: "40px 0" }
+const container: React.CSSProperties = { backgroundColor: "#ffffff", margin: "0 auto", maxWidth: "580px", borderRadius: "8px", overflow: "hidden" }
+const header: React.CSSProperties = { padding: "32px 40px 0" }
+const brand: React.CSSProperties = { fontSize: "22px", fontWeight: "700", color: "#0f172a", margin: 0 }
+const content: React.CSSProperties = { padding: "16px 40px" }
+const greeting: React.CSSProperties = { fontSize: "18px", fontWeight: "600", color: "#0f172a", margin: "0 0 12px" }
+const paragraph: React.CSSProperties = { fontSize: "15px", lineHeight: "1.7", color: "#475569", margin: "0 0 16px", whiteSpace: "pre-wrap" }
+const sectionLabel: React.CSSProperties = { fontSize: "11px", fontWeight: "700", color: "#ea580c", letterSpacing: "1px", textTransform: "uppercase", margin: "0 0 4px" }
+const sectionTitle: React.CSSProperties = { fontSize: "20px", fontWeight: "700", color: "#0f172a", margin: "0 0 12px", lineHeight: "1.3" }
+const subheading: React.CSSProperties = { fontSize: "15px", fontWeight: "600", color: "#0f172a", margin: "0 0 8px" }
+const buttonWrapper: React.CSSProperties = { margin: "8px 0 24px" }
+const buttonPrimary: React.CSSProperties = { backgroundColor: "#ea580c", borderRadius: "6px", color: "#ffffff", fontSize: "15px", fontWeight: "600", textDecoration: "none", textAlign: "center", display: "inline-block", padding: "14px 28px" }
+const linkList: React.CSSProperties = { fontSize: "14px", lineHeight: "2", color: "#475569", margin: "0 0 16px", whiteSpace: "pre-wrap" }
+const inlineLink: React.CSSProperties = { color: "#ea580c", fontWeight: "600", textDecoration: "none" }
+const divider: React.CSSProperties = { borderColor: "#e2e8f0", margin: "8px 40px" }
+const signoff: React.CSSProperties = { fontSize: "14px", color: "#64748b", lineHeight: "1.6", whiteSpace: "pre-wrap" }
+const footer: React.CSSProperties = { padding: "16px 40px 32px" }
+const footerText: React.CSSProperties = { fontSize: "12px", color: "#94a3b8", margin: "0 0 4px", textAlign: "center" }
+const footerLink: React.CSSProperties = { color: "#94a3b8", textDecoration: "underline" }

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "7.5.4",
+  "version": "7.6.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- Add section 12 "Communications and notifications" to Terms of Service
- Add WhatsApp/email notification toggles to profile settings page
- Add terms-update email template for blast notification