### PR TITLE
Fix: use singular detail URLs in search

### DIFF
--- a/apps/client-fnp/app/(landing)/search/SearchResults.tsx
+++ b/apps/client-fnp/app/(landing)/search/SearchResults.tsx
@@ -51,7 +51,7 @@ function getUrls(collection: string, doc: Record<string, any>): { guide?: string
   }
   if (collection === "prices") return { view: "/prices" }
   if (collection === "clients") {
-    const prefix = doc.type === "farmer" ? "/farmers" : "/buyers"
+    const prefix = doc.type === "farmer" ? "/farmer" : "/buyer"
     return { view: `${prefix}/${doc.slug}` }
   }
   if (collection === "bookings") return { view: `/bookings/${doc.slug}` }

--- a/apps/client-fnp/components/structures/ai-search.tsx
+++ b/apps/client-fnp/components/structures/ai-search.tsx
@@ -43,7 +43,7 @@ const COLLECTION_URL_PREFIX: Record<string, string> = {
   equipment: "/buy-equipment/",
   guides: "/buy-documents/",
   farm_produce: "/farm-produce/",
-  clients: "/buyers/",
+  clients: "/buyer/",
   prices: "/prices",
   bookings: "/bookings/",
   lots: "/lots/",
@@ -69,7 +69,7 @@ function getProductUrl(product: AISearchProduct): string {
   if (!prefix) return "/"
   if (product._collection === "prices") return "/prices"
   if (product._collection === "clients") {
-    const clientPrefix = product.type === "farmer" ? "/farmers/" : "/buyers/"
+    const clientPrefix = product.type === "farmer" ? "/farmer/" : "/buyer/"
     return `${clientPrefix}${product.slug}`
   }
   if (product._collection === "guides") {

--- a/apps/client-fnp/components/structures/search-modal.tsx
+++ b/apps/client-fnp/components/structures/search-modal.tsx
@@ -46,7 +46,7 @@ function getResultUrl(collection: string, doc: Record<string, any>): string {
 
   if (collection === "prices") return "/prices"
   if (collection === "clients") {
-    const prefix = doc.type === "farmer" ? "/farmers/" : "/buyers/"
+    const prefix = doc.type === "farmer" ? "/farmer/" : "/buyer/"
     return `${prefix}${doc.slug}`
   }
 

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "7.10.0",
+  "version": "7.10.1",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- Fixed search result URLs to use /farmer/ and /buyer/ (singular detail pages) instead of /farmers/ and /buyers/ (plural list pages)

## Test plan
- [ ] Search for a farmer — link goes to /farmer/slug
- [ ] Search for a buyer — link goes to /buyer/slug