### PR TITLE
improve dosage remarks readability

### DIFF
--- a/apps/client-fnp/components/agrochemical/AgrochemicalDosageTable.tsx
+++ b/apps/client-fnp/components/agrochemical/AgrochemicalDosageTable.tsx
@@ -70,7 +70,7 @@ export function AgrochemicalDosageTable({ dosageRates }: AgrochemicalDosageTable
                     {entry.remarks && entry.remarks.length > 0 ? (
                         <ul className="space-y-1">
                             {entry.remarks.map((remark: string, remarkIdx: number) => (
-                                <li key={remarkIdx} className="text-xs text-foreground flex items-start gap-1.5">
+                                <li key={remarkIdx} className={`text-sm flex items-start gap-1.5 ${remarkIdx % 2 === 0 ? "text-foreground" : "text-muted-foreground"}`}>
                                     <span className="h-1 w-1 mt-1.5 rounded-full bg-foreground/50 flex-shrink-0" />
                                     <span className="flex-1">{remark}</span>
                                 </li>

--- a/apps/client-fnp/components/agrochemical/FertilizerApplicationRates.tsx
+++ b/apps/client-fnp/components/agrochemical/FertilizerApplicationRates.tsx
@@ -76,7 +76,7 @@ export function FertilizerApplicationRates({ dosageRates }: FertilizerApplicatio
                                         {entry.remarks && entry.remarks.length > 0 ? (
                                             <ul className="space-y-1">
                                                 {entry.remarks.map((remark, remarkIdx) => (
-                                                    <li key={remarkIdx} className="text-xs text-foreground flex items-start gap-1.5">
+                                                    <li key={remarkIdx} className={`text-sm flex items-start gap-1.5 ${remarkIdx % 2 === 0 ? "text-foreground" : "text-muted-foreground"}`}>
                                                         <span className="h-1 w-1 mt-1.5 rounded-full bg-foreground/50 flex-shrink-0" />
                                                         <span className="flex-1">{remark}</span>
                                                     </li>

--- a/apps/client-fnp/package.json
+++ b/apps/client-fnp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-farmnport",
-  "version": "7.18.2",
+  "version": "7.18.3",
   "private": true,
   "scripts": {
     "dev": "next dev --port 3001",


### PR DESCRIPTION
## Summary
- Bump dosage remarks from text-xs to text-sm for easier reading
- Alternate foreground/muted colours on remarks for visual scanning
- Applied to both AgrochemicalDosageTable and FertilizerApplicationRates

## Test plan
- [ ] Check agrochemical detail page with dosage remarks
- [ ] Check plant nutrition detail page with application rates