### PR TITLE
Booking frequency, dynamic OG image, close_date fix

### DIFF
--- a/apps/admin-fnp/app/dashboard/farmnport/orders/booking-preorders/[id]/edit/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/orders/booking-preorders/[id]/edit/page.tsx
@@ -118,6 +118,7 @@ export default function EditPreOrderPage({ params }: { params: Promise<{ id: str
     breed_id: string
     breed_name: string
     unit: string
+    frequency: string
     name: string
     total_available: string
     unit_price: string
@@ -156,6 +157,7 @@ export default function EditPreOrderPage({ params }: { params: Promise<{ id: str
       breed_id: event.breed_id ?? "",
       breed_name: event.breed_name ?? "",
       unit: event.unit ?? "",
+      frequency: event.frequency ?? "",
       name: event.name ?? "",
       total_available: String(event.total_available ?? ""),
       unit_price: ((event.unit_price ?? 0) / 100).toFixed(2),
@@ -184,6 +186,7 @@ export default function EditPreOrderPage({ params }: { params: Promise<{ id: str
         breed_id: form!.breed_id || undefined,
         breed_name: form!.breed_name || undefined,
         unit: form!.unit || undefined,
+        frequency: form!.frequency || undefined,
         name: form!.name || undefined,
         total_available: parseInt(form!.total_available),
         unit_price: Math.round(parseFloat(form!.unit_price) * 100),
@@ -470,6 +473,21 @@ export default function EditPreOrderPage({ params }: { params: Promise<{ id: str
                     <SelectItem value="bags">Bags</SelectItem>
                     <SelectItem value="kg">Kg</SelectItem>
                     <SelectItem value="units">Units</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <div>
+              <label className={labelCls}>Frequency</label>
+              <div className="mt-2">
+                <Select value={form.frequency} onValueChange={(v) => setForm((f) => f ? { ...f, frequency: v } : f)}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="One-time (no frequency)" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="daily">Daily</SelectItem>
+                    <SelectItem value="weekly">Weekly</SelectItem>
+                    <SelectItem value="monthly">Monthly</SelectItem>
                   </SelectContent>
                 </Select>
               </div>

--- a/apps/admin-fnp/app/dashboard/farmnport/orders/booking-preorders/new/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/orders/booking-preorders/new/page.tsx
@@ -191,6 +191,7 @@ export default function NewPreOrderPage() {
     breed_id: "",
     breed_name: "",
     unit: "",
+    frequency: "",
     name: "",
     unit_price: "",
     deposit_per_unit: "",
@@ -226,6 +227,7 @@ export default function NewPreOrderPage() {
         breed_id: form.breed_id || undefined,
         breed_name: form.breed_name || undefined,
         unit: form.unit || undefined,
+        frequency: form.frequency || undefined,
         name: form.name || undefined,
         unit_price: Math.round(parseFloat(form.unit_price) * 100),
         deposit_per_unit: Math.round(parseFloat(form.deposit_per_unit) * 100),
@@ -498,6 +500,21 @@ export default function NewPreOrderPage() {
                     <SelectItem value="bags">Bags</SelectItem>
                     <SelectItem value="kg">Kg</SelectItem>
                     <SelectItem value="units">Units</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <div>
+              <label className={labelCls}>Frequency</label>
+              <div className="mt-2">
+                <Select value={form.frequency} onValueChange={(v) => setForm((f) => ({ ...f, frequency: v }))}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="One-time (no frequency)" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="daily">Daily</SelectItem>
+                    <SelectItem value="weekly">Weekly</SelectItem>
+                    <SelectItem value="monthly">Monthly</SelectItem>
                   </SelectContent>
                 </Select>
               </div>

--- a/apps/client-fnp/app/(landing)/account/(sections)/booking-preorders/BookingPreordersClient.tsx
+++ b/apps/client-fnp/app/(landing)/account/(sections)/booking-preorders/BookingPreordersClient.tsx
@@ -99,7 +99,7 @@ export default function MyPreOrdersPage() {
                     {event.product_name ? `${event.product_name} · ` : ""}
                     {booked}/{available} {event.unit} booked · {centsToDollars(event.unit_price)}/{event.unit}
                   </p>
-                  <p>Opens {formatDate(event.open_date)} · Closes {formatDate(event.close_date)}</p>
+                  <p>Opens {formatDate(event.open_date)}{event.close_date ? ` · Closes ${formatDate(event.close_date)}` : ""}</p>
                 </div>
               </div>
             )

--- a/apps/client-fnp/app/(landing)/account/(sections)/booking-preorders/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/account/(sections)/booking-preorders/[slug]/page.tsx
@@ -178,7 +178,7 @@ export default function BookingPreOrderDetailPage({ params }: { params: Promise<
               <Field label="Max Quantity" value={event.max_quantity || "No maximum"} />
               {event.quantity_step > 1 && <Field label="Step" value={`Multiples of ${event.quantity_step}`} />}
               <Field label="Opens" value={formatDate(event.open_date)} />
-              <Field label="Closes" value={formatDate(event.close_date)} />
+              {event.close_date && <Field label="Closes" value={formatDate(event.close_date)} />}
               <Field label="Market Side" value={event.market_side === "demand" ? "Buyer Request" : "Supply Offer"} />
             </div>
             {event.description && (

--- a/apps/client-fnp/app/(landing)/agrochemical-guides/page.tsx
+++ b/apps/client-fnp/app/(landing)/agrochemical-guides/page.tsx
@@ -13,13 +13,13 @@ export const metadata = {
     url: 'https://farmnport.com/agrochemical-guides',
     siteName: 'farmnport',
     type: 'website',
-    images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
+    images: [{ url: "https://farmnport.com/api/og", width: 1200, height: 630, alt: "farmnport" }],
   },
   twitter: {
     card: "summary_large_image",
     title: "Agrochemical Guides Zimbabwe",
     description: "Browse agrochemical product guides for Zimbabwe farmers. Herbicides, fungicides, insecticides, acaricides — dosage rates and application guidelines.",
-    images: ["/og-image.png"],
+    images: ["/api/og"],
   },
 }
 

--- a/apps/client-fnp/app/(landing)/animal-health-guides/page.tsx
+++ b/apps/client-fnp/app/(landing)/animal-health-guides/page.tsx
@@ -13,13 +13,13 @@ export const metadata = {
     url: 'https://farmnport.com/animal-health-guides',
     siteName: 'farmnport',
     type: 'website',
-    images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
+    images: [{ url: "https://farmnport.com/api/og", width: 1200, height: 630, alt: "farmnport" }],
   },
   twitter: {
     card: "summary_large_image",
     title: "Animal Health Product Guides Zimbabwe",
     description: "Browse animal health product guides for poultry and livestock in Zimbabwe. Vaccines, antibiotics, supplements — dosage rates and usage guidelines.",
-    images: ["/og-image.png"],
+    images: ["/api/og"],
   },
 }
 

--- a/apps/client-fnp/app/(landing)/bookings/[slug]/PreOrderDetailClient.tsx
+++ b/apps/client-fnp/app/(landing)/bookings/[slug]/PreOrderDetailClient.tsx
@@ -294,7 +294,7 @@ export default function PreOrderDetailPage({ preorder, depositEnabled = false }:
               <div className="rounded-xl border bg-muted/30 p-4">
                 <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2 min-h-[32px]">{event.market_side === "demand" ? "Quantity Needed" : "Available"}</p>
                 <p className="text-lg font-bold">{available.toLocaleString()}</p>
-                <p className="text-xs text-muted-foreground mt-1">of {event.total_available.toLocaleString()} {event.unit} total</p>
+                <p className="text-xs text-muted-foreground mt-1">{event.market_side === "demand" ? `${event.unit}${event.frequency ? ` / ${event.frequency}` : ""}` : `of ${event.total_available.toLocaleString()} ${event.unit} total`}</p>
               </div>
               )}
               <div className="rounded-xl border bg-muted/30 p-4">

--- a/apps/client-fnp/app/(landing)/bookings/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/bookings/[slug]/page.tsx
@@ -21,9 +21,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         const produce = titleCase(p.produce_name || "")
         const isBuyer = p.market_side === "demand"
         const action = isBuyer ? "Buying" : "Selling"
-        const cta = isBuyer ? "Supply Now" : "Book Now"
-
-        const title = `${supplier} ${action} ${produce} — ${cta} | farmnport`
+        const title = `${supplier} — ${action} ${produce} | farmnport`
         const description = p.description || (isBuyer
             ? `${supplier} is looking for ${produce}. Supply them now on farmnport.com.`
             : `${supplier} is selling ${produce}. Pre-order now on farmnport.com — secure your stock before it sells out.`)
@@ -37,7 +35,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
                 title,
                 description,
                 url: `${baseUrl}/bookings/${slug}`,
-                images: p.image_src ? [{ url: p.image_src }] : [],
+                images: [{ url: p.image_src || `${baseUrl}/api/og` }],
                 siteName: "farmnport",
                 type: "website",
             },
@@ -45,7 +43,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
                 card: "summary_large_image",
                 title,
                 description,
-                images: ["/og-image.png"],
+                images: [{ url: p.image_src || `${baseUrl}/api/og` }],
             },
         }
     } catch {
@@ -71,7 +69,7 @@ export default async function PreOrderDetailPage({ params }: Props) {
         "@context": "https://schema.org",
         "@type": "Product",
         "name": `${preorder.client_name || preorder.brand_name || "Supplier"} — ${preorder.produce_name || "Farm Produce"}`,
-        "image": preorder.image_src ? [preorder.image_src] : [`${baseUrl}/og-image.png`],
+        "image": preorder.image_src ? [preorder.image_src] : [`${baseUrl}/api/og`],
         "description": preorder.description || `${isBuyer ? "Buying" : "Selling"} ${preorder.produce_name || "farm produce"} on farmnport.com`,
         "sku": preorder.id || slug,
         "category": "Farm Bookings",

--- a/apps/client-fnp/app/(landing)/bookings/page.tsx
+++ b/apps/client-fnp/app/(landing)/bookings/page.tsx
@@ -25,13 +25,13 @@ export const metadata = {
         siteName: "farmnport",
         type: "website" as const,
         url: "https://farmnport.com/bookings",
-        images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
+        images: [{ url: "https://farmnport.com/api/og", width: 1200, height: 630, alt: "farmnport" }],
     },
     twitter: {
         card: "summary_large_image" as const,
         title: "Farm Bookings & Pre-Orders Zimbabwe – Prices & Availability",
         description: "Book day-old chicks, livestock and seasonal farm produce in advance. View prices and secure your order with a deposit.",
-        images: ["/og-image.png"],
+        images: ["/api/og"],
     },
 }
 

--- a/apps/client-fnp/app/(landing)/buy-agrochemicals/page.tsx
+++ b/apps/client-fnp/app/(landing)/buy-agrochemicals/page.tsx
@@ -13,13 +13,13 @@ export const metadata = {
         siteName: "farmnport",
         type: "website" as const,
         url: "https://farmnport.com/buy-agrochemicals",
-        images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
+        images: [{ url: "https://farmnport.com/api/og", width: 1200, height: 630, alt: "farmnport" }],
     },
     twitter: {
         card: "summary_large_image" as const,
         title: "Buy Agrochemicals Zimbabwe – Prices & Dosage Guides",
         description: "Browse herbicides, fungicides, insecticides and plant growth regulators. Compare prices, view dosage guides and spray programs for Zimbabwe crops.",
-        images: ["/og-image.png"],
+        images: ["/api/og"],
     },
 }
 

--- a/apps/client-fnp/app/(landing)/buy-animal-health/page.tsx
+++ b/apps/client-fnp/app/(landing)/buy-animal-health/page.tsx
@@ -13,13 +13,13 @@ export const metadata = {
         siteName: "farmnport",
         type: "website" as const,
         url: "https://farmnport.com/buy-animal-health",
-        images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
+        images: [{ url: "https://farmnport.com/api/og", width: 1200, height: 630, alt: "farmnport" }],
     },
     twitter: {
         card: "summary_large_image" as const,
         title: "Buy Animal Health Products Zimbabwe – Prices & Guides",
         description: "Shop dips, dewormers, vaccines and veterinary supplements for cattle, poultry and livestock. Compare prices, view dosage rates and order online.",
-        images: ["/og-image.png"],
+        images: ["/api/og"],
     },
 }
 

--- a/apps/client-fnp/app/(landing)/buy-documents/page.tsx
+++ b/apps/client-fnp/app/(landing)/buy-documents/page.tsx
@@ -15,13 +15,13 @@ export const metadata = {
         siteName: "farmnport",
         type: "website" as const,
         url: "https://farmnport.com/buy-documents",
-        images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
+        images: [{ url: "https://farmnport.com/api/og", width: 1200, height: 630, alt: "farmnport" }],
     },
     twitter: {
         card: "summary_large_image" as const,
         title: "Farm Building Plans & Documents | farmnport.com",
         description: "Download pig sty, goat pen, chicken house and cattle kraal design plans. Instant PDF download.",
-        images: ["/og-image.png"],
+        images: ["/api/og"],
     },
 }
 

--- a/apps/client-fnp/app/(landing)/buy-equipment/page.tsx
+++ b/apps/client-fnp/app/(landing)/buy-equipment/page.tsx
@@ -13,13 +13,13 @@ export const metadata = {
         siteName: "farmnport",
         type: "website" as const,
         url: "https://farmnport.com/buy-equipment",
-        images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
+        images: [{ url: "https://farmnport.com/api/og", width: 1200, height: 630, alt: "farmnport" }],
     },
     twitter: {
         card: "summary_large_image" as const,
         title: "Buy Farm Equipment Online — Zimbabwe",
         description: "Shop our complete range of quality agricultural equipment and machinery for Zimbabwe farmers.",
-        images: ["/og-image.png"],
+        images: ["/api/og"],
     },
 }
 

--- a/apps/client-fnp/app/(landing)/buy-feeds/page.tsx
+++ b/apps/client-fnp/app/(landing)/buy-feeds/page.tsx
@@ -13,13 +13,13 @@ export const metadata = {
         siteName: "farmnport",
         type: "website" as const,
         url: "https://farmnport.com/buy-feeds",
-        images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
+        images: [{ url: "https://farmnport.com/api/og", width: 1200, height: 630, alt: "farmnport" }],
     },
     twitter: {
         card: "summary_large_image" as const,
         title: "Buy Animal Feeds Zimbabwe – Prices & Product Range",
         description: "Shop poultry feeds, cattle feeds, pig feeds and pet food from top brands. Compare prices and order online.",
-        images: ["/og-image.png"],
+        images: ["/api/og"],
     },
 }
 

--- a/apps/client-fnp/app/(landing)/buy-plant-nutrition/page.tsx
+++ b/apps/client-fnp/app/(landing)/buy-plant-nutrition/page.tsx
@@ -13,13 +13,13 @@ export const metadata = {
         siteName: "farmnport",
         type: "website" as const,
         url: "https://farmnport.com/buy-plant-nutrition",
-        images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
+        images: [{ url: "https://farmnport.com/api/og", width: 1200, height: 630, alt: "farmnport" }],
     },
     twitter: {
         card: "summary_large_image" as const,
         title: "Buy Plant Nutrition & Fertilizers Zimbabwe – Prices & Guides",
         description: "Shop foliar feeds, soil amendments and crop nutrition products. Compare prices, view application rates and order online.",
-        images: ["/og-image.png"],
+        images: ["/api/og"],
     },
 }
 

--- a/apps/client-fnp/app/(landing)/buy-seed-products/page.tsx
+++ b/apps/client-fnp/app/(landing)/buy-seed-products/page.tsx
@@ -13,13 +13,13 @@ export const metadata = {
         siteName: "farmnport",
         type: "website" as const,
         url: "https://farmnport.com/buy-seed-products",
-        images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
+        images: [{ url: "https://farmnport.com/api/og", width: 1200, height: 630, alt: "farmnport" }],
     },
     twitter: {
         card: "summary_large_image" as const,
         title: "Buy Seed Products Zimbabwe – Prices & Varieties",
         description: "Shop maize seed, vegetable seed and pasture seed from certified suppliers. Compare prices, view varieties and order online.",
-        images: ["/og-image.png"],
+        images: ["/api/og"],
     },
 }
 

--- a/apps/client-fnp/app/(landing)/buyers/page.tsx
+++ b/apps/client-fnp/app/(landing)/buyers/page.tsx
@@ -22,7 +22,7 @@ export const metadata = {
         description: "Farmers, sell your fresh produce directly to buyers! Access fairer markets, build customer relationships, and reduce dependency on traditional channels.",
         images: [
             {
-                url: "/og-image.png",
+                url: "/api/og",
                 width: 1200,
                 height: 630,
                 alt: "Farmnport Buyers - Sell Your Farm Produce Directly",
@@ -33,7 +33,7 @@ export const metadata = {
         card: "summary_large_image",
         title: 'Sell Your Farm Produce Directly – Reach Buyers Faster.',
         description: "Farmers, sell your fresh produce directly to buyers! Access fairer markets, build customer relationships, and reduce dependency on traditional channels.",
-        images: ["/og-image.png"],
+        images: ["/api/og"],
     },
 }
 

--- a/apps/client-fnp/app/(landing)/farmers/page.tsx
+++ b/apps/client-fnp/app/(landing)/farmers/page.tsx
@@ -21,7 +21,7 @@ export const metadata = {
     description: "Looking for fresh, high-quality agricultural produce in Zimbabwe? Buy directly from local farmers for the best prices, farm-to-table freshness, and support for Zimbabwean agriculture.",
     images: [
       {
-        url: "/og-image.png",
+        url: "/api/og",
         width: 1200,
         height: 630,
         alt: "Farmnport Farmers - Buy Fresh Agricultural Produce",
@@ -32,7 +32,7 @@ export const metadata = {
     card: "summary_large_image",
     title: 'Buy Fresh Agricultural Produce Directly from Farmers',
     description: "Looking for fresh, high-quality agricultural produce in Zimbabwe? Buy directly from local farmers for the best prices, farm-to-table freshness, and support for Zimbabwean agriculture.",
-    images: ["/og-image.png"],
+    images: ["/api/og"],
   },
 }
 

--- a/apps/client-fnp/app/(landing)/feed-guides/[slug]/layout.tsx
+++ b/apps/client-fnp/app/(landing)/feed-guides/[slug]/layout.tsx
@@ -24,7 +24,7 @@ export async function generateMetadata({ params }: LayoutProps): Promise<Metadat
 
     const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://farmnport.com'
     const url = `${baseUrl}/feeds/${slug}`
-    const imageUrl = product.images?.[0]?.img?.src || `${baseUrl}/og-image.png`
+    const imageUrl = product.images?.[0]?.img?.src || `${baseUrl}/api/og`
     const name = capitalizeFirstLetter(product.name)
     const category = product.feed_category?.name || 'Livestock Feed'
     const animal = product.animal ? ` for ${product.animal}` : ''

--- a/apps/client-fnp/app/(landing)/feed-guides/page.tsx
+++ b/apps/client-fnp/app/(landing)/feed-guides/page.tsx
@@ -14,13 +14,13 @@ export const metadata: Metadata = {
         url: "https://farmnport.com/feed-guides",
         siteName: "farmnport",
         type: "website",
-        images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
+        images: [{ url: "https://farmnport.com/api/og", width: 1200, height: 630, alt: "farmnport" }],
     },
     twitter: {
         card: "summary_large_image",
         title: "Livestock Feed Guides Zimbabwe — Animal Feed Products & Nutrition",
         description: "Browse livestock feed product guides for Zimbabwe farmers. Compare feeds by animal type, phase, and nutritional specs.",
-        images: ["/og-image.png"],
+        images: ["/api/og"],
     },
 }
 

--- a/apps/client-fnp/app/(landing)/feeding-programs/[slug]/layout.tsx
+++ b/apps/client-fnp/app/(landing)/feeding-programs/[slug]/layout.tsx
@@ -23,7 +23,7 @@ export async function generateMetadata({ params }: LayoutProps): Promise<Metadat
 
     const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://farmnport.com'
     const url = `${baseUrl}/feeding-programs/${slug}`
-    const imageUrl = program.cover_image?.img?.src || `${baseUrl}/og-image.png`
+    const imageUrl = program.cover_image?.img?.src || `${baseUrl}/api/og`
 
     const stageCount = program.stages?.length || 0
     const animal = program.animal || 'livestock'

--- a/apps/client-fnp/app/(landing)/feeding-programs/page.tsx
+++ b/apps/client-fnp/app/(landing)/feeding-programs/page.tsx
@@ -14,13 +14,13 @@ export const metadata = {
         url: "https://farmnport.com/feeding-programs",
         siteName: "farmnport",
         type: "website",
-        images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
+        images: [{ url: "https://farmnport.com/api/og", width: 1200, height: 630, alt: "farmnport" }],
     },
     twitter: {
         card: "summary_large_image",
         title: "Feeding Programs Zimbabwe — Livestock Nutrition Schedules",
         description: "Browse structured feeding programs for livestock in Zimbabwe — formulations, schedules, and nutritional targets by animal type.",
-        images: ["/og-image.png"],
+        images: ["/api/og"],
     },
 }
 

--- a/apps/client-fnp/app/(landing)/lots/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/lots/[slug]/page.tsx
@@ -47,7 +47,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
             card: "summary_large_image",
             title,
             description,
-            images: ["/og-image.png"],
+            images: ["/api/og"],
         },
     }
 }
@@ -73,7 +73,7 @@ export default async function LotDetailPage({ params }: Props) {
         "@context": "https://schema.org",
         "@type": "Product",
         "name": `${produce}${breed ? ` — ${breed}` : ""}`,
-        "image": lot.images?.[0]?.img?.src ? [lot.images[0].img.src] : [`${AppURL}/og-image.png`],
+        "image": lot.images?.[0]?.img?.src ? [lot.images[0].img.src] : [`${AppURL}/api/og`],
         "description": lot.notes || `${isSelling ? "Selling" : "Buying"} ${produce} in Zimbabwe`,
         "sku": lot.id || slug,
         "category": "Farm Lots",

--- a/apps/client-fnp/app/(landing)/lots/buying/page.tsx
+++ b/apps/client-fnp/app/(landing)/lots/buying/page.tsx
@@ -15,7 +15,7 @@ export const metadata = {
         siteName: "Farmnport",
         title: 'Buying Lots – Farmers Looking to Buy Produce in Zimbabwe | farmnport.com',
         description: 'Browse buying lots from farmers and businesses looking to purchase farm produce across Zimbabwe.',
-        images: [{ url: "/og-image.png", width: 1200, height: 630, alt: "Farmnport Buying Lots" }],
+        images: [{ url: "/api/og", width: 1200, height: 630, alt: "Farmnport Buying Lots" }],
     },
 }
 

--- a/apps/client-fnp/app/(landing)/lots/page.tsx
+++ b/apps/client-fnp/app/(landing)/lots/page.tsx
@@ -20,7 +20,7 @@ export const metadata = {
         description: 'Browse farm produce lots listed by farmers across Zimbabwe. Buy chillies, maize, cattle and more — directly from sellers at listed prices.',
         images: [
             {
-                url: "/og-image.png",
+                url: "/api/og",
                 width: 1200,
                 height: 630,
                 alt: "Farm Produce Lots Zimbabwe – Farmnport",
@@ -31,7 +31,7 @@ export const metadata = {
         card: "summary_large_image",
         title: 'Farm Produce Lots Zimbabwe – Buy & Sell Directly | farmnport.com',
         description: 'Browse farm produce lots listed by farmers across Zimbabwe. Buy chillies, maize, cattle and more — directly from sellers at listed prices.',
-        images: ["/og-image.png"],
+        images: ["/api/og"],
     },
 }
 

--- a/apps/client-fnp/app/(landing)/lots/selling/page.tsx
+++ b/apps/client-fnp/app/(landing)/lots/selling/page.tsx
@@ -15,7 +15,7 @@ export const metadata = {
         siteName: "Farmnport",
         title: 'Selling Lots – Farm Produce for Sale in Zimbabwe | farmnport.com',
         description: 'Browse farm produce lots available for sale across Zimbabwe.',
-        images: [{ url: "/og-image.png", width: 1200, height: 630, alt: "Farmnport Selling Lots" }],
+        images: [{ url: "/api/og", width: 1200, height: 630, alt: "Farmnport Selling Lots" }],
     },
 }
 

--- a/apps/client-fnp/app/(landing)/plant-nutrition-guides/page.tsx
+++ b/apps/client-fnp/app/(landing)/plant-nutrition-guides/page.tsx
@@ -13,13 +13,13 @@ export const metadata = {
     url: 'https://farmnport.com/plant-nutrition-guides',
     siteName: 'farmnport',
     type: 'website',
-    images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
+    images: [{ url: "https://farmnport.com/api/og", width: 1200, height: 630, alt: "farmnport" }],
   },
   twitter: {
     card: "summary_large_image",
     title: "Plant Nutrition Guides Zimbabwe",
     description: "Browse plant nutrition product guides for Zimbabwe farmers. Fertilizers, foliar feeds, biostimulants — application rates and usage guidelines.",
-    images: ["/og-image.png"],
+    images: ["/api/og"],
   },
 }
 

--- a/apps/client-fnp/app/(landing)/sell/[commodity]/page.tsx
+++ b/apps/client-fnp/app/(landing)/sell/[commodity]/page.tsx
@@ -112,7 +112,7 @@ export async function generateMetadata({ params }: Props, _parent: ResolvingMeta
       siteName: "Farmnport",
       title: `${guide.title} | farmnport.com`,
       description: guide.description,
-      images: [{ url: "/og-image.png", width: 1200, height: 630, alt: `Sell ${guide.name} on Farmnport` }],
+      images: [{ url: "/api/og", width: 1200, height: 630, alt: `Sell ${guide.name} on Farmnport` }],
     },
   }
 }

--- a/apps/client-fnp/app/(landing)/sell/page.tsx
+++ b/apps/client-fnp/app/(landing)/sell/page.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
     title: "Sell Your Farm Produce Directly to Buyers | farmnport.com",
     description:
       "List lots, create bookings, and connect directly with buyers across Zimbabwe.",
-    images: [{ url: "/og-image.png", width: 1200, height: 630, alt: "Sell Farm Produce on Farmnport" }],
+    images: [{ url: "/api/og", width: 1200, height: 630, alt: "Sell Farm Produce on Farmnport" }],
   },
 }
 

--- a/apps/client-fnp/app/(landing)/spray-programs/[slug]/layout.tsx
+++ b/apps/client-fnp/app/(landing)/spray-programs/[slug]/layout.tsx
@@ -23,7 +23,7 @@ export async function generateMetadata({ params }: LayoutProps): Promise<Metadat
 
     const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://farmnport.com'
     const url = `${baseUrl}/spray-programs/${slug}`
-    const imageUrl = program.cover_image?.img?.src || `${baseUrl}/og-image.png`
+    const imageUrl = program.cover_image?.img?.src || `${baseUrl}/api/og`
 
     const stageCount = program.stages?.length || 0
     const description = `${program.name} spray program for ${program.farm_produce_name || 'crops'} with ${stageCount} growth stages. View recommended agrochemicals, dosages, and application methods for each stage.`

--- a/apps/client-fnp/app/(landing)/spray-programs/page.tsx
+++ b/apps/client-fnp/app/(landing)/spray-programs/page.tsx
@@ -14,13 +14,13 @@ export const metadata: Metadata = {
         url: "https://farmnport.com/spray-programs",
         siteName: "farmnport",
         type: "website",
-        images: [{ url: "https://farmnport.com/og-image.png", width: 1200, height: 630, alt: "farmnport" }],
+        images: [{ url: "https://farmnport.com/api/og", width: 1200, height: 630, alt: "farmnport" }],
     },
     twitter: {
         card: "summary_large_image",
         title: "Spray Programs Zimbabwe — Crop Protection Schedules",
         description: "Browse spray program schedules for Zimbabwe crops. Step-by-step agrochemical application timings for every growth stage.",
-        images: ["/og-image.png"],
+        images: ["/api/og"],
     },
 }
 

