### PR TITLE
Search improvements and clickable cards

### DIFF
--- a/apps/client-fnp/app/(landing)/animal-health-guides/[category]/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/animal-health-guides/[category]/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { ProductTargets } from "@/components/agrochemical/ProductTargets"
 import { GuideDetailLayout } from "@/components/shared/GuideDetailLayout"
 import { RelatedGuideProducts } from "@/components/sections/related-guide-products"
 import { ProductNotFound } from "@/components/shared/ProductNotFound"
+import { WantToBuyCTA } from "@/components/shared/WantToBuyCTA"
 
 type Props = { params: Promise<{ category: string; slug: string }> }
 
@@ -281,6 +282,15 @@ export default async function AnimalHealthGuidePage({ params }: GuidePageProps) 
                     )}
                 </p>
             </div>
+
+            {/* Want to Buy CTA */}
+            <WantToBuyCTA
+                available_for_sale={product.available_for_sale}
+                name={product.name}
+                brand={product.brand?.name}
+                href={`/buy-animal-health/${slug}`}
+                interestHref={`/interest/animal-health/${slug}`}
+            />
 
             {/* Active Ingredients */}
             <div>

--- a/apps/client-fnp/app/(landing)/equipment-guides/[category]/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/equipment-guides/[category]/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { guardTestItem } from "@/lib/guardTestItem"
 import { ProductNotFound } from "@/components/shared/ProductNotFound"
 import { GuideDetailLayout } from "@/components/shared/GuideDetailLayout"
 import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
+import { WantToBuyCTA } from "@/components/shared/WantToBuyCTA"
 
 type Props = { params: Promise<{ category: string; slug: string }> }
 
@@ -85,6 +86,15 @@ export default async function EquipmentGuidePage({ params }: GuidePageProps) {
                     <p className="text-muted-foreground leading-relaxed text-sm">{product.description}</p>
                 </div>
             )}
+
+            {/* Want to Buy CTA */}
+            <WantToBuyCTA
+                available_for_sale={product.available_for_sale}
+                name={product.name}
+                brand={product.brand?.name}
+                href={`/buy-equipment/${slug}`}
+                interestHref={`/interest/equipment/${slug}`}
+            />
 
             <AdSenseInFeed />
 

--- a/apps/client-fnp/app/(landing)/feed-guides/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/feed-guides/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { GuideDetailLayout } from "@/components/shared/GuideDetailLayout"
 import { RelatedGuideProducts } from "@/components/sections/related-guide-products"
 import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
 import { capitalizeFirstLetter } from "@/lib/utilities"
+import { WantToBuyCTA } from "@/components/shared/WantToBuyCTA"
 import { FeedBreadcrumb } from "./FeedBreadcrumb"
 
 interface FeedDetailPageProps {
@@ -157,6 +158,15 @@ export default async function FeedDetailPage({ params }: FeedDetailPageProps) {
                     <p className="text-muted-foreground leading-relaxed text-sm">{product.description}</p>
                 </div>
             )}
