### PR TITLE
fix: sort search results by relevance score

### DIFF
--- a/apps/client-fnp/app/(landing)/search/SearchResults.tsx
+++ b/apps/client-fnp/app/(landing)/search/SearchResults.tsx
@@ -9,7 +9,7 @@ import { BaseURL } from "@/lib/schemas"
 interface SearchResult {
   collection: string
   found: number
-  hits: { document: Record<string, any> }[]
+  hits: { document: Record<string, any>; score?: number }[]
 }
 
 const COLLECTION_LABELS: Record<string, string> = {
@@ -136,8 +136,9 @@ export function SearchResults() {
     .filter(group => group.collection !== "farm_produce")
     .filter(group => filter === "all" || group.collection === filter)
     .flatMap(group =>
-      (group.hits ?? []).map(hit => ({ collection: group.collection, doc: hit.document }))
+      (group.hits ?? []).map(hit => ({ collection: group.collection, doc: hit.document, score: hit.score ?? 0 }))
     )
+    .sort((a, b) => b.score - a.score)
   const totalFound = results.filter(r => r.collection !== "farm_produce").reduce((sum, r) => sum + r.found, 0)
   const hasMore = results.some(r => r.collection !== "farm_produce" && (filter === "all" || r.collection === filter) && r.found > page * 5)
 

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "7.13.0",
+  "version": "7.14.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- Sort flattened search results by Typesense text match score instead of fixed collection order
- Bump version to 7.14.0