### PR TITLE
Use booking_ref in all booking URLs for consistency

### DIFF
--- a/apps/client-fnp/app/(landing)/account/(sections)/booking-preorders/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/account/(sections)/booking-preorders/[slug]/page.tsx
@@ -238,7 +238,7 @@ export default function BookingPreOrderDetailPage({ params }: { params: Promise<
                     {bookings.map((b: any) => (
                       <Link
                         key={b.id}
-                        href={`/account/incoming-bookings/${b.id}`}
+                        href={`/account/incoming-bookings/${b.booking_ref}`}
                         className="block border rounded-lg p-3 hover:bg-muted/50 transition-colors"
                       >
                         <div className="flex items-center justify-between gap-3">

--- a/apps/client-fnp/app/(landing)/account/(sections)/bookings/[id]/page.tsx
+++ b/apps/client-fnp/app/(landing)/account/(sections)/bookings/[id]/page.tsx
@@ -86,6 +86,7 @@ export default function BookingDetailPage({ params }: { params: Promise<{ id: st
   const queryClient = useQueryClient()
   const [cancelOpen, setCancelOpen] = useState(false)
   const [cancelInput, setCancelInput] = useState("")
+  const [cancelReason, setCancelReason] = useState("")
   const [paying, setPaying] = useState(false)
   const [checking, setChecking] = useState(false)
   const [counterOpen, setCounterOpen] = useState(false)
@@ -103,9 +104,9 @@ export default function BookingDetailPage({ params }: { params: Promise<{ id: st
   }
 
   const cancelMutation = useMutation({
-    mutationFn: () => cancelBooking(id),
+    mutationFn: (reason: string) => cancelBooking(id, reason),
     onSuccess: () => { toast.success("Booking cancelled"); invalidate() },
-    onError: () => toast.error("Failed to cancel booking. Please try again."),
+    onError: (err: any) => toast.error(err?.response?.data?.message || "Failed to cancel booking."),
   })
 
   const counterMutation = useMutation({
@@ -494,12 +495,21 @@ export default function BookingDetailPage({ params }: { params: Promise<{ id: st
         </Link>
 
         {/* Cancel dialog */}
-        <Dialog open={cancelOpen} onOpenChange={(o) => { setCancelOpen(o); if (!o) setCancelInput("") }}>
+        <Dialog open={cancelOpen} onOpenChange={(o) => { setCancelOpen(o); if (!o) { setCancelInput(""); setCancelReason("") } }}>
           <DialogContent>
             <DialogHeader>
               <DialogTitle>Cancel Booking</DialogTitle>
             </DialogHeader>
-            <p className="text-sm text-muted-foreground">This action cannot be undone. Paste the booking reference to confirm cancellation.</p>
+            <p className="text-sm text-muted-foreground">This action cannot be undone. The seller will be notified with your reason.</p>
+            <textarea
+              value={cancelReason}
+              onChange={(e) => setCancelReason(e.target.value)}
+              placeholder="Provide a reason (minimum 10 characters)..."
+              rows={3}
+              className="w-full text-sm border rounded-lg px-3 py-2 resize-none focus:outline-none focus:ring-1 focus:ring-ring bg-transparent"
+            />
+            <p className="text-xs text-muted-foreground">{cancelReason.trim().length}/10 characters minimum</p>
+            <p className="text-xs text-muted-foreground mt-2">Paste the booking reference to confirm.</p>
             <div className="flex items-center justify-between bg-muted/50 rounded-lg px-3 py-2">
               <span className="text-sm font-mono font-semibold">{booking.booking_ref}</span>
               <button type="button" onClick={() => { navigator.clipboard.writeText(booking.booking_ref) }} className="text-xs text-primary hover:underline">Copy</button>
@@ -511,14 +521,14 @@ export default function BookingDetailPage({ params }: { params: Promise<{ id: st
               className="w-full text-sm border rounded-lg px-3 py-2 font-mono focus:outline-none focus:ring-1 focus:ring-ring bg-transparent"
             />
             <DialogFooter>
-              <button onClick={() => { setCancelOpen(false); setCancelInput("") }} className="px-4 py-2 text-sm rounded-lg border hover:bg-muted transition-colors">
+              <button onClick={() => { setCancelOpen(false); setCancelInput(""); setCancelReason("") }} className="px-4 py-2 text-sm rounded-lg border hover:bg-muted transition-colors">
                 Go back
               </button>
               <button
                 onClick={() => {
-                  cancelMutation.mutate(undefined, { onSuccess: () => { setCancelOpen(false); setCancelInput("") } })
+                  cancelMutation.mutate(cancelReason, { onSuccess: () => { setCancelOpen(false); setCancelInput(""); setCancelReason("") } })
                 }}
-                disabled={cancelInput !== booking.booking_ref || cancelMutation.isPending}
+                disabled={cancelInput !== booking.booking_ref || cancelReason.trim().length < 10 || cancelMutation.isPending}
                 className="px-4 py-2 text-sm rounded-lg bg-red-600 text-white hover:bg-red-700 transition-colors disabled:opacity-50"
               >
                 {cancelMutation.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : "Cancel Booking"}

--- a/apps/client-fnp/app/(landing)/account/(sections)/bookings/[ref]/page.tsx
+++ b/apps/client-fnp/app/(landing)/account/(sections)/bookings/[ref]/page.tsx
@@ -80,8 +80,8 @@ function PaymentDeadlineCountdown({ deadline }: { deadline: string }) {
   )
 }
 
-export default function BookingDetailPage({ params }: { params: Promise<{ id: string }> }) {
-  const { id } = use(params)
+export default function BookingDetailPage({ params }: { params: Promise<{ ref: string }> }) {
+  const { ref: id } = use(params)
   const { data: session, status } = useSession()
   const queryClient = useQueryClient()
   const [cancelOpen, setCancelOpen] = useState(false)

--- a/apps/client-fnp/app/(landing)/account/(sections)/bookings/page.tsx
+++ b/apps/client-fnp/app/(landing)/account/(sections)/bookings/page.tsx
@@ -120,7 +120,7 @@ export default function BookingsPage() {
                     {STATUS_LABELS[booking.status] ?? booking.status}, {formatDate(booking.booking_date)}
                   </p>
                   <Link
-                    href={`/account/bookings/${booking.id}`}
+                    href={`/account/bookings/${booking.booking_ref}`}
                     className="shrink-0 text-sm font-medium px-4 py-2 rounded-lg border hover:bg-muted transition-colors"
                   >
                     Booking Details

--- a/apps/client-fnp/app/(landing)/account/(sections)/incoming-bookings/[ref]/page.tsx
+++ b/apps/client-fnp/app/(landing)/account/(sections)/incoming-bookings/[ref]/page.tsx
@@ -123,8 +123,8 @@ function StatusSteps({ status, type }: { status: string; type: string }) {
   )
 }
 
-export default function IncomingBookingDetailPage({ params }: { params: Promise<{ id: string }> }) {
-  const { id } = use(params)
+export default function IncomingBookingDetailPage({ params }: { params: Promise<{ ref: string }> }) {
+  const { ref: id } = use(params)
   const { data: session } = useSession()
   const qc = useQueryClient()
   const [note, setNote] = useState("")

--- a/apps/client-fnp/app/(landing)/account/(sections)/incoming-bookings/page.tsx
+++ b/apps/client-fnp/app/(landing)/account/(sections)/incoming-bookings/page.tsx
@@ -70,7 +70,7 @@ export default function IncomingBookingsPage() {
                   </p>
                 </div>
                 <Link
-                  href={`/account/incoming-bookings/${booking.id}`}
+                  href={`/account/incoming-bookings/${booking.booking_ref}`}
                   className="shrink-0 text-sm font-medium px-4 py-2 rounded-lg border hover:bg-muted transition-colors"
                 >
                   Review

--- a/apps/client-fnp/emails/templates/bookings/preorder-rejected.tsx
+++ b/apps/client-fnp/emails/templates/bookings/preorder-rejected.tsx
@@ -1,19 +1,42 @@
 import { Body, Button, Container, Head, Hr, Html, Link, Preview, Section, Text } from "@react-email/components"
 
-interface Props { name?: string; bookingRef?: string; productName?: string; quantity?: number; reason?: string; bookingUrl?: string }
+interface Props { name?: string; bookingRef?: string; productName?: string; quantity?: number; unit?: string; reason?: string; bookingUrl?: string; marketSide?: string; cancelledBy?: string; action?: string }
 
 export default function PreorderRejectedEmail({
   name = "Okandas",
   bookingRef = "FNP-BK-PO-0001",
   productName = "Fivet Cobb 500 Day-Old Chicks",
   quantity = 100,
+  unit = "",
   reason = "Insufficient stock for requested quantity",
   bookingUrl = "https://farmnport.com/account/bookings/preview",
+  marketSide = "supply",
+  cancelledBy = "",
+  action = "rejected",
 }: Props) {
+  const isCancelled = action === "cancelled"
+  const isDemand = marketSide === "demand"
+  const qty = unit ? `${quantity} ${unit} of ${productName}` : `${quantity} ${productName}`
+
+  let headline = ""
+  if (isCancelled && cancelledBy) {
+    headline = isDemand
+      ? `${cancelledBy} cancelled your bid to supply ${qty}.`
+      : `${cancelledBy} cancelled your booking for ${qty}.`
+  } else {
+    headline = isDemand
+      ? `Unfortunately, your bid to supply ${qty} could not be fulfilled.`
+      : `Unfortunately, your booking request for ${qty} could not be fulfilled.`
+  }
+
+  const previewText = isCancelled
+    ? `Booking ${bookingRef} has been cancelled`
+    : `Booking ${bookingRef} could not be fulfilled`
+
   return (
     <Html lang="en">
       <Head />
-      <Preview>Booking {bookingRef} could not be fulfilled</Preview>
+      <Preview>{previewText}</Preview>
       <Body style={body}>
         <Container style={container}>
 
@@ -25,7 +48,7 @@ export default function PreorderRejectedEmail({
           {/* Content */}
           <Section style={content}>
             <Text style={greeting}>Hi {name},</Text>
-            <Text style={paragraph}>Unfortunately, your booking request for {quantity} {productName} could not be fulfilled.</Text>
+            <Text style={paragraph}>{headline}</Text>
             <Text style={paragraph}>Booking reference: <strong>{bookingRef}</strong></Text>
             {reason && <Text style={paragraph}>Reason: {reason}</Text>}
           </Section>

--- a/apps/client-fnp/lib/query.ts
+++ b/apps/client-fnp/lib/query.ts
@@ -1137,8 +1137,8 @@ export function getBooking(id: string) {
   return api.get(`${BaseURL}/booking/${id}`)
 }
 
-export function cancelBooking(id: string) {
-  return api.put(`${BaseURL}/booking/${id}/cancel`, {})
+export function cancelBooking(id: string, reason?: string) {
+  return api.put(`${BaseURL}/booking/${id}/cancel`, { reason })
 }
 
 export function initiatePreOrderPayment(id: string, data: { method?: string; phone?: string }) {

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "7.11.0",
+  "version": "7.12.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- Booking listing links use booking_ref instead of ObjectID
- Incoming booking listing links use booking_ref instead of ObjectID
- Route folders renamed from [id] to [ref]
- Preorder detail booking links use booking_ref
- Counter-offer UI, cancel dialog, email sender updates from prior commits included

## Test plan
- [ ] Booking detail pages load with booking_ref in URL
- [ ] Incoming booking detail pages load with booking_ref in URL
- [ ] Counter-offer negotiation works end to end
- [ ] Cancel with reason works for both buyer and seller