+
+            {/* Want to Buy CTA */}
+            <WantToBuyCTA
+                available_for_sale={product.available_for_sale}
+                name={product.name}
+                brand={product.brand?.name}
+                href={`/buy-feeds/${slug}`}
+                interestHref={`/interest/feed/${slug}`}
+            />
 
             {/* Breed Recommendations */}
             {product.breed_recommendations && (

--- a/apps/client-fnp/app/(landing)/plant-nutrition-guides/[category]/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/plant-nutrition-guides/[category]/[slug]/page.tsx
@@ -152,12 +152,17 @@ export default async function PlantNutritionGuidePage({ params }: GuidePageProps
 
             {/* Used On */}
             {product.dosage_rates && product.dosage_rates.length > 0 && (
-                <div className="rounded-xl border bg-card p-4">
+                <div className="rounded-xl border bg-card p-4 sm:h-[150px] overflow-y-auto">
                     <h2 className="text-sm font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-400 mb-3">
                         Used On
                     </h2>
                     <ul className="space-y-1.5">
-                        {Array.from(new Set(product.dosage_rates.map((rate: any) => rate.crop_group))).map((crop: any, idx: number) => (
+                        {Array.from(new Set(product.dosage_rates.flatMap((rate: any) => {
+                            if (rate.crop_group_items?.length > 0) return rate.crop_group_items
+                            if (rate.crop) return [rate.crop]
+                            if (rate.crop_group) return [rate.crop_group]
+                            return []
+                        }))).map((crop: any, idx: number) => (
                             <li key={idx} className="flex items-center gap-2 text-sm text-foreground">
                                 <span className="h-1.5 w-1.5 rounded-full bg-amber-500 dark:bg-amber-400 flex-shrink-0" />
                                 <span className="capitalize">{crop}</span>

--- a/apps/client-fnp/app/(landing)/search/SearchResults.tsx
+++ b/apps/client-fnp/app/(landing)/search/SearchResults.tsx
@@ -20,7 +20,7 @@ const COLLECTION_LABELS: Record<string, string> = {
   seed_products: "Seeds",
   equipment: "Equipment",
   guides: "Guide",
-  buyers: "Buyer",
+  clients: "Client",
   prices: "Market Prices",
   bookings: "Pre-Order",
   lots: "Lot",
@@ -50,7 +50,10 @@ function getUrls(collection: string, doc: Record<string, any>): { guide?: string
     return { view: `/buy-documents/${doc.slug}` }
   }
   if (collection === "prices") return { view: "/prices" }
-  if (collection === "buyers") return { view: `/buyer/${doc.slug}` }
+  if (collection === "clients") {
+    const prefix = doc.type === "farmer" ? "/farmers" : "/buyers"
+    return { view: `${prefix}/${doc.slug}` }
+  }
   if (collection === "bookings") return { view: `/bookings/${doc.slug}` }
   if (collection === "lots") return { view: `/lots/${doc.slug}` }
 
@@ -83,7 +86,10 @@ function getDescription(collection: string, doc: Record<string, any>): string {
     const location = [doc.city, doc.province].filter(Boolean).join(", ")
     return [doc.breed_name, qty, location].filter(Boolean).join(" · ")
   }
-  if (collection === "buyers") return [doc.short_description, doc.city, doc.province].filter(Boolean).join(" · ")
+  if (collection === "clients") {
+    const typeLabel = doc.type === "farmer" ? "Farmer" : "Buyer"
+    return [typeLabel, doc.short_description, doc.city, doc.province].filter(Boolean).join(" · ")
+  }
   if (collection === "bookings") return [doc.produce_name, doc.breed_name, doc.client_name].filter(Boolean).join(" · ")
   if (collection === "guides") return doc.description || ""
   return [doc.brand_name, doc.category_name].filter(Boolean).join(" · ")
@@ -209,10 +215,19 @@ export function SearchResults() {
               const price = getPrice(item.doc)
               const urls = getUrls(item.collection, item.doc)
               const image = item.doc.image_src
+              const primaryUrl = urls.buy || urls.view || "/"
               return (
-                <div
+                <Link
                   key={`${item.collection}-${item.doc.id}-${i}`}
-                  className="group flex flex-col rounded-lg border bg-card hover:border-primary/40 hover:shadow-md transition-all overflow-hidden cursor-pointer"
+                  href={primaryUrl}
+                  onClick={() => sendGTMEvent({
+                    event: "search_result_click",
+                    search_term: q,
+                    result_collection: item.collection,
+                    result_name: name,
+                    result_position: i + 1,
+                  })}
+                  className="group flex flex-col rounded-lg border bg-card hover:border-primary/40 hover:shadow-md transition-all overflow-hidden"
                 >
                   {/* Image */}
                   <div className="aspect-square bg-muted/30 dark:bg-white relative">
@@ -223,7 +238,7 @@ export function SearchResults() {
 
                   {/* Content */}
                   <div className="p-3 flex flex-col flex-1 border-t">
-                    <p className="text-[11px] font-medium text-foreground mb-1">{COLLECTION_LABELS[item.collection] ?? item.collection}</p>
+                    <p className="text-[11px] font-medium text-foreground mb-1">{item.collection === "clients" ? (item.doc.type === "farmer" ? "Farmer" : "Buyer") : (COLLECTION_LABELS[item.collection] ?? item.collection)}</p>
                     <h3 className="text-sm font-semibold group-hover:text-primary transition-colors line-clamp-2 capitalize">
                       {name}
                     </h3>
@@ -237,33 +252,37 @@ export function SearchResults() {
                       {/* Action buttons */}
                       <div className="flex items-center gap-1.5">
                         {urls.buy && (
-                          <Link
-                            href={urls.buy}
-                            className="flex-1 h-7 rounded text-xs font-semibold bg-primary text-primary-foreground hover:bg-primary/90 transition-colors inline-flex items-center justify-center"
-                          >
+                          <span className="flex-1 h-7 rounded text-xs font-semibold bg-primary text-primary-foreground hover:bg-primary/90 transition-colors inline-flex items-center justify-center">
                             Buy
-                          </Link>
+                          </span>
                         )}
                         {urls.guide && (
                           <Link
                             href={urls.guide}
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              sendGTMEvent({
+                                event: "search_guide_click",
+                                search_term: q,
+                                result_collection: item.collection,
+                                result_name: name,
+                                result_position: i + 1,
+                              })
+                            }}
                             className="flex-1 h-7 rounded text-xs font-medium border text-muted-foreground hover:bg-muted/50 hover:text-foreground transition-colors inline-flex items-center justify-center"
                           >
                             Guide
                           </Link>
                         )}
                         {urls.view && !urls.buy && (
-                          <Link
-                            href={urls.view}
-                            className="flex-1 h-7 rounded text-xs font-medium border text-muted-foreground hover:bg-muted/50 hover:text-foreground transition-colors inline-flex items-center justify-center"
-                          >
+                          <span className="flex-1 h-7 rounded text-xs font-medium border text-muted-foreground hover:bg-muted/50 hover:text-foreground transition-colors inline-flex items-center justify-center">
                             View
-                          </Link>
+                          </span>
                         )}
                       </div>
                     </div>
                   </div>
-                </div>
+                </Link>
               )
             })}
           </div>

--- a/apps/client-fnp/app/(landing)/seed-guides/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/seed-guides/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { formatProductName } from "@/lib/utilities"
 import { ProductNotFound } from "@/components/shared/ProductNotFound"
 import { GuideDetailLayout } from "@/components/shared/GuideDetailLayout"
 import { AdSenseInFeed } from "@/components/ads/AdSenseInFeed"
+import { WantToBuyCTA } from "@/components/shared/WantToBuyCTA"
 import { RelatedGuideProducts } from "@/components/sections/related-guide-products"
 
 interface Props {
@@ -87,6 +88,15 @@ export default async function SeedGuidePage({ params }: Props) {
                     <p className="text-muted-foreground leading-relaxed text-sm">{product.description}</p>
                 </div>
             )}
+
+            {/* Want to Buy CTA */}
+            <WantToBuyCTA
+                available_for_sale={product.available_for_sale}
+                name={product.name}
+                brand={product.brand?.name}
+                href={`/buy-seed-products/${slug}`}
+                interestHref={`/interest/seed/${slug}`}
+            />
 
             <AdSenseInFeed />
 

--- a/apps/client-fnp/components/layouts/site-header.tsx
+++ b/apps/client-fnp/components/layouts/site-header.tsx
@@ -6,7 +6,8 @@ import { useRouter } from "next/navigation"
 import { useSession } from "next-auth/react"
 import { signOut } from "next-auth/react"
 import { sendGTMEvent } from "@next/third-parties/google"
-import { Search, ShoppingCart } from "lucide-react"
+import { Search, ShoppingCart, Sparkles } from "lucide-react"
+import { AISearchOverlay } from "@/components/structures/ai-search"
 import { siteConfig } from "@/config/site"
 import { MobileNav } from "@/components/layouts/mobile-nav"
 import { AuthenticatedUser, AppURL } from "@/lib/schemas"
@@ -224,50 +225,60 @@ const SEARCH_CATEGORIES = [
   { value: "lots", label: "Lots" },
 ]
 
-function NavSearchBar({ router, onFocus }: { router: ReturnType<typeof useRouter>; onFocus?: () => void }) {
+function NavSearchBar({ router, onFocus, onAskAI }: { router: ReturnType<typeof useRouter>; onFocus?: () => void; onAskAI: () => void }) {
   const [category, setCategory] = useState("all")
 
   return (
-    <form
-      className="hidden lg:flex flex-1 items-center px-6"
-      onSubmit={(e) => {
-        e.preventDefault()
-        const input = e.currentTarget.querySelector("input[type=text]") as HTMLInputElement
-        const q = input?.value?.trim()
-        if (q) {
-          sendGTMEvent({ event: "search_open", method: "submit" })
-          const params = new URLSearchParams({ q })
-          if (category !== "all") params.set("category", category)
-          router.push(`/search?${params.toString()}`)
-        }
-      }}
-    >
-      <div className="relative w-full flex items-center rounded-sm bg-muted p-0.5">
-        <Select value={category} onValueChange={setCategory}>
-          <SelectTrigger className="h-8 w-auto gap-1 border-0 border-r border-border/40 rounded-none bg-transparent text-xs font-medium text-muted-foreground shadow-none focus:ring-0 focus:ring-offset-0 shrink-0">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {SEARCH_CATEGORIES.map((c) => (
-              <SelectItem key={c.value} value={c.value}>{c.label}</SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <input
-          type="text"
-          placeholder="Search for products, guides, programs..."
-          className="flex-1 h-8 pl-3 pr-12 text-sm bg-transparent outline-none placeholder:text-muted-foreground/60"
-          onFocus={onFocus}
-        />
-        <button type="submit" className="absolute right-0.5 top-1/2 -translate-y-1/2 h-8 w-9 flex items-center justify-center rounded-sm bg-primary text-primary-foreground hover:bg-primary/90 transition-colors">
-          <Search className="h-4 w-4" />
-        </button>
-      </div>
-    </form>
+    <div className="hidden lg:flex flex-1 items-center px-6 gap-2">
+      <button
+        type="button"
+        onClick={onAskAI}
+        className="shrink-0 flex items-center gap-1.5 h-9 px-3 rounded-sm bg-primary text-primary-foreground hover:bg-primary/90 transition-colors text-xs font-medium"
+      >
+        <Sparkles className="h-3.5 w-3.5" />
+        Ask AI
+      </button>
+      <form
+        className="flex-1"
+        onSubmit={(e) => {
+          e.preventDefault()
+          const input = e.currentTarget.querySelector("input[type=text]") as HTMLInputElement
+          const q = input?.value?.trim()
+          if (q) {
+            sendGTMEvent({ event: "search_open", method: "submit" })
+            const params = new URLSearchParams({ q })
+            if (category !== "all") params.set("category", category)
+            router.push(`/search?${params.toString()}`)
+          }
+        }}
+      >
+        <div className="relative w-full flex items-center rounded-sm bg-muted p-0.5">
+          <Select value={category} onValueChange={setCategory}>
+            <SelectTrigger className="h-8 w-auto gap-1 border-0 border-r border-border/40 rounded-none bg-transparent text-xs font-medium text-muted-foreground shadow-none focus:ring-0 focus:ring-offset-0 shrink-0">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {SEARCH_CATEGORIES.map((c) => (
+                <SelectItem key={c.value} value={c.value}>{c.label}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <input
+            type="text"
+            placeholder="Search for products, guides, programs..."
+            className="flex-1 h-8 pl-3 pr-12 text-sm bg-transparent outline-none placeholder:text-muted-foreground/60"
+            onFocus={onFocus}
+          />
+          <button type="submit" className="absolute right-0.5 top-1/2 -translate-y-1/2 h-8 w-9 flex items-center justify-center rounded-sm bg-primary text-primary-foreground hover:bg-primary/90 transition-colors">
+            <Search className="h-4 w-4" />
+          </button>
+        </div>
+      </form>
+    </div>
   )
 }
 
-function MobileSearch({ router }: { router: ReturnType<typeof useRouter> }) {
+function MobileSearch({ router, onAskAI }: { router: ReturnType<typeof useRouter>; onAskAI: () => void }) {
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState("")
 
@@ -284,6 +295,13 @@ function MobileSearch({ router }: { router: ReturnType<typeof useRouter> }) {
 
   return (
     <>
+      <button
+        onClick={onAskAI}
+        className="lg:hidden p-2 rounded-lg hover:bg-muted transition-colors"
+        aria-label="Ask AI"
+      >
+        <Sparkles className="h-5 w-5" />
+      </button>
       <button
         onClick={() => {
           sendGTMEvent({ event: "search_open", method: "mobile_icon" })
@@ -331,6 +349,7 @@ export function SiteHeader() {
   const user = (session?.user as AuthenticatedUser) ?? undefined
   const router = useRouter()
   const [categoryOpen, setCategoryOpen] = useState(false)
+  const [aiSearchOpen, setAiSearchOpen] = useState(false)
 
   // Cmd+K navigates to search
   useEffect(() => {
@@ -346,6 +365,8 @@ export function SiteHeader() {
   }, [router])
 
   return (
+    <>
+    <AISearchOverlay open={aiSearchOpen} onClose={() => setAiSearchOpen(false)} />
     <header className="sticky top-0 z-50 w-full bg-background border-b">
       {/* Main nav */}
       <div className="container flex h-14 items-center gap-2 lg:gap-6">
@@ -358,7 +379,7 @@ export function SiteHeader() {
         <SelectCategory open={categoryOpen} setOpen={setCategoryOpen} />
 
         {/* Search bar — takes remaining space */}
-        <NavSearchBar router={router} onFocus={() => setCategoryOpen(false)} />
+        <NavSearchBar router={router} onFocus={() => setCategoryOpen(false)} onAskAI={() => setAiSearchOpen(true)} />
 
         {/* Right side actions */}
         <div className="hidden lg:flex items-center gap-2">
@@ -423,9 +444,10 @@ export function SiteHeader() {
 
         {/* Mobile nav */}
         <div className="flex-1 lg:hidden" />
-        <MobileSearch router={router} />
+        <MobileSearch router={router} onAskAI={() => setAiSearchOpen(true)} />
         <MobileNav user={user} />
       </div>
     </header>
+    </>
   )
 }

--- a/apps/client-fnp/components/layouts/site-header.tsx
+++ b/apps/client-fnp/components/layouts/site-header.tsx
@@ -230,14 +230,14 @@ function NavSearchBar({ router, onFocus, onAskAI }: { router: ReturnType<typeof 
 
   return (
     <div className="hidden lg:flex flex-1 items-center px-6 gap-2">
-      <button
+      {/* <button
         type="button"
         onClick={onAskAI}
         className="shrink-0 flex items-center gap-1.5 h-9 px-3 rounded-sm bg-primary text-primary-foreground hover:bg-primary/90 transition-colors text-xs font-medium"
       >
         <Sparkles className="h-3.5 w-3.5" />
         Ask AI
-      </button>
+      </button> */}
       <form
         className="flex-1"
         onSubmit={(e) => {
@@ -295,13 +295,13 @@ function MobileSearch({ router, onAskAI }: { router: ReturnType<typeof useRouter
 
   return (
     <>
-      <button
+      {/* <button
         onClick={onAskAI}
         className="lg:hidden p-2 rounded-lg hover:bg-muted transition-colors"
         aria-label="Ask AI"
       >
         <Sparkles className="h-5 w-5" />
-      </button>
+      </button> */}
       <button
         onClick={() => {
           sendGTMEvent({ event: "search_open", method: "mobile_icon" })
@@ -366,7 +366,7 @@ export function SiteHeader() {
 
   return (
     <>
-    <AISearchOverlay open={aiSearchOpen} onClose={() => setAiSearchOpen(false)} />
+    {/* <AISearchOverlay open={aiSearchOpen} onClose={() => setAiSearchOpen(false)} /> */}
     <header className="sticky top-0 z-50 w-full bg-background border-b">
       {/* Main nav */}
       <div className="container flex h-14 items-center gap-2 lg:gap-6">

--- a/apps/client-fnp/components/structures/ai-search.tsx
+++ b/apps/client-fnp/components/structures/ai-search.tsx
@@ -1,0 +1,343 @@
+'use client'
+
+import * as React from "react"
+import { useRouter } from "next/navigation"
+import { sendGTMEvent } from "@next/third-parties/google"
+import { Sparkles, Search, ArrowUp, Loader2, X } from "lucide-react"
+import { BaseURL } from "@/lib/schemas"
+
+interface AISearchProduct {
+  id: string
+  name: string
+  slug: string
+  _collection: string
+  brand_name?: string
+  category_name?: string
+  image_src?: string
+}
+
+interface AISearchResponse {
+  message: string
+  language: string
+  products: AISearchProduct[]
+  cached: boolean
+  session_id: string
+  fallback?: string
+  error?: string
+  error_type?: string
+}
+
+interface ChatMessage {
+  role: "user" | "assistant"
+  content: string
+  products?: AISearchProduct[]
+}
+
+const COLLECTION_URL_PREFIX: Record<string, string> = {
+  agro_chemicals: "/buy-agrochemicals/",
+  animal_health: "/buy-animal-health/",
+  plant_nutrition: "/buy-plant-nutrition/",
+  feed_products: "/buy-feeds/",
+  seed_products: "/buy-seed-products/",
+  equipment: "/buy-equipment/",
+  guides: "/buy-documents/",
+  farm_produce: "/farm-produce/",
+  buyers: "/buyers/",
+  prices: "/prices",
+  bookings: "/bookings/",
+  lots: "/lots/",
+}
+
+const COLLECTION_LABELS: Record<string, string> = {
+  agro_chemicals: "Agrochemical",
+  animal_health: "Animal Health",
+  plant_nutrition: "Plant Nutrition",
+  feed_products: "Animal Feed",
+  seed_products: "Seeds",
+  equipment: "Equipment",
+  guides: "Guide",
+  farm_produce: "Farm Produce",
+  buyers: "Buyer",
+  prices: "Prices",
+  bookings: "Pre-Order",
+  lots: "Lot",
+}
+
+function getProductUrl(product: AISearchProduct): string {
+  const prefix = COLLECTION_URL_PREFIX[product._collection]
+  if (!prefix) return "/"
+  if (product._collection === "prices") return "/prices"
+  return `${prefix}${product.slug}`
+}
+
+export function AISearchOverlay({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const router = useRouter()
+  const [query, setQuery] = React.useState("")
+  const [messages, setMessages] = React.useState<ChatMessage[]>([])
+  const [loading, setLoading] = React.useState(false)
+  const [sessionId] = React.useState(() => crypto.randomUUID())
+  const [error, setError] = React.useState<string | null>(null)
+  const inputRef = React.useRef<HTMLInputElement>(null)
+  const messagesEndRef = React.useRef<HTMLDivElement>(null)
+
+  // Auto-focus input when opened
+  React.useEffect(() => {
+    if (open) {
+      setTimeout(() => inputRef.current?.focus(), 100)
+      sendGTMEvent({ event: "ai_search_session_start" })
+    }
+  }, [open])
+
+  // Scroll to bottom on new messages
+  React.useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" })
+  }, [messages])
+
+  // Reset on close
+  React.useEffect(() => {
+    if (!open) {
+      setQuery("")
+      setMessages([])
+      setError(null)
+    }
+  }, [open])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const q = query.trim()
+    if (!q || loading) return
+
+    setError(null)
+
+    // Add user message
+    const userMsg: ChatMessage = { role: "user", content: q }
+    setMessages((prev) => [...prev, userMsg])
+    setQuery("")
+    setLoading(true)
+
+    const turnNumber = messages.filter((m) => m.role === "user").length + 1
+
+    sendGTMEvent({
+      event: turnNumber > 1 ? "ai_search_followup" : "ai_search_query",
+      query: q,
+      session_id: sessionId,
+      turn_number: turnNumber,
+    })
+
+    try {
+      const res = await fetch(`${BaseURL}/ai-search`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query: q, session_id: sessionId }),
+      })
+
+      const data: AISearchResponse = await res.json()
+
+      if (!res.ok || data.error) {
+        if (data.fallback === "search") {
+          setError("AI search is temporarily unavailable. Use normal search instead.")
+          sendGTMEvent({ event: "ai_search_off_topic", query: q })
+        } else {
+          setError(data.error || "Something went wrong")
+        }
+        setLoading(false)
+        return
+      }
+
+      const assistantMsg: ChatMessage = {
+        role: "assistant",
+        content: data.message,
+        products: data.products,
+      }
+      setMessages((prev) => [...prev, assistantMsg])
+
+      sendGTMEvent({
+        event: data.cached ? "ai_search_cache_hit" : "ai_search_claude_call",
+        query: q,
+        language: data.language,
+      })
+
+      if (data.products.length === 0) {
+        sendGTMEvent({ event: "ai_search_no_results", query: q, language: data.language })
+      }
+    } catch {
+      setError("AI search is temporarily unavailable. Use normal search instead.")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  function handleProductClick(product: AISearchProduct, position: number) {
+    sendGTMEvent({
+      event: "ai_search_result_click",
+      product_id: product.id,
+      collection: product._collection,
+      position: position + 1,
+    })
+    onClose()
+    router.push(getProductUrl(product))
+  }
+
+  function handleViewAll() {
+    const lastUserMsg = [...messages].reverse().find((m) => m.role === "user")
+    if (lastUserMsg) {
+      sendGTMEvent({ event: "ai_search_view_all", query: lastUserMsg.content })
+      onClose()
+      router.push(`/search?q=${encodeURIComponent(lastUserMsg.content)}`)
+    }
+  }
+
+  function handleFallbackSearch() {
+    const lastUserMsg = [...messages].reverse().find((m) => m.role === "user")
+    const searchQuery = lastUserMsg?.content || query
+    if (searchQuery) {
+      onClose()
+      router.push(`/search?q=${encodeURIComponent(searchQuery)}`)
+    }
+  }
+
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 z-[60] bg-background flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 h-14 border-b shrink-0">
+        <div className="flex items-center gap-2">
+          <Sparkles className="h-4 w-4 text-primary" />
+          <span className="text-sm font-medium">Ask AI</span>
+        </div>
+        <button
+          onClick={onClose}
+          className="p-2 rounded-lg hover:bg-muted transition-colors"
+          aria-label="Close AI search"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto px-4 py-6">
+        <div className="max-w-2xl mx-auto space-y-6">
+          {messages.length === 0 && !loading && (
+            <div className="text-center py-16 space-y-3">
+              <Sparkles className="h-8 w-8 mx-auto text-muted-foreground/40" />
+              <p className="text-sm text-muted-foreground">
+                Ask me anything about farming products in English, Shona, or Ndebele
+              </p>
+              <div className="flex flex-wrap justify-center gap-2 pt-2">
+                {["mushonga wemadomasi", "chicken feed", "hybrid maize seed", "fertilizer yechibage"].map((example) => (
+                  <button
+                    key={example}
+                    className="text-xs px-3 py-1.5 rounded-full border hover:bg-muted transition-colors text-muted-foreground"
+                    onClick={() => {
+                      setQuery(example)
+                      inputRef.current?.focus()
+                    }}
+                  >
+                    {example}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {messages.map((msg, i) => (
+            <div key={i} className={msg.role === "user" ? "flex justify-end" : ""}>
+              {msg.role === "user" ? (
+                <div className="bg-primary text-primary-foreground rounded-2xl rounded-br-sm px-4 py-2 max-w-[80%]">
+                  <p className="text-sm">{msg.content}</p>
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  <p className="text-sm">{msg.content}</p>
+                  {msg.products && msg.products.length > 0 && (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                      {msg.products.map((product, pi) => (
+                        <button
+                          key={product.id || pi}
+                          className="flex items-center gap-3 rounded-lg border p-3 text-left hover:bg-muted/50 transition-colors"
+                          onClick={() => handleProductClick(product, pi)}
+                        >
+                          {product.image_src ? (
+                            <img src={product.image_src} alt="" className="h-10 w-10 rounded object-cover shrink-0" />
+                          ) : (
+                            <div className="h-10 w-10 rounded bg-muted/30 shrink-0" />
+                          )}
+                          <div className="min-w-0 flex-1">
+                            <p className="text-sm font-medium truncate capitalize">{product.name}</p>
+                            <div className="flex items-center gap-1.5">
+                              {product.brand_name && (
+                                <span className="text-xs text-muted-foreground truncate">{product.brand_name}</span>
+                              )}
+                              <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground">
+                                {COLLECTION_LABELS[product._collection] || product._collection}
+                              </span>
+                            </div>
+                          </div>
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                  {msg.products && msg.products.length > 0 && (
+                    <button
+                      onClick={handleViewAll}
+                      className="text-xs text-primary hover:underline flex items-center gap-1"
+                    >
+                      <Search className="h-3 w-3" />
+                      View all results
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
+          ))}
+
+          {loading && (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span className="text-sm">Searching...</span>
+            </div>
+          )}
+
+          {error && (
+            <div className="rounded-lg border border-orange-200 bg-orange-50 p-3 space-y-2">
+              <p className="text-sm text-orange-800">{error}</p>
+              <button
+                onClick={handleFallbackSearch}
+                className="text-xs font-medium text-primary hover:underline flex items-center gap-1"
+              >
+                <Search className="h-3 w-3" />
+                Switch to normal search
+              </button>
+            </div>
+          )}
+
+          <div ref={messagesEndRef} />
+        </div>
+      </div>
+
+      {/* Input */}
+      <div className="border-t px-4 py-3 shrink-0">
+        <form onSubmit={handleSubmit} className="max-w-2xl mx-auto">
+          <div className="relative flex items-center rounded-xl border bg-background">
+            <input
+              ref={inputRef}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Ask about farming products..."
+              className="flex-1 h-11 pl-4 pr-12 text-sm bg-transparent outline-none placeholder:text-muted-foreground/60 rounded-xl"
+              disabled={loading}
+            />
+            <button
+              type="submit"
+              disabled={!query.trim() || loading}
+              className="absolute right-1.5 top-1/2 -translate-y-1/2 h-8 w-8 flex items-center justify-center rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-40"
+            >
+              <ArrowUp className="h-4 w-4" />
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/apps/client-fnp/components/structures/ai-search.tsx
+++ b/apps/client-fnp/components/structures/ai-search.tsx
@@ -11,6 +11,7 @@ interface AISearchProduct {
   name: string
   slug: string
   _collection: string
+  type?: string
   brand_name?: string
   category_name?: string
   image_src?: string
@@ -42,7 +43,7 @@ const COLLECTION_URL_PREFIX: Record<string, string> = {
   equipment: "/buy-equipment/",
   guides: "/buy-documents/",
   farm_produce: "/farm-produce/",
-  buyers: "/buyers/",
+  clients: "/buyers/",
   prices: "/prices",
   bookings: "/bookings/",
   lots: "/lots/",
@@ -57,7 +58,7 @@ const COLLECTION_LABELS: Record<string, string> = {
   equipment: "Equipment",
   guides: "Guide",
   farm_produce: "Farm Produce",
-  buyers: "Buyer",
+  clients: "Client",
   prices: "Prices",
   bookings: "Pre-Order",
   lots: "Lot",
@@ -67,6 +68,15 @@ function getProductUrl(product: AISearchProduct): string {
   const prefix = COLLECTION_URL_PREFIX[product._collection]
   if (!prefix) return "/"
   if (product._collection === "prices") return "/prices"
+  if (product._collection === "clients") {
+    const clientPrefix = product.type === "farmer" ? "/farmers/" : "/buyers/"
+    return `${clientPrefix}${product.slug}`
+  }
+  if (product._collection === "guides") {
+    if (product.type === "spray_program") return `/spray-programs/${product.slug}`
+    if (product.type === "feeding_program") return `/feeding-programs/${product.slug}`
+    return `/buy-documents/${product.slug}`
+  }
   return `${prefix}${product.slug}`
 }
 
@@ -270,7 +280,7 @@ export function AISearchOverlay({ open, onClose }: { open: boolean; onClose: () 
                                 <span className="text-xs text-muted-foreground truncate">{product.brand_name}</span>
                               )}
                               <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground">
-                                {COLLECTION_LABELS[product._collection] || product._collection}
+                                {product._collection === "clients" ? (product.type === "farmer" ? "Farmer" : "Buyer") : (COLLECTION_LABELS[product._collection] || product._collection)}
                               </span>
                             </div>
                           </div>

--- a/apps/client-fnp/components/structures/buyer-price-uploads.tsx
+++ b/apps/client-fnp/components/structures/buyer-price-uploads.tsx
@@ -281,7 +281,7 @@ export function BuyerPriceUploads({ clientName, latestPrices }: { clientName: st
 
   return (
     <div className="rounded-md border bg-card shadow-sm overflow-hidden">
-      <div className="grid grid-cols-1 lg:grid-cols-[280px_1fr]" style={{ height: 560 }}>
+      <div className="grid grid-cols-1 lg:grid-cols-[280px_1fr]" style={{ height: 350 }}>
 
         {/* Left sidebar — date list */}
         <div className="border-b lg:border-b-0 lg:border-r flex flex-col min-h-0 max-h-60 lg:max-h-none">

--- a/apps/client-fnp/components/structures/search-modal.tsx
+++ b/apps/client-fnp/components/structures/search-modal.tsx
@@ -27,7 +27,7 @@ const COLLECTION_META: Record<string, { label: string; icon: React.ElementType; 
   equipment: { label: "Equipment", icon: Tractor, urlPrefix: "/buy-equipment/" },
   guides: { label: "Guides & Programs", icon: FileText, urlPrefix: "" },
   farm_produce: { label: "Farm Produce", icon: ShoppingBag, urlPrefix: "/farm-produce/" },
-  buyers: { label: "Buyers", icon: Users, urlPrefix: "/buyers/" },
+  clients: { label: "Farmers & Buyers", icon: Users, urlPrefix: "" },
   prices: { label: "Market Prices", icon: DollarSign, urlPrefix: "/prices" },
   bookings: { label: "Bookings", icon: CalendarCheck, urlPrefix: "/bookings/" },
   lots: { label: "Lots & Auctions", icon: Gavel, urlPrefix: "/lots/" },
@@ -45,7 +45,10 @@ function getResultUrl(collection: string, doc: Record<string, any>): string {
   }
 
   if (collection === "prices") return "/prices"
-  if (collection === "buyers") return `/buyers/${doc.slug}`
+  if (collection === "clients") {
+    const prefix = doc.type === "farmer" ? "/farmers/" : "/buyers/"
+    return `${prefix}${doc.slug}`
+  }
 
   return `${meta.urlPrefix}${doc.slug}`
 }
@@ -84,8 +87,9 @@ function getDisplaySub(collection: string, doc: Record<string, any>): string {
     const location = [doc.city, doc.province].filter(Boolean).join(", ")
     return [doc.breed_name, qty, price, location].filter(Boolean).join(" · ")
   }
-  if (collection === "buyers") {
-    return [doc.city, doc.province].filter(Boolean).join(", ")
+  if (collection === "clients") {
+    const typeLabel = doc.type === "farmer" ? "Farmer" : "Buyer"
+    return [typeLabel, doc.city, doc.province].filter(Boolean).join(" · ")
   }
   if (collection === "farm_produce") {
     return doc.category_name || ""
@@ -198,7 +202,7 @@ export function SearchModal({ open, onOpenChange }: { open: boolean; onOpenChang
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder="Search products, guides, buyers, prices..."
+            placeholder="Search products, guides, farmers, buyers, prices..."
             className="flex h-12 w-full bg-transparent px-3 text-sm outline-none placeholder:text-muted-foreground"
             autoFocus
           />
@@ -213,7 +217,7 @@ export function SearchModal({ open, onOpenChange }: { open: boolean; onOpenChang
         <div className="max-h-[400px] overflow-y-auto p-2">
           {!query.trim() && (
             <div className="py-12 text-center text-sm text-muted-foreground">
-              Start typing to search across all products, guides, and buyers
+              Start typing to search across all products, guides, farmers, and buyers
             </div>
           )}
 

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "7.9.3",
+  "version": "7.10.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- Renamed Typesense buyers collection to clients in frontend (supports farmer + buyer types)
- Made entire search result card clickable — navigates to buy/detail page
- Guide button remains separate link
- Added GTM events for search result and guide clicks
- AI search button commented out until ready
- Fixed guide URL routing in AI search for spray/feeding programs
- Reduced buyer price uploads panel height

## Test plan
- [ ] Search for "Michael Bhila" — should appear as Farmer
- [ ] Click search result card — should navigate to product page
- [ ] Click Guide button — should navigate to guide page
- [ ] Verify AI search button is hidden