### PR TITLE
fix: scroll to top on agrochemical filter selection

### DIFF
--- a/apps/client-fnp/components/generic/agroChemicalFilterSidebar.tsx
+++ b/apps/client-fnp/components/generic/agroChemicalFilterSidebar.tsx
@@ -160,6 +160,7 @@ function FilterContent({
   }, [aggregateData])
 
   const handleToggle = (filterKey: string, value: string) => {
+    window.scrollTo({ top: 0, behavior: 'smooth' })
     if (filterKey === 'used_on') {
       const isDeselecting = queryState.used_on === value
       sendGTMEvent({ event: 'filter', value: `${isDeselecting ? 'Remove' : 'Add'}UsedOnFilter` })

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "7.18.0",
+  "version": "7.18.1",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- Scroll to top smoothly when any filter is toggled in the agrochemical guides sidebar

## Test plan
- [ ] Select a brand/target/ingredient filter — page scrolls to top