--- a/apps/client-fnp/app/api/og/route.tsx
+++ b/apps/client-fnp/app/api/og/route.tsx
@@ -1,0 +1,35 @@
+import { ImageResponse } from "next/og"
+
+export const runtime = "edge"
+
+export async function GET() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: "#09090b",
+        }}
+      >
+        <div
+          style={{
+            fontSize: 120,
+            fontWeight: 700,
+            color: "#22c55e",
+            letterSpacing: "-3px",
+          }}
+        >
+          fp
+        </div>
+      </div>
+    ),
+    {
+      width: 1200,
+      height: 630,
+    }
+  )
+}

--- a/apps/client-fnp/app/layout.tsx
+++ b/apps/client-fnp/app/layout.tsx
@@ -43,13 +43,13 @@ export const metadata = {
     siteName: 'farmnport',
     locale: 'en_US',
     type: 'website',
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: 'Farmnport — Buy & Sell Farm Produce Directly in Zimbabwe' }],
+    images: [{ url: '/api/og', width: 1200, height: 630, alt: 'Farmnport — Buy & Sell Farm Produce Directly in Zimbabwe' }],
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Farmnport - Buy & Sell Farm Produce Directly in Zimbabwe',
     description: 'Connect farmers and buyers across Zimbabwe. Browse produce prices, find buyers and sellers, and access agrochemical guides.',
