### PR TITLE
fix: scroll to top on pagination across all listing pages

### DIFF
--- a/apps/client-fnp/app/(landing)/agrochemical-guides/AllAgroChemicalsClient.tsx
+++ b/apps/client-fnp/app/(landing)/agrochemical-guides/AllAgroChemicalsClient.tsx
@@ -52,6 +52,7 @@ export function AllAgroChemicalsClient({ initialChemicals, initialTotal }: AllAg
 
     const handlePageChange = (newPage: number) => {
         setQueryState({ p: newPage })
+        window.scrollTo({ top: 0, behavior: 'smooth' })
     }
 
     return (

--- a/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/AgroCategoryClient.tsx
+++ b/apps/client-fnp/app/(landing)/agrochemical-guides/[category]/AgroCategoryClient.tsx
@@ -51,6 +51,7 @@ export function AgroCategoryClient({ category, categoryName, initialChemicals, i
 
     const handlePageChange = (newPage: number) => {
         setQueryState({ p: newPage })
+        window.scrollTo({ top: 0, behavior: 'smooth' })
     }
 
     return (

--- a/apps/client-fnp/app/(landing)/animal-health-guides/AllAnimalHealthClient.tsx
+++ b/apps/client-fnp/app/(landing)/animal-health-guides/AllAnimalHealthClient.tsx
@@ -50,6 +50,7 @@ export function AllAnimalHealthClient({ initialProducts, initialTotal }: AllAnim
 
     const handlePageChange = (newPage: number) => {
         setQueryState({ p: newPage })
+        window.scrollTo({ top: 0, behavior: 'smooth' })
     }
 
     return (

--- a/apps/client-fnp/app/(landing)/animal-health-guides/[category]/AnimalHealthCategoryClient.tsx
+++ b/apps/client-fnp/app/(landing)/animal-health-guides/[category]/AnimalHealthCategoryClient.tsx
@@ -54,6 +54,7 @@ export function AnimalHealthCategoryClient({ category, categoryName, initialProd
 
     const handlePageChange = (newPage: number) => {
         setQueryState({ p: newPage })
+        window.scrollTo({ top: 0, behavior: 'smooth' })
     }
 
     return (

--- a/apps/client-fnp/app/(landing)/equipment-guides/AllEquipmentClient.tsx
+++ b/apps/client-fnp/app/(landing)/equipment-guides/AllEquipmentClient.tsx
@@ -39,6 +39,7 @@ export function AllEquipmentClient({ initialProducts, initialTotal }: AllEquipme
 
     const handlePageChange = (newPage: number) => {
         setQueryState({ p: newPage })
+        window.scrollTo({ top: 0, behavior: 'smooth' })
     }
 
     return (

--- a/apps/client-fnp/app/(landing)/equipment-guides/[category]/EquipmentCategoryClient.tsx
+++ b/apps/client-fnp/app/(landing)/equipment-guides/[category]/EquipmentCategoryClient.tsx
@@ -43,6 +43,7 @@ export function EquipmentCategoryClient({ category, categoryName, initialProduct
 
     const handlePageChange = (newPage: number) => {
         setQueryState({ p: newPage })
+        window.scrollTo({ top: 0, behavior: 'smooth' })
     }
 
     return (

--- a/apps/client-fnp/app/(landing)/plant-nutrition-guides/AllPlantNutritionClient.tsx
+++ b/apps/client-fnp/app/(landing)/plant-nutrition-guides/AllPlantNutritionClient.tsx
@@ -49,6 +49,7 @@ export function AllPlantNutritionClient({ initialProducts, initialTotal }: AllPl
 
     const handlePageChange = (newPage: number) => {
         setQueryState({ p: newPage })
+        window.scrollTo({ top: 0, behavior: 'smooth' })
     }
 
     return (

--- a/apps/client-fnp/app/(landing)/seed-guides/AllSeedGuidesClient.tsx
+++ b/apps/client-fnp/app/(landing)/seed-guides/AllSeedGuidesClient.tsx
@@ -39,6 +39,7 @@ export function AllSeedGuidesClient({ initialProducts, initialTotal }: AllSeedGu
 
     const handlePageChange = (newPage: number) => {
         setQueryState({ p: newPage })
+        window.scrollTo({ top: 0, behavior: 'smooth' })
     }
 
     return (

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "7.18.1",
+  "version": "7.18.2",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- Added smooth scroll-to-top on page change across all 14 listing pages (guides + buy pages)

## Test plan
- [ ] Click pagination on any listing page — page scrolls to top