### PR TITLE
fix: counter-offer waiting labels + booking email improvements

### DIFF
--- a/apps/client-fnp/app/(landing)/account/(sections)/bookings/[ref]/page.tsx
+++ b/apps/client-fnp/app/(landing)/account/(sections)/bookings/[ref]/page.tsx
@@ -355,10 +355,10 @@ export default function BookingDetailPage({ params }: { params: Promise<{ ref: s
           </div>
         )}
 
-        {/* Waiting for seller response */}
+        {/* Waiting for other party to respond */}
         {booking.status === "countered" && booking.countered_by === "buyer" && (
           <div className="border border-purple-200 bg-purple-50 rounded-xl p-4">
-            <p className="text-sm text-purple-700">Waiting for the seller to respond to your counter-offer.</p>
+            <p className="text-sm text-purple-700">Waiting for the {isDemand ? "buyer" : "seller"} to respond to your counter-offer.</p>
           </div>
         )}
 

--- a/apps/client-fnp/app/(landing)/account/(sections)/incoming-bookings/[ref]/page.tsx
+++ b/apps/client-fnp/app/(landing)/account/(sections)/incoming-bookings/[ref]/page.tsx
@@ -459,7 +459,7 @@ export default function IncomingBookingDetailPage({ params }: { params: Promise<
               )}
 
               {booking.status === "countered" && booking.countered_by === "seller" && (
-                <p className="text-sm text-muted-foreground text-center">Waiting for the buyer to respond to your counter-offer.</p>
+                <p className="text-sm text-muted-foreground text-center">Waiting for the {booking.pre_order?.market_side === "demand" ? "supplier" : "buyer"} to respond to your counter-offer.</p>
               )}
 
               {/* Supply: event owner is seller → Mark Ready / Mark Collected / wait for buyer */}

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "7.17.0",
+  "version": "7.17.1",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- Counter-offer waiting messages use market_side for correct buyer/seller/supplier labels
- Booking email improvements from previous PR