### PR TITLE
Capitalise client names in emails and admin tables

### DIFF
--- a/apps/admin-fnp/components/structures/columns/bookings.tsx
+++ b/apps/admin-fnp/components/structures/columns/bookings.tsx
@@ -67,7 +67,7 @@ export const bookingColumns: ColumnDef<any>[] = [
     header: "Client",
     cell: ({ row }) => (
       <div>
-        <p className="font-medium">{row.original.client_name}</p>
+        <p className="font-medium capitalize">{row.original.client_name}</p>
         <p className="text-xs text-muted-foreground">{row.original.client_phone}</p>
       </div>
     ),

--- a/apps/admin-fnp/components/structures/columns/cdmPrices.tsx
+++ b/apps/admin-fnp/components/structures/columns/cdmPrices.tsx
@@ -42,6 +42,7 @@ export const cdmPriceColumns: ColumnDef<CdmPrice>[] = [
   {
     accessorKey: "client_name",
     header: "Client Name",
+    cell: ({ row }: any) => <span className="capitalize">{row.original.client_name}</span>,
   },
   {
     accessorKey: "exchange_rate",

--- a/apps/admin-fnp/components/structures/columns/chef-bookings.tsx
+++ b/apps/admin-fnp/components/structures/columns/chef-bookings.tsx
@@ -52,7 +52,7 @@ export const chefBookingColumns: ColumnDef<ChefBookingRow>[] = [
     accessorKey: "client_name",
     header: "Client",
     cell: ({ row }) => (
-      <span className="text-sm">{row.original.client_name}</span>
+      <span className="text-sm capitalize">{row.original.client_name}</span>
     ),
   },
   {

--- a/apps/admin-fnp/components/structures/columns/clients.tsx
+++ b/apps/admin-fnp/components/structures/columns/clients.tsx
@@ -35,7 +35,8 @@ const columnHelper = createColumnHelper<ApplicationUser>()
     enableHiding: false,
   }),
   columnHelper.accessor('name', {
-    header: "Name"
+    header: "Name",
+    cell: ({ getValue }) => <span className="capitalize">{getValue()}</span>,
   }),
   columnHelper.accessor('address', {
     header: "Address"

--- a/apps/admin-fnp/components/structures/columns/orders.tsx
+++ b/apps/admin-fnp/components/structures/columns/orders.tsx
@@ -79,7 +79,7 @@ export const orderColumns: ColumnDef<OrderRow>[] = [
       const order = row.original
       return (
         <div>
-          <span className="text-sm">{order.client_name}</span>
+          <span className="text-sm capitalize">{order.client_name}</span>
           <p className="text-xs text-muted-foreground">{order.client_email}</p>
         </div>
       )

--- a/apps/admin-fnp/components/structures/columns/priceSeries.tsx
+++ b/apps/admin-fnp/components/structures/columns/priceSeries.tsx
@@ -68,7 +68,7 @@ export const priceSeriesColumns: ColumnDef<PriceSeriesEntry>[] = [
     accessorKey: "client_name",
     header: "Client",
     cell: ({ row }) => (
-      <span className="text-sm">{row.getValue("client_name") || row.original.client_id}</span>
+      <span className="text-sm capitalize">{row.getValue("client_name") || row.original.client_id}</span>
     ),
   },
   {

--- a/apps/admin-fnp/components/structures/columns/producerLists.tsx
+++ b/apps/admin-fnp/components/structures/columns/producerLists.tsx
@@ -43,6 +43,7 @@ export const producerPriceListColumns: ColumnDef<ProducerPriceList>[] = [
   {
     accessorKey: "client_name",
     header: "Client Name",
+    cell: ({ row }: any) => <span className="capitalize">{row.original.client_name}</span>,
   },
   {
     id: "see_price",

--- a/apps/client-fnp/emails/templates/auth/magic-link.tsx
+++ b/apps/client-fnp/emails/templates/auth/magic-link.tsx
@@ -1,4 +1,5 @@
 import { Body, Button, Container, Head, Hr, Html, Link, Preview, Section, Text } from "@react-email/components"
+import { titleCase } from "@/lib/utilities"
 
 interface MagicLinkEmailProps {
   name?: string
@@ -23,7 +24,7 @@ export default function MagicLinkEmail({
 
           {/* Greeting */}
           <Section style={content}>
-            <Text style={greeting}>Hi {name},</Text>
+            <Text style={greeting}>Hi {titleCase(name)},</Text>
             <Text style={paragraph}>
               We received a request to reset the password for your farmnport account.
             </Text>

--- a/apps/client-fnp/emails/templates/auth/phone-update-code.tsx
+++ b/apps/client-fnp/emails/templates/auth/phone-update-code.tsx
@@ -1,4 +1,5 @@
 import { Body, Container, Head, Hr, Html, Link, Preview, Section, Text } from "@react-email/components"
+import { titleCase } from "@/lib/utilities"
 
 interface PhoneUpdateCodeEmailProps {
   name?: string
@@ -23,7 +24,7 @@ export default function PhoneUpdateCodeEmail({
           </Section>
 
           <Section style={content}>
-            <Text style={greeting}>Hi {name},</Text>
+            <Text style={greeting}>Hi {titleCase(name)},</Text>
             <Text style={paragraph}>
               You requested to update your phone number to {phone}. Use the verification code below to confirm the change.
             </Text>

--- a/apps/client-fnp/emails/templates/auth/verify-reminder.tsx
+++ b/apps/client-fnp/emails/templates/auth/verify-reminder.tsx
@@ -1,4 +1,5 @@
 import { Body, Button, Container, Head, Hr, Html, Link, Preview, Section, Text } from "@react-email/components"
+import { titleCase } from "@/lib/utilities"
 
 interface VerifyReminderEmailProps {
   name?: string
@@ -25,7 +26,7 @@ export default function VerifyReminderEmail({
 
           {/* Greeting */}
           <Section style={content}>
-            <Text style={greeting}>Hi {name},</Text>
+            <Text style={greeting}>Hi {titleCase(name)},</Text>
             <Text style={paragraph}>
               You signed up on farmnport but haven't verified your email yet. A verified account unlocks everything you need to trade directly.
             </Text>

--- a/apps/client-fnp/emails/templates/blast.tsx
+++ b/apps/client-fnp/emails/templates/blast.tsx
@@ -1,4 +1,5 @@
 import { Body, Container, Head, Hr, Html, Link, Preview, Section, Text } from "@react-email/components"
+import { titleCase } from "@/lib/utilities"
 
 interface BlastEmailProps {
   name?: string
@@ -27,7 +28,7 @@ export default function BlastEmail({ name = "Okandas", message = "", link, linkL
 
           {/* Greeting + Message */}
           <Section style={content}>
-            <Text style={greeting}>Hi {name},</Text>
+            <Text style={greeting}>Hi {titleCase(name)},</Text>
             <Text style={paragraph}>{message}</Text>
             {link && (
               <Text style={{ margin: "0 0 8px" }}><Link href={link} style={inlineLink}>{linkLabel || link}</Link></Text>

--- a/apps/client-fnp/emails/templates/bookings/booking-status.tsx
+++ b/apps/client-fnp/emails/templates/bookings/booking-status.tsx
@@ -1,4 +1,5 @@
 import { Body, Button, Container, Head, Hr, Html, Link, Preview, Section, Text } from "@react-email/components"
+import { titleCase } from "@/lib/utilities"
 
 interface BookingStatusEmailProps {
   name?: string
@@ -50,7 +51,7 @@ export default function BookingStatusEmail({
 
           {/* Content */}
           <Section style={content}>
-            <Text style={greeting}>Hi {name},</Text>
+            <Text style={greeting}>Hi {titleCase(name)},</Text>
             <Text style={paragraph}>{message}</Text>
             {estimatedDate && (
               <Text style={paragraph}>

--- a/apps/client-fnp/emails/templates/bookings/preorder-event-rejected.tsx
+++ b/apps/client-fnp/emails/templates/bookings/preorder-event-rejected.tsx
@@ -1,4 +1,5 @@
 import { Body, Button, Container, Head, Hr, Html, Link, Preview, Section, Text } from "@react-email/components"
+import { titleCase } from "@/lib/utilities"
 
 interface Props { name?: string; eventTitle?: string; produceName?: string; reason?: string; eventUrl?: string }
 
@@ -23,7 +24,7 @@ export default function PreorderEventRejectedEmail({
 
           {/* Content */}
           <Section style={content}>
-            <Text style={greeting}>Hi {name},</Text>
+            <Text style={greeting}>Hi {titleCase(name)},</Text>
             <Text style={paragraph}>Your booking listing <strong>{eventTitle}</strong> for {produceName} was not approved.</Text>
             {reason && <Text style={paragraph}>Reason: {reason}</Text>}
           </Section>

--- a/apps/client-fnp/emails/templates/bookings/preorder-expired.tsx
+++ b/apps/client-fnp/emails/templates/bookings/preorder-expired.tsx
@@ -1,4 +1,5 @@
 import { Body, Button, Container, Head, Hr, Html, Link, Preview, Section, Text } from "@react-email/components"
+import { titleCase } from "@/lib/utilities"
 
 interface Props { name?: string; bookingRef?: string; productName?: string; quantity?: number; bookingUrl?: string }
 
@@ -23,7 +24,7 @@ export default function PreorderExpiredEmail({
 
           {/* Content */}
           <Section style={content}>
-            <Text style={greeting}>Hi {name},</Text>
+            <Text style={greeting}>Hi {titleCase(name)},</Text>
             <Text style={paragraph}>Your booking for {quantity} {productName} has expired because the payment was not received within the deadline. Your reserved quantity has been released.</Text>
             <Text style={paragraph}>Booking reference: <strong>{bookingRef}</strong></Text>
             <Text style={paragraph}>If you&apos;d still like to place an order, you can submit a new booking request.</Text>

--- a/apps/client-fnp/emails/templates/bookings/preorder-rejected.tsx
+++ b/apps/client-fnp/emails/templates/bookings/preorder-rejected.tsx
@@ -1,4 +1,5 @@
 import { Body, Button, Container, Head, Hr, Html, Link, Preview, Section, Text } from "@react-email/components"
+import { titleCase } from "@/lib/utilities"
 
 interface Props { name?: string; bookingRef?: string; productName?: string; quantity?: number; unit?: string; reason?: string; bookingUrl?: string; marketSide?: string; cancelledBy?: string; action?: string }
 
@@ -17,12 +18,13 @@ export default function PreorderRejectedEmail({
   const isCancelled = action === "cancelled"
   const isDemand = marketSide === "demand"
   const qty = unit ? `${quantity} ${unit} of ${productName}` : `${quantity} ${productName}`
+  const who = titleCase(cancelledBy)
 
   let headline = ""
-  if (isCancelled && cancelledBy) {
+  if (isCancelled && who) {
     headline = isDemand
-      ? `${cancelledBy} cancelled your bid to supply ${qty}.`
-      : `${cancelledBy} cancelled your booking for ${qty}.`
+      ? `${who} cancelled your bid to supply ${qty}.`
+      : `${who} cancelled your booking for ${qty}.`
   } else {
     headline = isDemand
       ? `Unfortunately, your bid to supply ${qty} could not be fulfilled.`
@@ -47,7 +49,7 @@ export default function PreorderRejectedEmail({
 
           {/* Content */}
           <Section style={content}>
-            <Text style={greeting}>Hi {name},</Text>
+            <Text style={greeting}>Hi {titleCase(name)},</Text>
             <Text style={paragraph}>{headline}</Text>
             <Text style={paragraph}>Booking reference: <strong>{bookingRef}</strong></Text>
             {reason && <Text style={paragraph}>Reason: {reason}</Text>}

--- a/apps/client-fnp/emails/templates/bookings/preorder-request-received.tsx
+++ b/apps/client-fnp/emails/templates/bookings/preorder-request-received.tsx
@@ -1,4 +1,5 @@
 import { Body, Button, Container, Head, Hr, Html, Link, Preview, Section, Text } from "@react-email/components"
+import { titleCase } from "@/lib/utilities"
 
 interface Props { name?: string; bookingRef?: string; productName?: string; quantity?: number; bookingUrl?: string }
 
@@ -19,7 +20,7 @@ export default function PreorderRequestReceivedEmail({ name = "Okandas", booking
 
           {/* Content */}
           <Section style={content}>
-            <Text style={greeting}>Hi {name},</Text>
+            <Text style={greeting}>Hi {titleCase(name)},</Text>
             <Text style={paragraph}>Your pre-order request has been submitted. We&apos;ll confirm availability and notify you to pay.</Text>
             <Text style={paragraph}>Booking reference: <strong>{bookingRef}</strong></Text>
             <Text style={paragraph}>{details}</Text>

--- a/apps/client-fnp/emails/templates/lots/lot-bid-countered.tsx
+++ b/apps/client-fnp/emails/templates/lots/lot-bid-countered.tsx
@@ -1,4 +1,5 @@
 import { Body, Button, Container, Head, Hr, Html, Link, Preview, Section, Text } from "@react-email/components"
+import { titleCase } from "@/lib/utilities"
 
 interface LotBidCounteredEmailProps {
   name?: string
@@ -35,9 +36,9 @@ export default function LotBidCounteredEmail({
 
           {/* Greeting */}
           <Section style={content}>
-            <Text style={greeting}>Hi {name},</Text>
+            <Text style={greeting}>Hi {titleCase(name)},</Text>
             <Text style={paragraph}>
-              {counterName} has made a counter-offer on lot {lotSlug}.
+              {titleCase(counterName)} has made a counter-offer on lot {lotSlug}.
             </Text>
             <Text style={paragraph}>
               {"Quantity: "}{quantity} {unit}{"\n"}

--- a/apps/client-fnp/emails/templates/lots/lot-bid-received.tsx
+++ b/apps/client-fnp/emails/templates/lots/lot-bid-received.tsx
@@ -1,4 +1,5 @@
 import { Body, Button, Container, Head, Hr, Html, Link, Preview, Section, Text } from "@react-email/components"
+import { titleCase } from "@/lib/utilities"
 
 interface LotBidReceivedEmailProps {
   name?: string
@@ -33,9 +34,9 @@ export default function LotBidReceivedEmail({
 
           {/* Greeting */}
           <Section style={content}>
-            <Text style={greeting}>Hi {name},</Text>
+            <Text style={greeting}>Hi {titleCase(name)},</Text>
             <Text style={paragraph}>
-              {bidderName} has placed an offer on your lot.
+              {titleCase(bidderName)} has placed an offer on your lot.
             </Text>
             <Text style={paragraph}>
               {"Quantity: "}{quantity} {unit}{"\n"}

--- a/apps/client-fnp/emails/templates/lots/lot-bid-rejected.tsx
+++ b/apps/client-fnp/emails/templates/lots/lot-bid-rejected.tsx
@@ -1,4 +1,5 @@
 import { Body, Button, Container, Head, Hr, Html, Link, Preview, Section, Text } from "@react-email/components"
+import { titleCase } from "@/lib/utilities"
 
 interface LotBidRejectedEmailProps {
   name?: string
@@ -25,7 +26,7 @@ export default function LotBidRejectedEmail({
 
           {/* Greeting */}
           <Section style={content}>
-            <Text style={greeting}>Hi {name},</Text>
+            <Text style={greeting}>Hi {titleCase(name)},</Text>
             <Text style={paragraph}>
               Unfortunately, {lotOwnerName} did not accept your offer on lot {lotSlug}.
             </Text>

--- a/apps/client-fnp/emails/templates/marketing-launch.tsx
+++ b/apps/client-fnp/emails/templates/marketing-launch.tsx
@@ -1,4 +1,5 @@
 import { Body, Button, Container, Head, Hr, Html, Link, Preview, Section, Text } from "@react-email/components"
+import { titleCase } from "@/lib/utilities"
 
 interface MarketingLaunchEmailProps {
   name?: string
@@ -24,7 +25,7 @@ export default function MarketingLaunchEmail({ name = "Member" }: MarketingLaunc
 
           {/* Greeting */}
           <Section style={content}>
-            <Text style={greeting}>Hi {name},</Text>
+            <Text style={greeting}>Hi {titleCase(name)},</Text>
             <Text style={paragraph}>
               We have added two new ways for you to trade directly on farmnport. Whether you supply or buy produce, these tools help you connect faster.
             </Text>

--- a/apps/client-fnp/emails/templates/menus-blast.tsx
+++ b/apps/client-fnp/emails/templates/menus-blast.tsx
@@ -1,4 +1,5 @@
 import { Body, Container, Head, Hr, Html, Link, Preview, Section, Text } from "@react-email/components"
+import { titleCase } from "@/lib/utilities"
 
 interface MenusBlastEmailProps {
   name?: string
@@ -24,7 +25,7 @@ export default function MenusBlastEmail({ name = "there", message = "" }: MenusB
 
           {/* Greeting + Message */}
           <Section style={content}>
-            <Text style={greeting}>Hi {name},</Text>
+            <Text style={greeting}>Hi {titleCase(name)},</Text>
             <Text style={paragraph}>{message}</Text>
           </Section>
 

--- a/apps/client-fnp/emails/templates/menus-reviews-favourites.tsx
+++ b/apps/client-fnp/emails/templates/menus-reviews-favourites.tsx
@@ -1,4 +1,5 @@
 import { Body, Button, Container, Head, Hr, Html, Img, Link, Preview, Section, Text } from "@react-email/components"
+import { titleCase } from "@/lib/utilities"
 
 interface MenusReviewsFavouritesEmailProps {
   name?: string
@@ -22,7 +23,7 @@ export default function MenusReviewsFavouritesEmail({ name = "there" }: MenusRev
 
           {/* Greeting */}
           <Section style={content}>
-            <Text style={greeting}>Hi {name},</Text>
+            <Text style={greeting}>Hi {titleCase(name)},</Text>
             <Text style={paragraph}>
               Thank you for using menus.co.zw — we are building Zimbabwe's most complete restaurant guide and your input makes it better for everyone.
             </Text>

--- a/apps/client-fnp/emails/templates/orders/order-status.tsx
+++ b/apps/client-fnp/emails/templates/orders/order-status.tsx
@@ -1,4 +1,5 @@
 import { Body, Button, Container, Head, Hr, Html, Link, Preview, Section, Text } from "@react-email/components"
+import { titleCase } from "@/lib/utilities"
 
 interface OrderStatusEmailProps {
   name?: string
@@ -49,7 +50,7 @@ export default function OrderStatusEmail({
           {/* Greeting */}
           <Section style={content}>
             <Text style={greeting}>Order update</Text>
-            <Text style={paragraph}>Hi {name},</Text>
+            <Text style={paragraph}>Hi {titleCase(name)},</Text>
             <Text style={paragraph}>{message}</Text>
             <Text style={paragraph}>
               {"Order: "}<strong>{orderNumber}</strong>

--- a/apps/client-fnp/emails/templates/terms-update.tsx
+++ b/apps/client-fnp/emails/templates/terms-update.tsx
@@ -1,4 +1,5 @@
 import { Body, Button, Container, Head, Hr, Html, Link, Preview, Section, Text } from "@react-email/components"
+import { titleCase } from "@/lib/utilities"
 
 interface TermsUpdateEmailProps {
   name?: string
@@ -19,7 +20,7 @@ export default function TermsUpdateEmail({ name = "Member" }: TermsUpdateEmailPr
 
           {/* Greeting */}
           <Section style={content}>
-            <Text style={greeting}>Hi {name},</Text>
+            <Text style={greeting}>Hi {titleCase(name)},</Text>
             <Text style={paragraph}>
               We have made some updates to our Terms of Service that we would like you to know about.
             </Text>

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "7.12.0",
+  "version": "7.12.1",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- titleCase(name) on all 16 email template greetings
- Capitalise bidder/counter names in lot bid emails
- CSS capitalize on client_name in 7 admin table columns

## Test plan
- [ ] Email greeting shows "Hi Motion Tract," not "Hi motion tract,"
- [ ] Admin clients table shows capitalised names