### PR TITLE
Add fee_bearer-aware pricing display

### DIFF
--- a/apps/admin-fnp/app/dashboard/farmnport/orders/bookings/[id]/page.tsx
+++ b/apps/admin-fnp/app/dashboard/farmnport/orders/bookings/[id]/page.tsx
@@ -6,7 +6,7 @@ import { Loader2, CalendarDays, Truck, ArrowLeft, CheckCircle2, Circle } from "l
 import Link from "next/link"
 
 import { queryAdminBooking, updateBookingStatus, confirmPreOrderBooking, rejectPreOrderBooking, markPreOrderReady, markPreOrderCollected } from "@/lib/query"
-import { centsToDollars } from "@/lib/utilities"
+import { centsToDollars, DEFAULT_PLATFORM_FEE_RATE, feePercentLabel } from "@/lib/utilities"
 import { toast } from "@/components/ui/use-toast"
 import { FormSkeleton } from "@/components/state/skeleton-table"
 import { DashboardShell } from "@/components/state/dashboardShell"
@@ -316,8 +316,10 @@ export default function AdminBookingDetailPage({ params }: { params: Promise<{ i
               <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-4">Payment</p>
               {(() => {
                 const subtotal = (booking.pre_order.unit_price ?? 0) * (booking.pre_order.quantity ?? 0)
-                const fee = Math.round(subtotal * 0.069)
-                const total = subtotal + fee
+                const isDemand = booking.pre_order.market_side === "demand"
+                const fee = Math.round(subtotal * DEFAULT_PLATFORM_FEE_RATE)
+                const buyerTotal = isDemand ? subtotal : subtotal + fee
+                const sellerNet = isDemand ? subtotal - fee : subtotal
                 return (
                 <div className="space-y-2 text-sm">
                   <div className="flex justify-between">
@@ -325,17 +327,23 @@ export default function AdminBookingDetailPage({ params }: { params: Promise<{ i
                     <span className="font-medium">{centsToDollars(subtotal)}</span>
                   </div>
                   <div className="flex justify-between">
-                    <span className="text-muted-foreground">Platform Fee (6.9%)</span>
+                    <span className="text-muted-foreground">Platform Fee ({feePercentLabel()}) — {isDemand ? "seller pays" : "buyer pays"}</span>
                     <span className="font-medium">{centsToDollars(fee)}</span>
                   </div>
                   <div className="flex justify-between border-t pt-2 mt-1">
-                    <span className="font-semibold">Total</span>
-                    <span className="font-bold">{centsToDollars(total)}</span>
+                    <span className="font-semibold">Buyer Pays</span>
+                    <span className="font-bold">{centsToDollars(buyerTotal)}</span>
+                  </div>
+                  <div className="flex justify-between">
+                    <span className="font-semibold">Seller Receives</span>
+                    <span className="font-bold">{centsToDollars(sellerNet)}</span>
                   </div>
                   <div className="flex justify-between">
                     <span className="text-muted-foreground">Payment Status</span>
                     <span className={`font-medium ${booking.pre_order.deposit_paid ? "text-green-700" : "text-red-600"}`}>
-                      {booking.pre_order.deposit_paid ? "Paid" : "Not yet paid"}
+                      {booking.pre_order.deposit_paid
+                        ? booking.payment_method === "cash" ? "Paid (Cash)" : "Paid (Online)"
+                        : "Not yet paid"}
                     </span>
                   </div>
                   {booking.pre_order.deposit_paid && (() => {

--- a/apps/admin-fnp/lib/query.ts
+++ b/apps/admin-fnp/lib/query.ts
@@ -1689,6 +1689,7 @@ export function updatePreOrder(id: string, data: Partial<{
   breed_id: string
   breed_name: string
   unit: string
+  frequency: string
   name: string
   status: string
   total_available: number

--- a/apps/admin-fnp/lib/query.ts
+++ b/apps/admin-fnp/lib/query.ts
@@ -1654,6 +1654,7 @@ export function createPreOrder(data: {
   breed_id?: string
   breed_name?: string
   unit?: string
+  frequency?: string
   name?: string
   unit_price: number
   deposit_per_unit: number

--- a/apps/admin-fnp/lib/utilities.ts
+++ b/apps/admin-fnp/lib/utilities.ts
@@ -80,6 +80,12 @@ export function dollarsToCents(dollars: number) {
   return Math.round(100 * dollars)
 }
 
+export const DEFAULT_PLATFORM_FEE_RATE = 0.069
+
+export function feePercentLabel(rate = DEFAULT_PLATFORM_FEE_RATE): string {
+  return `${(rate * 100).toFixed(1)}%`
+}
+
 export function createPriceListDefaultValues(priceList: ProducerPriceList) {
   return {
     defaultValues: {

--- a/apps/client-fnp/app/(landing)/account/(sections)/bookings/[ref]/page.tsx
+++ b/apps/client-fnp/app/(landing)/account/(sections)/bookings/[ref]/page.tsx
@@ -8,7 +8,7 @@ import Link from "next/link"
 import { toast } from "sonner"
 
 import { getBooking, cancelBooking, initiatePreOrderPayment, pollPreOrderPayment, respondToBooking } from "@/lib/query"
-import { centsToDollars, plural } from "@/lib/utilities"
+import { centsToDollars, plural, DEFAULT_PLATFORM_FEE_RATE, feePercentLabel } from "@/lib/utilities"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog"
 
 const STATUS_STYLES: Record<string, string> = {
@@ -180,8 +180,10 @@ export default function BookingDetailPage({ params }: { params: Promise<{ ref: s
 
         {/* Pay Now banner for confirmed bookings */}
         {canPay && (() => {
+          const sellerPaysFee = booking.pre_order?.market_side === "demand"
           const subtotal = booking.pre_order.deposit_amount / 100
-          const fee = Math.round(booking.pre_order.deposit_amount * 0.069) / 100
+          const rate = DEFAULT_PLATFORM_FEE_RATE
+          const fee = sellerPaysFee ? 0 : Math.round(booking.pre_order.deposit_amount * rate) / 100
           const total = subtotal + fee
           return (
           <div className="border border-orange-200 bg-orange-50 rounded-xl p-5 space-y-3">
@@ -204,10 +206,12 @@ export default function BookingDetailPage({ params }: { params: Promise<{ ref: s
                 <span className="text-orange-700">Subtotal</span>
                 <span className="font-medium">${subtotal.toFixed(2)}</span>
               </div>
+              {!sellerPaysFee && (
               <div className="flex justify-between">
-                <span className="text-orange-700">Platform fee (6.9%)</span>
+                <span className="text-orange-700">Platform fee ({feePercentLabel(rate)})</span>
                 <span className="font-medium">${fee.toFixed(2)}</span>
               </div>
+              )}
               <div className="flex justify-between border-t pt-1">
                 <span className="font-semibold text-orange-900">Total</span>
                 <span className="font-bold text-orange-900">${total.toFixed(2)}</span>
@@ -337,8 +341,14 @@ export default function BookingDetailPage({ params }: { params: Promise<{ ref: s
                 {booking.pre_order.unit_price > 0 && (
                 <div>
                   <p className="text-muted-foreground text-xs mb-0.5">Unit Price</p>
-                  <p className="font-medium">${(booking.pre_order.unit_price / 100 * 1.069).toFixed(2)}</p>
-                  <p className="text-xs text-muted-foreground">incl. fees</p>
+                  {booking.pre_order.market_side === "demand" ? (
+                    <p className="font-medium">{centsToDollars(booking.pre_order.unit_price)}</p>
+                  ) : (
+                    <>
+                      <p className="font-medium">${(booking.pre_order.unit_price / 100 * (1 + DEFAULT_PLATFORM_FEE_RATE)).toFixed(2)}</p>
+                      <p className="text-xs text-muted-foreground">incl. fees</p>
+                    </>
+                  )}
                 </div>
                 )}
               </div>
@@ -377,19 +387,30 @@ export default function BookingDetailPage({ params }: { params: Promise<{ ref: s
                 </div>
               )}
 
-              {booking.pre_order.unit_price > 0 && <div className="border-t pt-3 grid grid-cols-2 gap-3 text-sm">
+              {booking.pre_order.unit_price > 0 && (() => {
+                const isDemand = booking.pre_order.market_side === "demand"
+                const depositCents = booking.pre_order.deposit_amount
+                const feeCents = isDemand ? 0 : Math.round(depositCents * DEFAULT_PLATFORM_FEE_RATE)
+                const totalCents = depositCents + feeCents
+                return <div className="border-t pt-3 grid grid-cols-2 gap-3 text-sm">
                 <div>
                   <p className="text-muted-foreground text-xs mb-0.5">Subtotal</p>
-                  <p className="font-medium">${(booking.pre_order.deposit_amount / 100).toFixed(2)}</p>
+                  <p className="font-medium">{centsToDollars(depositCents)}</p>
                 </div>
+                {!isDemand && (
                 <div>
-                  <p className="text-muted-foreground text-xs mb-0.5">Platform Fee (6.9%)</p>
-                  <p className="font-medium">${(Math.round(booking.pre_order.deposit_amount * 0.069) / 100).toFixed(2)}</p>
+                  <p className="text-muted-foreground text-xs mb-0.5">Platform Fee ({feePercentLabel()})</p>
+                  <p className="font-medium">{centsToDollars(feeCents)}</p>
                 </div>
+                )}
                 <div>
                   <p className="text-muted-foreground text-xs mb-0.5">Total Due</p>
-                  <p className="font-bold text-orange-700">${(Math.round(booking.pre_order.deposit_amount * 1.069) / 100).toFixed(2)}</p>
-                  <p className="text-xs text-muted-foreground">{booking.pre_order.deposit_paid ? "Paid" : "Not yet paid"}</p>
+                  <p className="font-bold text-orange-700">{centsToDollars(totalCents)}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {booking.pre_order.deposit_paid
+                      ? booking.payment_method === "cash" ? "Paid (Cash)" : "Paid (Online)"
+                      : "Not yet paid"}
+                  </p>
                 </div>
                 {booking.pre_order.balance_due > 0 && (
                   <div>
@@ -397,7 +418,8 @@ export default function BookingDetailPage({ params }: { params: Promise<{ ref: s
                     <p className="font-bold">${(booking.pre_order.balance_due / 100).toFixed(2)}</p>
                   </div>
                 )}
-              </div>}
+              </div>
+              })()}
             </div>
           )}
 

--- a/apps/client-fnp/app/(landing)/account/(sections)/incoming-bookings/[ref]/page.tsx
+++ b/apps/client-fnp/app/(landing)/account/(sections)/incoming-bookings/[ref]/page.tsx
@@ -9,7 +9,7 @@ import Link from "next/link"
 import { toast } from "sonner"
 
 import { getIncomingBooking, buyerUpdateBookingStatus, clientConfirmBooking, clientRejectBooking, clientCashPayment, clientMarkReady, clientMarkCollected, respondToBooking } from "@/lib/query"
-import { centsToDollars, platformFee, withPlatformFee, plural } from "@/lib/utilities"
+import { centsToDollars, platformFee, withPlatformFee, plural, DEFAULT_PLATFORM_FEE_RATE, feePercentLabel } from "@/lib/utilities"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog"
 
 const STATUS_STYLES: Record<string, string> = {
@@ -129,6 +129,7 @@ export default function IncomingBookingDetailPage({ params }: { params: Promise<
   const qc = useQueryClient()
   const [note, setNote] = useState("")
   const [cancelOpen, setCancelOpen] = useState(false)
+  const [cashOpen, setCashOpen] = useState(false)
   const [cancelReason, setCancelReason] = useState("")
   const [confirmOpen, setConfirmOpen] = useState(false)
   const [confirmInput, setConfirmInput] = useState("")
@@ -193,7 +194,7 @@ export default function IncomingBookingDetailPage({ params }: { params: Promise<
 
   const cashPaymentMutation = useMutation({
     mutationFn: () => clientCashPayment(id),
-    onSuccess: () => { toast.success("Cash payment recorded — marked ready for collection"); invalidate() },
+    onSuccess: () => { toast.success("Cash on delivery confirmed — marked ready for collection"); invalidate() },
     onError: (err: any) => toast.error(err?.response?.data?.message || "Failed to update"),
   })
 
@@ -323,38 +324,81 @@ export default function IncomingBookingDetailPage({ params }: { params: Promise<
                   <span className="font-medium">{centsToDollars(booking.pre_order.offer_price)} per {plural(booking.pre_order.unit || "unit", 1)}</span>
                 </div>
                 )}
-                {booking.pre_order.unit_price > 0 && (
-                <>
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Unit Price</span>
-                  <span className="font-medium">{centsToDollars(booking.pre_order.unit_price)}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Platform Fee (6.9%)</span>
-                  <span className="font-medium">{centsToDollars(platformFee(booking.pre_order.unit_price))}</span>
-                </div>
-                <div className="flex justify-between border-t pt-2">
-                  <span className="font-semibold">Total Unit Price</span>
-                  <span className="font-bold">{centsToDollars(withPlatformFee(booking.pre_order.unit_price))}</span>
-                </div>
-                <div className="border-t pt-2 mt-2 flex justify-between">
-                  <span className="text-muted-foreground">Subtotal</span>
-                  <span className="font-medium">{centsToDollars(booking.pre_order.deposit_amount)}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Platform Fee (6.9%)</span>
-                  <span className="font-medium">{centsToDollars(platformFee(booking.pre_order.deposit_amount))}</span>
-                </div>
-                <div className="flex justify-between border-t pt-2">
-                  <span className="font-semibold">Total Due</span>
-                  <span className="font-bold">{centsToDollars(withPlatformFee(booking.pre_order.deposit_amount))}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">Payment</span>
-                  <span className={`font-medium ${booking.pre_order.deposit_paid ? "text-green-700" : "text-red-600"}`}>{booking.pre_order.deposit_paid ? "Paid" : "Not yet paid"}</span>
-                </div>
-                </>
-                )}
+                {booking.pre_order.unit_price > 0 && (() => {
+                  const isDemand = booking.pre_order.market_side === "demand"
+                  const feePct = feePercentLabel()
+                  return (
+                  <>
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">Unit Price</span>
+                    <span className="font-medium">{centsToDollars(booking.pre_order.unit_price)}</span>
+                  </div>
+                  {isDemand ? (
+                    <>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Platform Fee ({feePct})</span>
+                      <span className="font-medium text-red-600">-{centsToDollars(platformFee(booking.pre_order.unit_price))}</span>
+                    </div>
+                    <div className="flex justify-between border-t pt-2">
+                      <span className="font-semibold">You Receive per Unit</span>
+                      <span className="font-bold">{centsToDollars(booking.pre_order.unit_price - platformFee(booking.pre_order.unit_price))}</span>
+                    </div>
+                    <div className="border-t pt-2 mt-2 flex justify-between">
+                      <span className="text-muted-foreground">Order Total</span>
+                      <span className="font-medium">{centsToDollars(booking.pre_order.deposit_amount)}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Platform Fee ({feePct})</span>
+                      <span className="font-medium text-red-600">-{centsToDollars(platformFee(booking.pre_order.deposit_amount))}</span>
+                    </div>
+                    <div className="flex justify-between border-t pt-2">
+                      <span className="font-semibold">You Receive</span>
+                      <span className="font-bold">{centsToDollars(booking.pre_order.deposit_amount - platformFee(booking.pre_order.deposit_amount))}</span>
+                    </div>
+                    </>
+                  ) : (
+                    <>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Platform Fee ({feePct})</span>
+                      <span className="font-medium">{centsToDollars(platformFee(booking.pre_order.unit_price))}</span>
+                    </div>
+                    <div className="flex justify-between border-t pt-2">
+                      <span className="font-semibold">Total Unit Price</span>
+                      <span className="font-bold">{centsToDollars(withPlatformFee(booking.pre_order.unit_price))}</span>
+                    </div>
+                    <div className="border-t pt-2 mt-2 flex justify-between">
+                      <span className="text-muted-foreground">Subtotal</span>
+                      <span className="font-medium">{centsToDollars(booking.pre_order.deposit_amount)}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Platform Fee ({feePct})</span>
+                      <span className="font-medium">{centsToDollars(platformFee(booking.pre_order.deposit_amount))}</span>
+                    </div>
+                    <div className="flex justify-between border-t pt-2">
+                      <span className="font-semibold">Total Due</span>
+                      <span className="font-bold">{centsToDollars(withPlatformFee(booking.pre_order.deposit_amount))}</span>
+                    </div>
+                    </>
+                  )}
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">Payment</span>
+                    <span className={`font-medium ${booking.pre_order.deposit_paid ? "text-green-700" : "text-red-600"}`}>
+                      {booking.pre_order.deposit_paid
+                        ? booking.payment_method === "cash" ? "Paid (Cash)" : "Paid (Online)"
+                        : "Not yet paid"}
+                    </span>
+                  </div>
+                  {booking.payment_method === "cash" && booking.pre_order.deposit_paid && (
+                    <div className="flex justify-between border-t pt-2 mt-1">
+                      <span className="text-muted-foreground">Platform fee owed to farmnport</span>
+                      <span className="font-medium text-orange-700">
+                        {centsToDollars(platformFee(booking.pre_order.deposit_amount))}
+                      </span>
+                    </div>
+                  )}
+                  </>
+                  )
+                })()}
               </div>
               {booking.pre_order.buyer_notes && (
                 <div className="mt-4 pt-4 border-t">
@@ -431,11 +475,10 @@ export default function IncomingBookingDetailPage({ params }: { params: Promise<
               {["confirmed", "pending_payment"].includes(booking.status) && (
                 <>
                   <button
-                    onClick={() => cashPaymentMutation.mutate()}
-                    disabled={cashPaymentMutation.isPending}
+                    onClick={() => setCashOpen(true)}
                     className="w-full py-2 rounded-lg text-sm font-medium transition-colors disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90"
                   >
-                    {cashPaymentMutation.isPending ? <Loader2 className="w-4 h-4 animate-spin mx-auto" /> : "Cash Payment"}
+                    Cash on Delivery
                   </button>
                   <p className="text-xs text-muted-foreground text-center">Online payments coming soon</p>
                 </>
@@ -595,6 +638,72 @@ export default function IncomingBookingDetailPage({ params }: { params: Promise<
               {(rejectMutation.isPending || cancelMutation.isPending)
                 ? <Loader2 className="w-4 h-4 animate-spin" />
                 : booking.status === "pending" ? "Reject" : "Cancel Booking"}
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Cash payment confirmation dialog */}
+      <Dialog open={cashOpen} onOpenChange={setCashOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Confirm Cash on Delivery</DialogTitle>
+          </DialogHeader>
+          {booking.pre_order && (() => {
+            const isDemand = booking.pre_order.market_side === "demand"
+            const depositCents = booking.pre_order.deposit_amount
+            const unitPriceCents = booking.pre_order.unit_price
+            const qty = booking.pre_order.quantity
+            const totalCents = unitPriceCents > 0 ? unitPriceCents * qty : depositCents
+            const feeCents = platformFee(totalCents)
+            const netCents = totalCents - feeCents
+            return (
+            <div className="space-y-4">
+              <p className="text-sm text-muted-foreground">
+                {isDemand
+                  ? "The supplier will be paid in cash on delivery/collection. The platform fee will be invoiced to you separately."
+                  : "The buyer will pay you in cash on delivery/collection. This marks the order as ready."}
+              </p>
+              <div className="bg-muted/50 rounded-lg p-4 text-sm space-y-2">
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">{isDemand ? "Supplier receives" : "You receive from buyer"}</span>
+                  <span className="font-semibold">{centsToDollars(totalCents)}</span>
+                </div>
+                {isDemand ? (
+                  <>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Platform fee ({feePercentLabel()}) — owed to farmnport</span>
+                      <span className="font-medium text-red-600">{centsToDollars(feeCents)}</span>
+                    </div>
+                    <p className="text-xs text-muted-foreground">This fee will be invoiced to you by farmnport after collection.</p>
+                  </>
+                ) : (
+                  <>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">Platform fee ({feePercentLabel()}) — owed to farmnport</span>
+                      <span className="font-medium text-red-600">-{centsToDollars(feeCents)}</span>
+                    </div>
+                    <div className="flex justify-between border-t pt-2">
+                      <span className="font-semibold">You keep</span>
+                      <span className="font-bold">{centsToDollars(netCents)}</span>
+                    </div>
+                    <p className="text-xs text-muted-foreground">The platform fee of {centsToDollars(feeCents)} will be invoiced to you by farmnport after collection.</p>
+                  </>
+                )}
+              </div>
+            </div>
+            )
+          })()}
+          <DialogFooter>
+            <button onClick={() => setCashOpen(false)} className="px-4 py-2 text-sm rounded-lg border hover:bg-muted transition-colors">
+              Go back
+            </button>
+            <button
+              onClick={() => cashPaymentMutation.mutate(undefined, { onSuccess: () => setCashOpen(false) })}
+              disabled={cashPaymentMutation.isPending}
+              className="px-4 py-2 text-sm rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
+            >
+              {cashPaymentMutation.isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : "Confirm Cash on Delivery"}
             </button>
           </DialogFooter>
         </DialogContent>

--- a/apps/client-fnp/app/(landing)/bookings/BookingsClient.tsx
+++ b/apps/client-fnp/app/(landing)/bookings/BookingsClient.tsx
@@ -6,6 +6,7 @@ import { driver } from "driver.js"
 import "driver.js/dist/driver.css"
 
 import { ProductSidebarNav } from "@/components/generic/ProductSidebarNav"
+import { DEFAULT_PLATFORM_FEE_RATE } from "@/lib/utilities"
 
 function formatDate(d: string) {
   return new Date(d).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" })
@@ -39,7 +40,7 @@ function EventCard({ event }: { event: any }) {
           {event.unit_price > 0 && (
           <div className="flex justify-between">
             <span>Unit price</span>
-            <span className="font-semibold text-foreground">${(event.unit_price / 100 * 1.069).toFixed(2)}</span>
+            <span className="font-semibold text-foreground">${(event.unit_price / 100 * (event.fee_bearer === "seller" ? 1 : 1 + (event.platform_fee_rate || DEFAULT_PLATFORM_FEE_RATE))).toFixed(2)}</span>
           </div>
           )}
           {event.deposit_per_unit > 0 && (

--- a/apps/client-fnp/app/(landing)/bookings/[slug]/PreOrderDetailClient.tsx
+++ b/apps/client-fnp/app/(landing)/bookings/[slug]/PreOrderDetailClient.tsx
@@ -11,7 +11,7 @@ import { driver } from "driver.js"
 import "driver.js/dist/driver.css"
 
 import { createBooking, queryClient as queryClientProfile, queryClientMe } from "@/lib/query"
-import { plural, titleCase } from "@/lib/utilities"
+import { plural, titleCase, centsToDollars, DEFAULT_PLATFORM_FEE_RATE, feePercentLabel } from "@/lib/utilities"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { ShareBar } from "@/components/shared/ShareBar"
 import { ProductImageGallery } from "@/components/shared/ProductImageGallery"
@@ -270,8 +270,17 @@ export default function PreOrderDetailPage({ preorder, depositEnabled = false }:
               {event.unit_price > 0 ? (
               <div className="rounded-xl border bg-muted/30 p-4">
                 <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">Unit Price</p>
-                <p className="text-2xl font-bold">${(event.unit_price / 100 * 1.069).toFixed(2)}</p>
-                <p className="text-xs text-muted-foreground mt-1">per {event.unit || "unit"} incl. fees</p>
+                {event.fee_bearer === "seller" ? (
+                  <>
+                    <p className="text-2xl font-bold">{centsToDollars(event.unit_price)}</p>
+                    <p className="text-xs text-muted-foreground mt-1">per {event.unit || "unit"}</p>
+                  </>
+                ) : (
+                  <>
+                    <p className="text-2xl font-bold">${(event.unit_price / 100 * (1 + (event.platform_fee_rate || DEFAULT_PLATFORM_FEE_RATE))).toFixed(2)}</p>
+                    <p className="text-xs text-muted-foreground mt-1">per {event.unit || "unit"} incl. fees</p>
+                  </>
+                )}
               </div>
               ) : (
               <div className="rounded-xl border bg-muted/30 p-4">
@@ -555,7 +564,11 @@ export default function PreOrderDetailPage({ preorder, depositEnabled = false }:
                   </div>
                 )}
 
-                {qty >= minQty && event.unit_price > 0 && (
+                {qty >= minQty && event.unit_price > 0 && (() => {
+                  const rate = event.platform_fee_rate || DEFAULT_PLATFORM_FEE_RATE
+                  const feePct = feePercentLabel(rate)
+                  const sellerPaysFee = event.fee_bearer === "seller"
+                  return (
                   <div className="bg-muted/50 rounded-lg p-3 text-sm space-y-1.5">
                     <div className="flex justify-between">
                       <span className="text-muted-foreground">Order total ({qty.toLocaleString()} units)</span>
@@ -572,20 +585,32 @@ export default function PreOrderDetailPage({ preorder, depositEnabled = false }:
                           <span className="font-medium">${balanceDue.toFixed(2)}</span>
                         </div>
                       </>
+                    ) : sellerPaysFee ? (
+                      <>
+                        <div className="flex justify-between">
+                          <span className="text-muted-foreground">Platform fee ({feePct})</span>
+                          <span className="font-medium">-${(orderTotal * rate).toFixed(2)}</span>
+                        </div>
+                        <div className="flex justify-between border-t pt-1.5">
+                          <span className="font-semibold">You receive</span>
+                          <span className="font-bold">${(orderTotal * (1 - rate)).toFixed(2)}</span>
+                        </div>
+                      </>
                     ) : (
                       <>
                         <div className="flex justify-between">
-                          <span className="text-muted-foreground">Platform fee (6.9%)</span>
-                          <span className="font-medium">${(orderTotal * 0.069).toFixed(2)}</span>
+                          <span className="text-muted-foreground">Platform fee ({feePct})</span>
+                          <span className="font-medium">${(orderTotal * rate).toFixed(2)}</span>
                         </div>
                         <div className="flex justify-between border-t pt-1.5">
                           <span className="font-semibold">Total</span>
-                          <span className="font-bold">${(orderTotal * 1.069).toFixed(2)}</span>
+                          <span className="font-bold">${(orderTotal * (1 + rate)).toFixed(2)}</span>
                         </div>
                       </>
                     )}
                   </div>
-                )}
+                  )
+                })()}
 
                 <button
                   id="booking-submit"

--- a/apps/client-fnp/app/(landing)/lots/[slug]/page.tsx
+++ b/apps/client-fnp/app/(landing)/lots/[slug]/page.tsx
@@ -7,7 +7,7 @@ import { PlaceBidForm } from "@/components/forms/place-bid"
 import { LotBidsPanel } from "@/components/layouts/lot-bids-panel"
 import { fetchLot, fetchLotBids, fetchMyBidOnLot } from "@/lib/serverFetch"
 import { retrieveUser } from "@/lib/actions"
-import { capitalizeFirstLetter, formatDate, centsToDollars } from "@/lib/utilities"
+import { capitalizeFirstLetter, formatDate, centsToDollars, DEFAULT_PLATFORM_FEE_RATE } from "@/lib/utilities"
 import { PayBidButton } from "@/components/ui/pay-bid-button"
 import { ShareBar } from "@/components/shared/ShareBar"
 import { AppURL } from "@/lib/schemas"
@@ -30,7 +30,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     const province = lot.province ? `, ${capitalizeFirstLetter(lot.province)}` : ""
 
     const title = `${typeLabel}: ${produce}${breed}${province} | farmnport.com`
-    const description = `${typeLabel} ${produce}${breed} in Zimbabwe. ${lot.quantity.toLocaleString()} ${lot.unit} available at ${centsToDollars(Math.round(lot.price_per_unit_cents * 1.069))}/${lot.unit}. ${lot.notes ?? ""}`
+    const feeMultiplier = lot.fee_bearer === "seller" ? 1 : 1 + (lot.platform_fee_rate || DEFAULT_PLATFORM_FEE_RATE)
+    const description = `${typeLabel} ${produce}${breed} in Zimbabwe. ${lot.quantity.toLocaleString()} ${lot.unit} available at ${centsToDollars(Math.round(lot.price_per_unit_cents * feeMultiplier))}/${lot.unit}. ${lot.notes ?? ""}`
 
     return {
         title,
@@ -172,8 +173,17 @@ export default async function LotDetailPage({ params }: Props) {
                                 <div className="grid grid-cols-3 gap-3">
                                     <div className="rounded-xl border bg-card p-4">
                                         <p className="text-xs text-muted-foreground mb-1">Listed price</p>
-                                        <p className="text-2xl font-bold">{centsToDollars(Math.round(lot.price_per_unit_cents * 1.069))}</p>
-                                        <p className="text-xs text-muted-foreground mt-0.5">per {lot.unit} incl. fees</p>
+                                        {lot.fee_bearer === "seller" ? (
+                                          <>
+                                            <p className="text-2xl font-bold">{centsToDollars(lot.price_per_unit_cents)}</p>
+                                            <p className="text-xs text-muted-foreground mt-0.5">per {lot.unit}</p>
+                                          </>
+                                        ) : (
+                                          <>
+                                            <p className="text-2xl font-bold">{centsToDollars(Math.round(lot.price_per_unit_cents * (1 + (lot.platform_fee_rate || DEFAULT_PLATFORM_FEE_RATE))))}</p>
+                                            <p className="text-xs text-muted-foreground mt-0.5">per {lot.unit} incl. fees</p>
+                                          </>
+                                        )}
                                     </div>
                                     <div className="rounded-xl border bg-card p-4">
                                         <p className="text-xs text-muted-foreground mb-1">Quantity</p>

--- a/apps/client-fnp/components/structures/client-activity.tsx
+++ b/apps/client-fnp/components/structures/client-activity.tsx
@@ -5,7 +5,7 @@ import Link from "next/link"
 import { useQuery } from "@tanstack/react-query"
 import { ChevronLeft, ChevronRight, ArrowRight } from "lucide-react"
 import { queryLots, listPreOrders } from "@/lib/query"
-import { centsToDollars } from "@/lib/utilities"
+import { centsToDollars, DEFAULT_PLATFORM_FEE_RATE } from "@/lib/utilities"
 
 function formatDate(d: string) {
   return new Date(d).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" })
@@ -63,7 +63,7 @@ function PreOrderCard({ event }: { event: any }) {
           {event.unit_price > 0 && (
             <div className="flex justify-between">
               <span>{event.market_side === "demand" ? "Buying at" : "Price"}</span>
-              <span className="font-semibold text-foreground">${(event.unit_price / 100 * 1.069).toFixed(2)}</span>
+              <span className="font-semibold text-foreground">${(event.unit_price / 100 * (event.fee_bearer === "seller" ? 1 : 1 + (event.platform_fee_rate || DEFAULT_PLATFORM_FEE_RATE))).toFixed(2)}</span>
             </div>
           )}
           <div className="flex justify-between">

--- a/apps/client-fnp/lib/utilities.ts
+++ b/apps/client-fnp/lib/utilities.ts
@@ -78,22 +78,26 @@ export function centsToDollars(cents: number): string {
   return `$${dollars.toFixed(2)}`
 }
 
-const PLATFORM_FEE_RATE = 0.069
+export const DEFAULT_PLATFORM_FEE_RATE = 0.069
 
-export function platformFee(cents: number): number {
-  return Math.round(cents * PLATFORM_FEE_RATE)
+export function platformFee(cents: number, rate = DEFAULT_PLATFORM_FEE_RATE): number {
+  return Math.round(cents * rate)
 }
 
-export function withPlatformFee(cents: number): number {
-  return cents + platformFee(cents)
+export function withPlatformFee(cents: number, rate = DEFAULT_PLATFORM_FEE_RATE): number {
+  return cents + platformFee(cents, rate)
 }
 
-export function platformFeeDisplay(cents: number): string {
-  return centsToDollars(platformFee(cents))
+export function platformFeeDisplay(cents: number, rate = DEFAULT_PLATFORM_FEE_RATE): string {
+  return centsToDollars(platformFee(cents, rate))
 }
 
-export function withPlatformFeeDisplay(cents: number): string {
-  return centsToDollars(withPlatformFee(cents))
+export function withPlatformFeeDisplay(cents: number, rate = DEFAULT_PLATFORM_FEE_RATE): string {
+  return centsToDollars(withPlatformFee(cents, rate))
+}
+
+export function feePercentLabel(rate = DEFAULT_PLATFORM_FEE_RATE): string {
+  return `${(rate * 100).toFixed(1)}%`
 }
 
 export function titleCase(str?: string): string {

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "7.14.0",
+  "version": "7.15.0",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- Remove hardcoded 0.069 fee rate, use DEFAULT_PLATFORM_FEE_RATE constant
- Show base price for demand bookings (seller pays fee), price+fee for supply
- Cash on delivery confirmation dialog with fee breakdown
- Payment status shows Paid (Cash) vs Paid (Online)
- Admin view shows Buyer Pays / Seller Receives breakdown