### PR TITLE
Booking counter-offers, nav fixes, email updates

### DIFF
--- a/apps/admin-fnp/config/dashboard.ts
+++ b/apps/admin-fnp/config/dashboard.ts
@@ -111,12 +111,12 @@ export const dashboardConfig: DashboardConfig = {
           icon: "shoppingCart",
         },
         {
-          title: "Bookings",
+          title: "Booking Bids",
           href: "/dashboard/farmnport/orders/bookings",
           icon: "calender",
         },
         {
-          title: "Bookings",
+          title: "Pre-Orders",
           href: "/dashboard/farmnport/orders/booking-preorders",
           icon: "calender",
         },

--- a/apps/client-fnp/app/(landing)/account/(sections)/booking-preorders/BookingPreordersClient.tsx
+++ b/apps/client-fnp/app/(landing)/account/(sections)/booking-preorders/BookingPreordersClient.tsx
@@ -88,7 +88,7 @@ export default function MyPreOrdersPage() {
                     {statusLabel}, {event.title || event.name || "—"}
                   </p>
                   <Link
-                    href={`/account/booking-preorders/${event.id}`}
+                    href={`/account/booking-preorders/${event.slug}`}
                     className="shrink-0 text-sm font-medium px-4 py-2 rounded-lg border hover:bg-muted transition-colors"
                   >
                     Manage

--- a/apps/client-fnp/app/(landing)/account/(sections)/booking-preorders/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/account/(sections)/booking-preorders/[slug]/page.tsx
@@ -1,0 +1,366 @@
+"use client"
+
+import { useState, use } from "react"
+import { useSession } from "next-auth/react"
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
+import { Loader2, CalendarCheck, Users, Package, ChevronDown, ChevronUp } from "lucide-react"
+import Link from "next/link"
+import { toast } from "sonner"
+
+import { getPreOrder, clientPreOrderBookings, clientResetPreOrderCapacity, clientUpdatePreOrderCapacity } from "@/lib/query"
+import { centsToDollars } from "@/lib/utilities"
+
+const STATUS_STYLES: Record<string, string> = {
+  draft:                  "bg-muted text-muted-foreground",
+  open:                   "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+  closed:                 "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
+  pending_stock_approval: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400",
+  fulfilled:              "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
+  cancelled:              "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  draft:                  "Draft",
+  open:                   "Open",
+  closed:                 "Closed",
+  pending_stock_approval: "Stock Approval",
+  fulfilled:              "Fulfilled",
+  cancelled:              "Cancelled",
+}
+
+const BOOKING_STATUS_STYLES: Record<string, string> = {
+  pending:         "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400",
+  confirmed:       "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
+  pending_payment: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400",
+  paid:            "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+  ready:           "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400",
+  collected:       "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+  rejected:        "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+  expired:         "bg-muted text-muted-foreground",
+  cancelled:       "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+}
+
+const BOOKING_STATUS_LABELS: Record<string, string> = {
+  pending:         "Pending",
+  confirmed:       "Confirmed",
+  pending_payment: "Payment Processing",
+  paid:            "Paid",
+  ready:           "Ready",
+  collected:       "Collected",
+  rejected:        "Rejected",
+  expired:         "Expired",
+  cancelled:       "Cancelled",
+}
+
+function formatDate(d: string) {
+  return new Date(d).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" })
+}
+
+function formatDateTime(d: string) {
+  return new Date(d).toLocaleString("en-GB", { day: "numeric", month: "short", year: "numeric", hour: "2-digit", minute: "2-digit" })
+}
+
+function Field({ label, value }: { label: string; value?: string | number | null }) {
+  return (
+    <div>
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-sm font-medium mt-0.5">{value ?? "—"}</p>
+    </div>
+  )
+}
+
+export default function BookingPreOrderDetailPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = use(params)
+  const { data: session } = useSession()
+  const qc = useQueryClient()
+  const [showBookings, setShowBookings] = useState(true)
+  const [capacityOpen, setCapacityOpen] = useState(false)
+  const [newCapacity, setNewCapacity] = useState("")
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["booking-preorder", slug],
+    queryFn: () => getPreOrder(slug).then((r) => r.data),
+    enabled: !!session,
+  })
+
+  const event = (data as any)?.preorder
+  const eventId = event?.id
+
+  const { data: bookingsData, isLoading: bookingsLoading } = useQuery({
+    queryKey: ["booking-preorder-bookings", eventId],
+    queryFn: () => clientPreOrderBookings(eventId).then((r) => r.data),
+    enabled: !!session && !!eventId,
+  })
+
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ["booking-preorder", slug] })
+    qc.invalidateQueries({ queryKey: ["booking-preorder-bookings", eventId] })
+    qc.invalidateQueries({ queryKey: ["my-booking-events"] })
+  }
+
+  const resetMutation = useMutation({
+    mutationFn: () => clientResetPreOrderCapacity(eventId),
+    onSuccess: () => { toast.success("Capacity reset — booked count recalculated"); invalidate() },
+    onError: (err: any) => toast.error(err?.response?.data?.message || "Failed to reset"),
+  })
+
+  const updateCapacityMutation = useMutation({
+    mutationFn: (total: number) => clientUpdatePreOrderCapacity(eventId, total),
+    onSuccess: () => { toast.success("Capacity updated"); setCapacityOpen(false); setNewCapacity(""); invalidate() },
+    onError: (err: any) => toast.error(err?.response?.data?.message || "Failed to update"),
+  })
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-16">
+        <Loader2 className="w-8 h-8 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  if (!event) {
+    return <p className="text-muted-foreground text-sm">Booking event not found.</p>
+  }
+
+  const booked = event.total_booked ?? 0
+  const available = event.total_available ?? 0
+  const percentage = available > 0 ? Math.round((booked / available) * 100) : 0
+  const bookings: any[] = (bookingsData as any)?.bookings ?? []
+  const totalBookings = (bookingsData as any)?.total ?? 0
+  const statusLabel = STATUS_LABELS[event.status] ?? event.status ?? "Draft"
+
+  return (
+    <div>
+      <nav className="flex items-center gap-1.5 text-sm text-muted-foreground mb-4">
+        <Link href="/account" className="hover:text-foreground transition-colors">Account</Link>
+        <span>/</span>
+        <Link href="/account/booking-preorders" className="hover:text-foreground transition-colors">My Bookings</Link>
+        <span>/</span>
+        <span className="text-foreground font-medium">{event.short_id}</span>
+      </nav>
+
+      <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
+        <div className="flex items-center gap-3 flex-wrap">
+          <h1 className="text-lg font-bold">{event.name || event.produce_name}</h1>
+          <span className={`text-xs px-2.5 py-0.5 rounded-full font-medium ${STATUS_STYLES[event.status] ?? "bg-muted text-muted-foreground"}`}>
+            {statusLabel}
+          </span>
+          <span className="text-xs font-mono text-muted-foreground">{event.short_id}</span>
+        </div>
+        <p className="text-xs text-muted-foreground">{formatDateTime(event.created)}</p>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+
+        {/* Left: event details */}
+        <div className="lg:col-span-2 space-y-5">
+
+          {/* Capacity */}
+          <div className="border rounded-xl p-5">
+            <div className="flex items-center justify-between mb-4">
+              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Capacity</p>
+              <p className="text-sm font-semibold">{booked}/{available} {event.unit} ({percentage}%)</p>
+            </div>
+            <div className="w-full bg-muted rounded-full h-2.5">
+              <div className="bg-primary h-2.5 rounded-full transition-all" style={{ width: `${Math.min(percentage, 100)}%` }} />
+            </div>
+          </div>
+
+          {/* Details */}
+          <div className="border rounded-xl p-5">
+            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-4">Details</p>
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+              <Field label="Produce" value={event.produce_name} />
+              {event.breed_name && <Field label="Breed / Variety" value={event.breed_name} />}
+              <Field label="Unit Price" value={centsToDollars(event.unit_price)} />
+              {event.deposit_per_unit > 0 && <Field label="Deposit per Unit" value={centsToDollars(event.deposit_per_unit)} />}
+              <Field label="Min Quantity" value={event.min_quantity || "No minimum"} />
+              <Field label="Max Quantity" value={event.max_quantity || "No maximum"} />
+              {event.quantity_step > 1 && <Field label="Step" value={`Multiples of ${event.quantity_step}`} />}
+              <Field label="Opens" value={formatDate(event.open_date)} />
+              <Field label="Closes" value={formatDate(event.close_date)} />
+              <Field label="Market Side" value={event.market_side === "demand" ? "Buyer Request" : "Supply Offer"} />
+            </div>
+            {event.description && (
+              <div className="mt-4 pt-4 border-t">
+                <p className="text-xs text-muted-foreground">Description</p>
+                <p className="text-sm mt-0.5">{event.description}</p>
+              </div>
+            )}
+          </div>
+
+          {/* Delivery / Collection locations */}
+          {(event.delivery_locations?.length > 0 || event.collection_locations?.length > 0) && (
+            <div className="border rounded-xl p-5">
+              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-4">Locations</p>
+              {event.collection_locations?.length > 0 && (
+                <div className="mb-3">
+                  <p className="text-xs text-muted-foreground mb-1">Collection Points</p>
+                  {event.collection_locations.map((loc: any) => (
+                    <p key={loc.id} className="text-sm">{loc.name}{loc.address ? ` — ${loc.address}` : ""}</p>
+                  ))}
+                </div>
+              )}
+              {event.delivery_locations?.length > 0 && (
+                <div>
+                  <p className="text-xs text-muted-foreground mb-1">Delivery Points</p>
+                  {event.delivery_locations.map((loc: any) => (
+                    <p key={loc.id} className="text-sm">{loc.name}{loc.address ? ` — ${loc.address}` : ""}</p>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Bookings list */}
+          <div className="border rounded-xl p-5">
+            <button
+              onClick={() => setShowBookings(!showBookings)}
+              className="w-full flex items-center justify-between"
+            >
+              <div className="flex items-center gap-2">
+                <Users className="w-4 h-4 text-muted-foreground" />
+                <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Bookings ({totalBookings})</p>
+              </div>
+              {showBookings ? <ChevronUp className="w-4 h-4 text-muted-foreground" /> : <ChevronDown className="w-4 h-4 text-muted-foreground" />}
+            </button>
+
+            {showBookings && (
+              <div className="mt-4">
+                {bookingsLoading ? (
+                  <div className="flex justify-center py-6">
+                    <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+                  </div>
+                ) : bookings.length === 0 ? (
+                  <p className="text-sm text-muted-foreground text-center py-6">No bookings yet.</p>
+                ) : (
+                  <div className="space-y-3">
+                    {bookings.map((b: any) => (
+                      <Link
+                        key={b.id}
+                        href={`/account/incoming-bookings/${b.id}`}
+                        className="block border rounded-lg p-3 hover:bg-muted/50 transition-colors"
+                      >
+                        <div className="flex items-center justify-between gap-3">
+                          <div className="min-w-0">
+                            <p className="text-sm font-medium">{b.booking_ref}</p>
+                            <p className="text-xs text-muted-foreground mt-0.5">
+                              {b.buyer_name || "Anonymous"} — {b.pre_order?.quantity?.toLocaleString()} {b.pre_order?.unit || event.unit}
+                            </p>
+                          </div>
+                          <span className={`shrink-0 text-xs px-2 py-0.5 rounded-full font-medium ${BOOKING_STATUS_STYLES[b.status] ?? "bg-muted text-muted-foreground"}`}>
+                            {BOOKING_STATUS_LABELS[b.status] ?? b.status}
+                          </span>
+                        </div>
+                        <p className="text-xs text-muted-foreground mt-1">{formatDateTime(b.created)}</p>
+                      </Link>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Right: actions */}
+        <div className="space-y-5">
+
+          {/* Quick stats */}
+          <div className="border rounded-xl p-5 space-y-3">
+            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Summary</p>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="text-center p-3 bg-muted/30 rounded-lg">
+                <p className="text-lg font-bold">{totalBookings}</p>
+                <p className="text-xs text-muted-foreground">Bookings</p>
+              </div>
+              <div className="text-center p-3 bg-muted/30 rounded-lg">
+                <p className="text-lg font-bold">{booked}</p>
+                <p className="text-xs text-muted-foreground">{event.unit} Booked</p>
+              </div>
+              <div className="text-center p-3 bg-muted/30 rounded-lg">
+                <p className="text-lg font-bold">{available - booked}</p>
+                <p className="text-xs text-muted-foreground">{event.unit} Left</p>
+              </div>
+              <div className="text-center p-3 bg-muted/30 rounded-lg">
+                <p className="text-lg font-bold">{centsToDollars(booked * event.unit_price)}</p>
+                <p className="text-xs text-muted-foreground">Revenue</p>
+              </div>
+            </div>
+          </div>
+
+          {/* Management actions */}
+          {!["cancelled", "fulfilled"].includes(event.status) && (
+            <div className="border rounded-xl p-5 space-y-3">
+              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Manage</p>
+
+              <button
+                onClick={() => resetMutation.mutate()}
+                disabled={resetMutation.isPending}
+                className="w-full py-2 rounded-lg text-sm font-medium border hover:bg-muted transition-colors disabled:opacity-50"
+              >
+                {resetMutation.isPending ? <Loader2 className="w-4 h-4 animate-spin mx-auto" /> : "Recalculate Booked Count"}
+              </button>
+
+              {!capacityOpen ? (
+                <button
+                  onClick={() => { setCapacityOpen(true); setNewCapacity(String(available)) }}
+                  className="w-full py-2 rounded-lg text-sm font-medium border hover:bg-muted transition-colors"
+                >
+                  Update Capacity
+                </button>
+              ) : (
+                <div className="space-y-2">
+                  <input
+                    type="number"
+                    value={newCapacity}
+                    onChange={(e) => setNewCapacity(e.target.value)}
+                    min={booked}
+                    className="w-full text-sm border rounded-lg px-3 py-2 focus:outline-none focus:ring-1 focus:ring-ring bg-transparent"
+                    placeholder="New total available"
+                  />
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => { setCapacityOpen(false); setNewCapacity("") }}
+                      className="flex-1 py-2 text-sm rounded-lg border hover:bg-muted transition-colors"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={() => updateCapacityMutation.mutate(Number(newCapacity))}
+                      disabled={!newCapacity || Number(newCapacity) < booked || updateCapacityMutation.isPending}
+                      className="flex-1 py-2 text-sm rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
+                    >
+                      {updateCapacityMutation.isPending ? <Loader2 className="w-4 h-4 animate-spin mx-auto" /> : "Save"}
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Status history */}
+          {event.status_history?.length > 0 && (
+            <div className="border rounded-xl p-5">
+              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-4">History</p>
+              <div className="space-y-4">
+                {[...event.status_history].reverse().map((h: any, i: number) => (
+                  <div key={i} className="flex gap-3 text-sm">
+                    <div className="w-1.5 h-1.5 rounded-full bg-muted-foreground/40 mt-1.5 shrink-0" />
+                    <div>
+                      <p className="font-medium text-sm capitalize">{h.to}</p>
+                      {h.note && <p className="text-xs text-muted-foreground mt-0.5">{h.note}</p>}
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        {formatDateTime(h.timestamp)}
+                        {h.changed_by ? ` · ${h.changed_by}` : ""}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/client-fnp/app/(landing)/account/(sections)/bookings/[id]/page.tsx
+++ b/apps/client-fnp/app/(landing)/account/(sections)/bookings/[id]/page.tsx
@@ -7,7 +7,7 @@ import { Loader2, CalendarDays, Truck, Package, CheckCircle, XCircle, Clock, Ale
 import Link from "next/link"
 import { toast } from "sonner"
 
-import { getBooking, cancelBooking, initiatePreOrderPayment, pollPreOrderPayment } from "@/lib/query"
+import { getBooking, cancelBooking, initiatePreOrderPayment, pollPreOrderPayment, respondToBooking } from "@/lib/query"
 import { centsToDollars, plural } from "@/lib/utilities"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog"
 
@@ -23,6 +23,7 @@ const STATUS_STYLES: Record<string, string> = {
   rejected:         "bg-red-100 text-red-800",
   expired:          "bg-muted text-muted-foreground",
   cancelled:        "bg-red-100 text-red-800",
+  countered:        "bg-purple-100 text-purple-800",
 }
 
 const STATUS_LABELS: Record<string, string> = {
@@ -37,6 +38,7 @@ const STATUS_LABELS: Record<string, string> = {
   rejected:         "Rejected",
   expired:          "Expired",
   cancelled:        "Cancelled",
+  countered:        "Counter-Offer",
 }
 
 const STATUS_ICONS: Record<string, React.ReactNode> = {
@@ -86,6 +88,8 @@ export default function BookingDetailPage({ params }: { params: Promise<{ id: st
   const [cancelInput, setCancelInput] = useState("")
   const [paying, setPaying] = useState(false)
   const [checking, setChecking] = useState(false)
+  const [counterOpen, setCounterOpen] = useState(false)
+  const [counterPrice, setCounterPrice] = useState("")
 
   const { data, isLoading } = useQuery({
     queryKey: ["booking", id],
@@ -93,16 +97,33 @@ export default function BookingDetailPage({ params }: { params: Promise<{ id: st
     enabled: !!session,
   })
 
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ["booking", id] })
+    queryClient.invalidateQueries({ queryKey: ["my-bookings"] })
+  }
+
   const cancelMutation = useMutation({
     mutationFn: () => cancelBooking(id),
-    onSuccess: () => {
-      toast.success("Booking cancelled")
-      queryClient.invalidateQueries({ queryKey: ["booking", id] })
-      queryClient.invalidateQueries({ queryKey: ["my-bookings"] })
-    },
-    onError: () => {
-      toast.error("Failed to cancel booking. Please try again.")
-    },
+    onSuccess: () => { toast.success("Booking cancelled"); invalidate() },
+    onError: () => toast.error("Failed to cancel booking. Please try again."),
+  })
+
+  const counterMutation = useMutation({
+    mutationFn: (cents: number) => respondToBooking(id, { action: "counter", price_per_unit_cents: cents }),
+    onSuccess: () => { toast.success("Counter-offer sent"); setCounterOpen(false); setCounterPrice(""); invalidate() },
+    onError: (err: any) => toast.error(err?.response?.data?.message || "Failed to send counter-offer"),
+  })
+
+  const acceptMutation = useMutation({
+    mutationFn: () => respondToBooking(id, { action: "accept" }),
+    onSuccess: () => { toast.success("Offer accepted"); invalidate() },
+    onError: (err: any) => toast.error(err?.response?.data?.message || "Failed to accept"),
+  })
+
+  const rejectMutation = useMutation({
+    mutationFn: () => respondToBooking(id, { action: "reject", notes: "Buyer declined the counter-offer" }),
+    onSuccess: () => { toast.success("Offer rejected"); invalidate() },
+    onError: (err: any) => toast.error(err?.response?.data?.message || "Failed to reject"),
   })
 
 
@@ -241,6 +262,48 @@ export default function BookingDetailPage({ params }: { params: Promise<{ id: st
           </div>
         )}
 
+        {/* Counter-offer response — buyer's turn */}
+        {booking.status === "countered" && booking.countered_by === "seller" && booking.pre_order && (
+          <div className="border border-purple-200 bg-purple-50 rounded-xl p-5 space-y-3">
+            <p className="font-semibold text-purple-900">The seller made a counter-offer</p>
+            <p className="text-sm text-purple-700">
+              New price: <span className="font-bold">${(booking.pre_order.offer_price / 100).toFixed(2)}</span> per {booking.pre_order.unit || "unit"}
+              {" "}({booking.pre_order.quantity} {booking.pre_order.unit || "units"} = ${((booking.pre_order.offer_price / 100) * booking.pre_order.quantity).toFixed(2)})
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <button
+                onClick={() => acceptMutation.mutate()}
+                disabled={acceptMutation.isPending}
+                className="inline-flex items-center gap-2 rounded-md bg-primary text-primary-foreground text-sm font-semibold px-4 py-1.5 hover:bg-primary/90 transition-colors disabled:opacity-50"
+              >
+                {acceptMutation.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : null}
+                Accept Offer
+              </button>
+              <button
+                onClick={() => setCounterOpen(true)}
+                className="inline-flex items-center gap-2 rounded-md border border-purple-200 text-purple-700 text-sm font-semibold px-4 py-1.5 hover:bg-purple-50 transition-colors"
+              >
+                Counter-Offer
+              </button>
+              <button
+                onClick={() => rejectMutation.mutate()}
+                disabled={rejectMutation.isPending}
+                className="inline-flex items-center gap-2 rounded-md border border-red-200 text-red-600 text-sm font-semibold px-4 py-1.5 hover:bg-red-50 transition-colors disabled:opacity-50"
+              >
+                {rejectMutation.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : null}
+                Decline
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Waiting for seller response */}
+        {booking.status === "countered" && booking.countered_by === "buyer" && (
+          <div className="border border-purple-200 bg-purple-50 rounded-xl p-4">
+            <p className="text-sm text-purple-700">Waiting for the seller to respond to your counter-offer.</p>
+          </div>
+        )}
+
         {/* Expired notice */}
         {booking.status === "expired" && (
           <div className="border border-muted bg-muted/30 rounded-xl p-4">
@@ -370,6 +433,27 @@ export default function BookingDetailPage({ params }: { params: Promise<{ id: st
           )}
         </div>
 
+        {/* Negotiation history */}
+        {booking.counter_offers?.length > 0 && (
+          <div className="border border-purple-200 rounded-xl p-5">
+            <h2 className="text-sm font-semibold text-purple-700 mb-4">Negotiation</h2>
+            <div className="space-y-3">
+              {[...booking.counter_offers].reverse().map((co: any, i: number) => (
+                <div key={i} className="flex gap-3 text-sm">
+                  <div className="w-1.5 h-1.5 rounded-full bg-purple-400 mt-1.5 shrink-0" />
+                  <div>
+                    <p className="font-medium">${(co.price_per_unit_cents / 100).toFixed(2)} per {booking.pre_order?.unit || "unit"}</p>
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                      {co.by_name} ({co.by_role}) · {formatDateTime(co.created_at)}
+                    </p>
+                    {co.notes && <p className="text-xs text-muted-foreground mt-0.5">{co.notes}</p>}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
         {/* Status history */}
         {booking.status_history?.length > 0 && (
           <div className="border rounded-xl p-5">
@@ -438,6 +522,55 @@ export default function BookingDetailPage({ params }: { params: Promise<{ id: st
                 className="px-4 py-2 text-sm rounded-lg bg-red-600 text-white hover:bg-red-700 transition-colors disabled:opacity-50"
               >
                 {cancelMutation.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : "Cancel Booking"}
+              </button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+
+        {/* Counter-offer dialog */}
+        <Dialog open={counterOpen} onOpenChange={(o) => { setCounterOpen(o); if (!o) setCounterPrice("") }}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Make a Counter-Offer</DialogTitle>
+            </DialogHeader>
+            <p className="text-sm text-muted-foreground">
+              Propose a different price per {booking.pre_order?.unit || "unit"}. The seller can accept, reject, or counter back.
+            </p>
+            {booking.pre_order?.offer_price > 0 && (
+              <div className="bg-muted/50 rounded-lg px-3 py-2 text-sm">
+                Current offered price: <span className="font-semibold">${(booking.pre_order.offer_price / 100).toFixed(2)}</span> per {booking.pre_order.unit || "unit"}
+              </div>
+            )}
+            <div className="relative">
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">$</span>
+              <input
+                type="number"
+                step="0.01"
+                min="0.01"
+                value={counterPrice}
+                onChange={(e) => setCounterPrice(e.target.value)}
+                placeholder="0.00"
+                className="w-full text-sm border rounded-lg pl-7 pr-3 py-2 focus:outline-none focus:ring-1 focus:ring-ring bg-transparent"
+              />
+            </div>
+            {counterPrice && (
+              <p className="text-xs text-muted-foreground">
+                Total: ${(parseFloat(counterPrice) * (booking.pre_order?.quantity || 0)).toFixed(2)} for {booking.pre_order?.quantity} {booking.pre_order?.unit || "units"}
+              </p>
+            )}
+            <DialogFooter>
+              <button onClick={() => { setCounterOpen(false); setCounterPrice("") }} className="px-4 py-2 text-sm rounded-lg border hover:bg-muted transition-colors">
+                Go back
+              </button>
+              <button
+                onClick={() => {
+                  const cents = Math.round(parseFloat(counterPrice) * 100)
+                  if (cents > 0) counterMutation.mutate(cents)
+                }}
+                disabled={!counterPrice || parseFloat(counterPrice) <= 0 || counterMutation.isPending}
+                className="px-4 py-2 text-sm rounded-lg bg-purple-600 text-white hover:bg-purple-700 transition-colors disabled:opacity-50"
+              >
+                {counterMutation.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : "Send Counter-Offer"}
               </button>
             </DialogFooter>
           </DialogContent>

--- a/apps/client-fnp/app/(landing)/account/(sections)/bookings/page.tsx
+++ b/apps/client-fnp/app/(landing)/account/(sections)/bookings/page.tsx
@@ -20,6 +20,7 @@ const STATUS_LABELS: Record<string, string> = {
   rejected:         "Rejected",
   expired:          "Expired",
   cancelled:        "Cancelled",
+  countered:        "Counter-Offer",
 }
 
 function formatDate(d: string) {

--- a/apps/client-fnp/app/(landing)/account/(sections)/incoming-bookings/[id]/page.tsx
+++ b/apps/client-fnp/app/(landing)/account/(sections)/incoming-bookings/[id]/page.tsx
@@ -8,7 +8,7 @@ import { sendGTMEvent } from "@next/third-parties/google"
 import Link from "next/link"
 import { toast } from "sonner"
 
-import { getIncomingBooking, buyerUpdateBookingStatus, clientConfirmBooking, clientRejectBooking, clientCashPayment, clientMarkReady, clientMarkCollected } from "@/lib/query"
+import { getIncomingBooking, buyerUpdateBookingStatus, clientConfirmBooking, clientRejectBooking, clientCashPayment, clientMarkReady, clientMarkCollected, respondToBooking } from "@/lib/query"
 import { centsToDollars, platformFee, withPlatformFee, plural } from "@/lib/utilities"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog"
 
@@ -24,6 +24,7 @@ const STATUS_STYLES: Record<string, string> = {
   rejected:         "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
   expired:          "bg-muted text-muted-foreground",
   cancelled:        "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+  countered:        "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400",
 }
 
 const STATUS_LABELS: Record<string, string> = {
@@ -38,6 +39,7 @@ const STATUS_LABELS: Record<string, string> = {
   rejected:         "Rejected",
   expired:          "Expired",
   cancelled:        "Cancelled",
+  countered:        "Counter-Offer",
 }
 
 const DELIVERY_STEPS = [
@@ -130,8 +132,8 @@ export default function IncomingBookingDetailPage({ params }: { params: Promise<
   const [cancelReason, setCancelReason] = useState("")
   const [confirmOpen, setConfirmOpen] = useState(false)
   const [confirmInput, setConfirmInput] = useState("")
-  const [rejectOpen, setRejectOpen] = useState(false)
-  const [rejectReason, setRejectReason] = useState("")
+  const [counterOpen, setCounterOpen] = useState(false)
+  const [counterPrice, setCounterPrice] = useState("")
 
   const { data, isLoading } = useQuery({
     queryKey: ["incoming-booking", id],
@@ -165,10 +167,28 @@ export default function IncomingBookingDetailPage({ params }: { params: Promise<
     onError: (err: any) => toast.error(err?.response?.data?.message || "Failed to confirm"),
   })
 
+  const cancelMutation = useMutation({
+    mutationFn: (reason: string) => clientRejectBooking(id, reason),
+    onSuccess: () => { toast.success("Booking cancelled"); setCancelOpen(false); setCancelReason(""); invalidate() },
+    onError: (err: any) => toast.error(err?.response?.data?.message || "Failed to cancel"),
+  })
+
+  const counterMutation = useMutation({
+    mutationFn: (cents: number) => respondToBooking(id, { action: "counter", price_per_unit_cents: cents }),
+    onSuccess: () => { toast.success("Counter-offer sent"); setCounterOpen(false); setCounterPrice(""); invalidate() },
+    onError: (err: any) => toast.error(err?.response?.data?.message || "Failed to send counter-offer"),
+  })
+
+  const acceptMutation = useMutation({
+    mutationFn: () => respondToBooking(id, { action: "accept" }),
+    onSuccess: () => { toast.success("Booking accepted — buyer notified to pay"); invalidate() },
+    onError: (err: any) => toast.error(err?.response?.data?.message || "Failed to accept"),
+  })
+
   const rejectMutation = useMutation({
-    mutationFn: () => clientRejectBooking(id, rejectReason),
-    onSuccess: () => { toast.success("Booking rejected"); setRejectOpen(false); setRejectReason(""); invalidate() },
-    onError: () => toast.error("Failed to reject"),
+    mutationFn: (reason: string) => respondToBooking(id, { action: "reject", notes: reason }),
+    onSuccess: () => { toast.success("Booking rejected"); setCancelOpen(false); setCancelReason(""); invalidate() },
+    onError: (err: any) => toast.error(err?.response?.data?.message || "Failed to reject"),
   })
 
   const cashPaymentMutation = useMutation({
@@ -203,7 +223,7 @@ export default function IncomingBookingDetailPage({ params }: { params: Promise<
   }
 
   const actions = BUYER_TRANSITIONS[booking.status] ?? []
-  const canCancel = !["completed", "cancelled", "expired", "rejected"].includes(booking.status)
+  const canCancel = !["completed", "collected", "cancelled", "expired", "rejected"].includes(booking.status)
 
   return (
     <div>
@@ -360,21 +380,32 @@ export default function IncomingBookingDetailPage({ params }: { params: Promise<
             <div className="border rounded-xl p-5 space-y-3">
               <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Actions</p>
 
-              {booking.status === "pending" && (
+              {(booking.status === "pending" || (booking.status === "countered" && booking.countered_by === "buyer")) && (
                 <>
                   <button
-                    onClick={() => setConfirmOpen(true)}
-                    className="w-full py-2 rounded-lg text-sm font-medium transition-colors bg-primary text-primary-foreground hover:bg-primary/90"
+                    onClick={() => acceptMutation.mutate()}
+                    disabled={acceptMutation.isPending}
+                    className="w-full py-2 rounded-lg text-sm font-medium transition-colors disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90"
                   >
-                    {confirmMutation.isPending ? <Loader2 className="w-4 h-4 animate-spin mx-auto" /> : "Confirm Booking"}
+                    {acceptMutation.isPending ? <Loader2 className="w-4 h-4 animate-spin mx-auto" /> : `Accept${booking.pre_order?.offer_price ? ` at ${(booking.pre_order.offer_price / 100).toFixed(2)}/${booking.pre_order.unit || "unit"}` : ""}`}
                   </button>
                   <button
-                    onClick={() => setRejectOpen(true)}
+                    onClick={() => setCounterOpen(true)}
+                    className="w-full py-2 rounded-lg text-sm font-medium border border-purple-200 text-purple-700 hover:bg-purple-50 transition-colors"
+                  >
+                    Counter-Offer
+                  </button>
+                  <button
+                    onClick={() => setCancelOpen(true)}
                     className="w-full py-2 rounded-lg text-sm font-medium border border-red-200 text-red-600 hover:bg-red-50 transition-colors"
                   >
                     Reject Booking
                   </button>
                 </>
+              )}
+
+              {booking.status === "countered" && booking.countered_by === "seller" && (
+                <p className="text-sm text-muted-foreground text-center">Waiting for the buyer to respond to your counter-offer.</p>
               )}
 
               {booking.status === "paid" && (
@@ -438,6 +469,27 @@ export default function IncomingBookingDetailPage({ params }: { params: Promise<
             </div>
           )}
 
+          {/* Negotiation history */}
+          {booking.counter_offers?.length > 0 && (
+            <div className="border border-purple-200 rounded-xl p-5">
+              <p className="text-xs font-medium text-purple-700 uppercase tracking-wide mb-4">Negotiation</p>
+              <div className="space-y-3">
+                {[...booking.counter_offers].reverse().map((co: any, i: number) => (
+                  <div key={i} className="flex gap-3 text-sm">
+                    <div className="w-1.5 h-1.5 rounded-full bg-purple-400 mt-1.5 shrink-0" />
+                    <div>
+                      <p className="font-medium">${(co.price_per_unit_cents / 100).toFixed(2)} per {booking.pre_order?.unit || "unit"}</p>
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        {co.by_name} ({co.by_role}) · {formatDateTime(co.created_at)}
+                      </p>
+                      {co.notes && <p className="text-xs text-muted-foreground mt-0.5">{co.notes}</p>}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
           {/* Status history */}
           {booking.status_history?.length > 0 && (
             <div className="border rounded-xl p-5">
@@ -461,69 +513,13 @@ export default function IncomingBookingDetailPage({ params }: { params: Promise<
             </div>
           )}
 
-          {canCancel && !cancelOpen && (
+          {canCancel && (
             <button
               onClick={() => setCancelOpen(true)}
               className="w-full py-2 rounded-lg text-sm font-medium border border-red-200 text-red-600 hover:bg-red-50 dark:hover:bg-red-950/20 transition-colors"
             >
               Cancel Booking
             </button>
-          )}
-
-          {rejectOpen && (
-            <div className="border border-red-200 rounded-xl p-4 space-y-3">
-              <p className="text-sm font-medium text-red-600">Reject Booking</p>
-              <textarea
-                value={rejectReason}
-                onChange={(e) => setRejectReason(e.target.value)}
-                placeholder="e.g. Insufficient stock, quantity too high..."
-                rows={2}
-                className="w-full text-sm border rounded-lg px-3 py-2 resize-none focus:outline-none focus:ring-1 focus:ring-ring bg-transparent"
-              />
-              <div className="flex gap-2">
-                <button
-                  onClick={() => { setRejectOpen(false); setRejectReason("") }}
-                  className="flex-1 py-2 text-sm rounded-lg border hover:bg-muted transition-colors"
-                >
-                  Go back
-                </button>
-                <button
-                  onClick={() => rejectMutation.mutate()}
-                  disabled={!rejectReason.trim() || rejectMutation.isPending}
-                  className="flex-1 py-2 text-sm rounded-lg bg-red-600 text-white hover:bg-red-700 transition-colors disabled:opacity-50"
-                >
-                  {rejectMutation.isPending ? <Loader2 className="w-4 h-4 animate-spin mx-auto" /> : "Reject"}
-                </button>
-              </div>
-            </div>
-          )}
-
-          {cancelOpen && (
-            <div className="border border-red-200 rounded-xl p-4 space-y-3">
-              <p className="text-sm font-medium text-red-600">Confirm Cancellation</p>
-              <textarea
-                value={cancelReason}
-                onChange={(e) => setCancelReason(e.target.value)}
-                placeholder="Reason for cancellation..."
-                rows={2}
-                className="w-full text-sm border rounded-lg px-3 py-2 resize-none focus:outline-none focus:ring-1 focus:ring-ring bg-transparent"
-              />
-              <div className="flex gap-2">
-                <button
-                  onClick={() => { setCancelOpen(false); setCancelReason("") }}
-                  className="flex-1 py-2 text-sm rounded-lg border hover:bg-muted transition-colors"
-                >
-                  Go back
-                </button>
-                <button
-                  onClick={() => mutation.mutate("cancelled")}
-                  disabled={!cancelReason.trim() || mutation.isPending}
-                  className="flex-1 py-2 text-sm rounded-lg bg-red-600 text-white hover:bg-red-700 transition-colors disabled:opacity-50"
-                >
-                  {mutation.isPending ? <Loader2 className="w-4 h-4 animate-spin mx-auto" /> : "Cancel Booking"}
-                </button>
-              </div>
-            </div>
           )}
         </div>
       </div>
@@ -557,6 +553,97 @@ export default function IncomingBookingDetailPage({ params }: { params: Promise<
               className="px-4 py-2 text-sm rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
             >
               {confirmMutation.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : "Confirm"}
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Cancel dialog */}
+      <Dialog open={cancelOpen} onOpenChange={(o) => { setCancelOpen(o); if (!o) setCancelReason("") }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{booking.status === "pending" ? "Reject Booking" : "Cancel Booking"}</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            {booking.status === "pending"
+              ? "This will reject the booking and notify the buyer."
+              : "This will cancel the booking and release the reserved quantity. The buyer will be notified."}
+          </p>
+          <textarea
+            value={cancelReason}
+            onChange={(e) => setCancelReason(e.target.value)}
+            placeholder="Provide a reason (minimum 10 characters)..."
+            rows={3}
+            className="w-full text-sm border rounded-lg px-3 py-2 resize-none focus:outline-none focus:ring-1 focus:ring-ring bg-transparent"
+          />
+          <p className="text-xs text-muted-foreground">{cancelReason.trim().length}/10 characters minimum</p>
+          <DialogFooter>
+            <button onClick={() => { setCancelOpen(false); setCancelReason("") }} className="px-4 py-2 text-sm rounded-lg border hover:bg-muted transition-colors">
+              Go back
+            </button>
+            <button
+              onClick={() => {
+                if (["pending", "countered"].includes(booking.status)) {
+                  rejectMutation.mutate(cancelReason, { onSuccess: () => { setCancelOpen(false); setCancelReason("") } })
+                } else {
+                  cancelMutation.mutate(cancelReason, { onSuccess: () => { setCancelOpen(false); setCancelReason("") } })
+                }
+              }}
+              disabled={cancelReason.trim().length < 10 || rejectMutation.isPending || cancelMutation.isPending}
+              className="px-4 py-2 text-sm rounded-lg bg-red-600 text-white hover:bg-red-700 transition-colors disabled:opacity-50"
+            >
+              {(rejectMutation.isPending || cancelMutation.isPending)
+                ? <Loader2 className="w-4 h-4 animate-spin" />
+                : booking.status === "pending" ? "Reject" : "Cancel Booking"}
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Counter-offer dialog */}
+      <Dialog open={counterOpen} onOpenChange={(o) => { setCounterOpen(o); if (!o) setCounterPrice("") }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Make a Counter-Offer</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            Propose a different price per {booking.pre_order?.unit || "unit"}. The buyer can accept, reject, or counter back.
+          </p>
+          {booking.pre_order?.offer_price > 0 && (
+            <div className="bg-muted/50 rounded-lg px-3 py-2 text-sm">
+              Current offered price: <span className="font-semibold">${(booking.pre_order.offer_price / 100).toFixed(2)}</span> per {booking.pre_order.unit || "unit"}
+            </div>
+          )}
+          <div className="relative">
+            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">$</span>
+            <input
+              type="number"
+              step="0.01"
+              min="0.01"
+              value={counterPrice}
+              onChange={(e) => setCounterPrice(e.target.value)}
+              placeholder="0.00"
+              className="w-full text-sm border rounded-lg pl-7 pr-3 py-2 focus:outline-none focus:ring-1 focus:ring-ring bg-transparent"
+            />
+          </div>
+          {counterPrice && (
+            <p className="text-xs text-muted-foreground">
+              Total: ${(parseFloat(counterPrice) * (booking.pre_order?.quantity || 0)).toFixed(2)} for {booking.pre_order?.quantity} {booking.pre_order?.unit || "units"}
+            </p>
+          )}
+          <DialogFooter>
+            <button onClick={() => { setCounterOpen(false); setCounterPrice("") }} className="px-4 py-2 text-sm rounded-lg border hover:bg-muted transition-colors">
+              Go back
+            </button>
+            <button
+              onClick={() => {
+                const cents = Math.round(parseFloat(counterPrice) * 100)
+                if (cents > 0) counterMutation.mutate(cents)
+              }}
+              disabled={!counterPrice || parseFloat(counterPrice) <= 0 || counterMutation.isPending}
+              className="px-4 py-2 text-sm rounded-lg bg-purple-600 text-white hover:bg-purple-700 transition-colors disabled:opacity-50"
+            >
+              {counterMutation.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : "Send Counter-Offer"}
             </button>
           </DialogFooter>
         </DialogContent>

--- a/apps/client-fnp/app/(landing)/account/(sections)/incoming-bookings/page.tsx
+++ b/apps/client-fnp/app/(landing)/account/(sections)/incoming-bookings/page.tsx
@@ -19,6 +19,7 @@ const STATUS_LABELS: Record<string, string> = {
   rejected:         "Rejected",
   expired:          "Expired",
   cancelled:        "Cancelled",
+  countered:        "Counter-Offer",
 }
 
 function formatDate(d: string) {

--- a/apps/client-fnp/app/(landing)/bookings/[slug]/PreOrderDetailClient.tsx
+++ b/apps/client-fnp/app/(landing)/bookings/[slug]/PreOrderDetailClient.tsx
@@ -340,15 +340,15 @@ export default function PreOrderDetailPage({ preorder, depositEnabled = false }:
                 {event.market_side === "demand" ? (
                   <>
                     <li>Submit your supply offer with the quantity you can provide</li>
-                    <li>The buyer reviews your offer and confirms</li>
-                    <li>Deliver on the agreed date or prepare for collection</li>
+                    <li>The buyer reviews and confirms your offer</li>
+                    <li>Deliver on the agreed date or prepare for the buyer to collect</li>
                   </>
                 ) : (
                   <>
-                    <li>Submit your booking request</li>
-                    <li>We confirm your delivery or collection date and notify you</li>
+                    <li>Submit your booking request with your desired quantity</li>
+                    <li>The farmer confirms your order and notifies you of the collection or delivery date</li>
                     <li>Pay to secure your allocation{event.payment_deadline_hours ? ` (within ${event.payment_deadline_hours} hours)` : ""}</li>
-                    <li>Collect your order when ready — balance due on collection</li>
+                    <li>Collect your order on the agreed date — balance due on collection</li>
                   </>
                 )}
               </ol>

--- a/apps/client-fnp/app/api/emails/send/route.ts
+++ b/apps/client-fnp/app/api/emails/send/route.ts
@@ -192,6 +192,11 @@ export async function POST(req: NextRequest) {
       html = await render(PreorderRejectedEmail(props as Parameters<typeof PreorderRejectedEmail>[0]))
       break
 
+    case "preorder-cancelled":
+      subject = `Booking Cancelled — ${(props as { bookingRef?: string }).bookingRef ?? ""}`
+      html = await render(PreorderRejectedEmail(props as Parameters<typeof PreorderRejectedEmail>[0]))
+      break
+
     case "preorder-event-rejected":
       subject = `Booking Listing Not Approved — ${(props as { eventTitle?: string }).eventTitle ?? ""}`
       html = await render(PreorderEventRejectedEmail(props as Parameters<typeof PreorderEventRejectedEmail>[0]))

--- a/apps/client-fnp/app/api/emails/send/route.ts
+++ b/apps/client-fnp/app/api/emails/send/route.ts
@@ -36,8 +36,8 @@ import {
   PhoneUpdateCodeEmail,
 } from "@/emails"
 
-const FROM_FARMNPORT = "farmnport <noreply@farmnport.com>"
-const FROM_MENUS = "menus <noreply@farmnport.com>"
+const FROM_FARMNPORT = "farmnport <support@notifications.farmnport.com>"
+const FROM_MENUS = "menus <support@notifications.farmnport.com>"
 
 export async function POST(req: NextRequest) {
   const resend = new Resend(process.env.RESEND_API_KEY)

--- a/apps/client-fnp/lib/query.ts
+++ b/apps/client-fnp/lib/query.ts
@@ -1186,6 +1186,10 @@ export function buyerUpdateBookingStatus(id: string, status: string, note?: stri
   return api.put(`${BaseURL}/booking/${id}/buyer-status`, { status, note })
 }
 
+export function respondToBooking(id: string, data: { action: "accept" | "reject" | "counter"; price_per_unit_cents?: number; notes?: string }) {
+  return api.patch(`${BaseURL}/booking/${id}/respond`, data)
+}
+
 export function getIncomingBooking(id: string) {
   return api.get(`${BaseURL}/booking/incoming/${id}`)
 }

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "7.10.1",
+  "version": "7.11.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- Added booking counter-offer UI and preorder detail page improvements
- Renamed duplicate Bookings nav items to Booking Bids and Pre-Orders
- Improved pre-order how-it-works wording for supply and demand sides
- Added preorder-cancelled email route
- Switched email sender to support@notifications.farmnport.com

## Test plan
- [ ] Admin nav shows Booking Bids and Pre-Orders separately
- [ ] Pre-order how-it-works shows correct wording for supply vs demand
- [ ] Counter-offer flow works end to end