### PR TITLE
Fix supplier contact styling on incoming bookings

### DIFF
--- a/apps/client-fnp/app/(landing)/account/(sections)/incoming-bookings/[id]/page.tsx
+++ b/apps/client-fnp/app/(landing)/account/(sections)/incoming-bookings/[id]/page.tsx
@@ -81,7 +81,7 @@ function ContactField({ label, value, href, event }: { label: string; value?: st
   return (
     <div>
       <p className="text-xs text-muted-foreground">{label}</p>
-      <a href={href} onClick={() => sendGTMEvent({ event: "contact_click", method: event, value })} className="text-sm font-medium text-primary hover:underline break-all mt-0.5 block">
+      <a href={href} onClick={() => sendGTMEvent({ event: "contact_click", method: event, value })} className="text-sm font-medium text-foreground hover:underline break-all mt-0.5 block">
         {value}
       </a>
     </div>
@@ -241,18 +241,15 @@ export default function IncomingBookingDetailPage({ params }: { params: Promise<
 
           {/* Farmer details */}
           <div className="border rounded-xl p-5">
-            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-4">Supplier</p>
-            <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
-              {booking.status === "pending" ? (
-                <Field label="Name" value={booking.client_name} />
-              ) : (
-              <>
-                <Field label="Name"  value={booking.client_name} />
+            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
+              Supplier: <span className="text-foreground capitalize">{booking.client_name}</span>
+            </p>
+            {booking.status !== "pending" && (
+              <div className="grid grid-cols-2 gap-4 mt-3">
                 <ContactField label="Phone" value={booking.client_phone} href={`tel:${booking.client_phone}`} event="phone" />
                 <ContactField label="Email" value={booking.client_email} href={`mailto:${booking.client_email}`} event="email" />
-              </>
-              )}
-            </div>
+              </div>
+            )}
           </div>
 
           {/* Delivery details */}

--- a/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/[slug]/page.tsx
@@ -183,7 +183,7 @@ export default async function AgroChemicalGuidePage({ params }: GuidePageProps) 
             </div>
 
             {/* Used On & Targets Grid */}
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:h-[315px]">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:h-[150px]">
                 {chemical.dosage_rates && chemical.dosage_rates.length > 0 && (
                     <div className="rounded-xl border bg-card p-4 overflow-y-auto">
                         <h2 className="text-sm font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-400 mb-3">

--- a/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { AgrochemicalDosageTable } from "@/components/agrochemical/AgrochemicalD
 import { ProductTargets } from "@/components/agrochemical/ProductTargets"
 import { GuideDetailLayout } from "@/components/shared/GuideDetailLayout"
 import { RelatedGuideProducts } from "@/components/sections/related-guide-products"
+import { WantToBuyCTA } from "@/components/shared/WantToBuyCTA"
 
 type Props = { params: Promise<{ category: string; slug: string }> }
 
@@ -175,6 +176,15 @@ export default async function AgroChemicalGuidePage({ params }: GuidePageProps) 
                     )}
                 </p>
             </div>
+
+            {/* Want to Buy CTA */}
+            <WantToBuyCTA
+                available_for_sale={chemical.available_for_sale}
+                name={chemical.name}
+                brand={chemical.brand?.name}
+                href={`/buy-agrochemicals/${slug}`}
+                interestHref={`/interest/agrochemical/${slug}`}
+            />
 
             {/* Active Ingredients */}
             <div>

--- a/apps/client-fnp/components/shared/GuideDetailLayout.tsx
+++ b/apps/client-fnp/components/shared/GuideDetailLayout.tsx
@@ -129,15 +129,6 @@ export function GuideDetailLayout({
                             </div>
                         )}
 
-                        {/* Want to Buy CTA */}
-                        <WantToBuyCTA
-                            available_for_sale={product.available_for_sale}
-                            name={product.name}
-                            brand={product.brand?.name}
-                            href={buyHref}
-                            interestHref={interestHref}
-                        />
-
                         {/* Precautions (array) */}
                         {resolvedPrecautions && resolvedPrecautions.length > 0 && (
                             <div className="rounded-lg border border-red-200 dark:border-red-900 bg-red-50/50 dark:bg-red-950/30 px-3 py-2">

--- a/apps/client-fnp/components/shared/WantToBuyCTA.tsx
+++ b/apps/client-fnp/components/shared/WantToBuyCTA.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link"
 import { ShoppingCart } from "lucide-react"
+import { capitalizeFirstLetter } from "@/lib/utilities"
 
 interface WantToBuyCTAProps {
     available_for_sale: boolean
@@ -10,7 +11,7 @@ interface WantToBuyCTAProps {
 }
 
 export function WantToBuyCTA({ name, brand, href }: WantToBuyCTAProps) {
-    const label = brand ? `${name} ${brand}` : name
+    const label = brand ? `${name} ${capitalizeFirstLetter(brand)}` : name
     return (
         <Link
             href={href}

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "7.6.0",
+  "version": "7.6.1",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- Inline supplier name with header instead of separate field
- Phone/email links use neutral color instead of orange
- 2-column layout for contact details