-    images: ['/og-image.png'],
+    images: ['/api/og'],
   },
   other: {
     'google-adsense-account': 'ca-pub-9685248262342396'

--- a/apps/client-fnp/lib/utilities.ts
+++ b/apps/client-fnp/lib/utilities.ts
@@ -145,7 +145,7 @@ export function buildGuideMetadata(
 ) {
   const name = formatProductName(product.name)
   const brandInTitle = product.brand?.name ? ` ${formatProductName(product.brand.name)}` : ''
-  const ogImage = imageUrl || '/og-image.png'
+  const ogImage = imageUrl || '/api/og'
   return {
     title: `${name}${brandInTitle} – ${categorySingularTitle} ${titleSuffix} | farmnport.com`,
     description,
@@ -177,7 +177,7 @@ export function buildBuyMetadata(
 ) {
   const name = formatProductName(product.name)
   const brand = product.brand?.name ? ` ${formatProductName(product.brand.name)}` : ''
-  const ogImage = imageUrl || '/og-image.png'
+  const ogImage = imageUrl || '/api/og'
   const description = product.description ||
     `Buy ${name}${brand}. ${category} for ${descriptionContext}. View pricing and order online at farmnport.com.`
   return {

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "7.12.1",
+  "version": "7.13.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- Add frequency dropdown to admin create/edit forms
- Show frequency on public booking page for demand-side bookings
- Hide close_date when null on manage page (fixes "1 Jan 1" bug)
- Add dynamic /api/og route with branded "fp" card (1200x630)
- Replace all static og-image.png with /api/og site-wide
- Fix booking OG title format

## Test plan
- [ ] Verify OG preview on WhatsApp/social
- [ ] Create booking with frequency in admin
- [ ] Check manage page hides close date when null